### PR TITLE
Tips manager dashboard mockups: design comparison, finalized 7-style ledger, tested logic core

### DIFF
--- a/docs/mockups/tips-dashboard/PROMPT.md
+++ b/docs/mockups/tips-dashboard/PROMPT.md
@@ -1,0 +1,279 @@
+# Design brief — Babytuna tip-tracking manager dashboard
+
+You are designing a manager dashboard for a small restaurant group. Deliver
+**one self-contained HTML file containing three distinct design variants** of
+that dashboard.
+
+This brief gives you the domain, the data, and the functional requirements. It
+deliberately does **not** tell you how the page should look or how it should be
+laid out — the information architecture, visual design, and interaction model
+are the work, and they are yours to decide.
+
+---
+
+## 1. Output contract
+
+Write exactly one file:
+
+```
+docs/mockups/tips-dashboard/<your-label>.html
+```
+
+Replace `<your-label>` with a short lowercase identifier for yourself (e.g.
+`claude-opus`, `gpt`, `gemini`). Do not create any other files. Do not modify
+any existing file in the repository.
+
+The file must:
+
+- Open and work correctly by double-clicking it — `file://`, no server, no
+  build step, no install.
+- Be **fully self-contained**. All CSS and JS inline. No CDN links, no external
+  fonts, no remote images, no `fetch`. Any imagery must be inline SVG or a
+  `data:` URI. A machine with no network must render it identically.
+- Contain **three complete variants** of the dashboard, reachable from a
+  persistent control at the top of the page (however you choose to present
+  that). Switching variants must not reload the page or lose scroll position
+  unrecoverably.
+- Label each variant with a short name and a **one-to-two sentence design
+  thesis** — what this version optimizes for and what it trades away. Put this
+  where a reviewer will read it before scrolling into the variant.
+- Be populated with the sample data in §6 — all three variants, same numbers.
+  Do not invent different data per variant; the comparison is about design.
+- Be responsive down to a 1024px-wide laptop screen. Mobile is not required.
+
+Static mockup, not a working app. Buttons and controls do not need real
+behavior. Interactions that are *part of the design being evaluated* (switching
+variants, opening a modal or drawer, expanding a row, toggling a filter) should
+actually work, using local state only, so the reviewer can feel the flow.
+Everything else can be inert.
+
+---
+
+## 2. What this product is
+
+Two restaurants — **Babytuna Sushi** and **Babytuna Poki & Pho** — under one
+owner.
+
+At the end of each shift, whoever is closing records that shift's tips on a
+phone. They open a small web app by scanning a QR sticker by the register,
+enter two amounts and pick which staff are splitting, and save. That phone app
+already exists and is in use. It is a separate screen from what you are
+designing.
+
+You are designing the **manager side**: the single page the owner opens on a
+laptop to see what was recorded, fix mistakes, and manage the staff list and
+device access.
+
+---
+
+## 3. Who uses it
+
+One person: the owner. Not a finance team, not a shift lead, not a multi-tenant
+SaaS admin. He is checking last night's numbers, correcting the occasional
+mistake, adding a new hire before their first shift, and pulling a spreadsheet
+when it is time to do payroll.
+
+He is on a laptop, usually in the middle of doing five other things. He is not
+going to read documentation or discover features by exploration.
+
+---
+
+## 4. The domain rules that matter
+
+**Shifts.** Each restaurant records tips twice a day: **lunch** and **dinner**.
+So there are at most four records per day across the group. A record is
+uniquely identified by (date, restaurant, meal) — there is exactly one lunch
+record for Sushi on a given day, and re-recording it edits the existing one.
+
+**Business date.** The day rolls over at 4am, not midnight. Tips entered at
+12:30am after a Friday dinner shift belong to Friday. Dates you display are
+business dates.
+
+**Cash and card are treated differently — this is the central rule.**
+
+- **Cash tips are split** evenly among the staff on that shift, and handed out
+  that night. The per-person share is what people actually care about.
+- **Card tips are recorded but not split.** They are logged for payroll and
+  reporting and are paid out through a separate process. They must never be
+  included in the per-person share.
+
+Per-person share = **cash ÷ number of people**, rounded to the nearest cent,
+with exact half-cents rounding **up** (`$96.25 ÷ 2` = `$48.13`, not `$48.12`).
+Card is not in that number. Rounding remainders stay in the drawer, so the
+shares will not always sum exactly to the cash total (`$100 ÷ 3` = `$33.33`
+each, `$99.99` distributed). This is intentional and correct.
+
+The design needs to make the cash/card distinction legible without a reviewer
+having to be told. A manager glancing at a row should not be able to confuse
+"the pool that gets split" with "the amount that was logged."
+
+**Flagged entries.** When an amount is wildly out of line with history for that
+restaurant and meal (a suspected typo — `$3,000` where the slot normally sees
+`$150–$350`), the entry is saved but marked as flagged. The manager should be
+able to notice these and act on them. There is no separate approval workflow;
+flagging is informational.
+
+**Who entered it.** Each record notes which staff member closed, and whether it
+was typed or dictated by voice. Minor metadata, but present.
+
+---
+
+## 5. What the page must do
+
+All four areas below live on **one page**. Do not put them behind a tab bar or
+a router — the owner should be able to scroll the whole thing, and this page
+will later be embedded as one section inside a larger dashboard. How you order,
+group, prioritize, or progressively disclose these areas is a design decision
+and a meaningful part of what is being compared.
+
+**A. Review recorded tips.**
+Filter by date range and restaurant. See the records in that range with their
+cash, card, per-person share, who was on the split, and whether they were
+flagged. Show totals for the range and some sense of daily subtotals. Export
+to spreadsheet.
+
+**B. Correct a record after the fact.**
+The owner needs to fix a shift that was entered wrong — change the cash amount,
+the card amount, or who was on the split — without going to the restaurant and
+using the phone. Corrections change what people get paid, so the design should
+handle confirmation and consequence with appropriate weight.
+
+**C. Manage the staff list.**
+Add a person. Rename them. Set which restaurant they work at — Sushi, Poki &
+Pho, or both. Control the order they appear in on the phone app's picker, since
+that is what closers tap through every night. Deactivate someone who left
+(their history must survive) and delete someone added by mistake. A new hire
+being added before their first shift is the common case and should be fast.
+
+**D. Device access.**
+Each restaurant has a QR sticker and a numeric PIN that let a phone sign in.
+Both can be rotated, and each shows when it was last rotated. Rotating the QR
+code invalidates the printed sticker and requires printing a new one; rotating
+the PIN means telling the closers a new number. There is also a "sign out every
+phone at this restaurant" action. These are destructive and infrequent — treat
+them accordingly.
+
+A rotated secret is displayed exactly once, immediately after rotation, and is
+unrecoverable afterward because only a hash is stored. That one-time reveal is
+a real design problem worth solving well.
+
+---
+
+## 6. Sample data — use exactly this
+
+**Staff**
+
+| Name  | Works at     | Status   |
+|-------|--------------|----------|
+| Maria | Sushi        | active   |
+| Jose  | Sushi        | active   |
+| Ken   | Both         | active   |
+| Rey   | Both         | active   |
+| Lena  | Poki & Pho   | active   |
+| Tom   | Poki & Pho   | active   |
+| Aiko  | Sushi        | inactive |
+
+**Records** (most recent first; per-person is cash ÷ people)
+
+| Date         | Restaurant | Meal   | Cash      | Card    | People            | Per person | Flag |
+|--------------|------------|--------|-----------|---------|-------------------|------------|------|
+| Sun Aug 9    | Sushi      | Dinner | 412.00    | 688.50  | Maria, Jose, Ken  | 137.33     |      |
+| Sun Aug 9    | Sushi      | Lunch  | 96.25     | 210.00  | Maria, Ken        | 48.13      |      |
+| Sun Aug 9    | Poki & Pho | Dinner | 188.00    | 402.75  | Lena, Tom         | 94.00      |      |
+| Sat Aug 8    | Sushi      | Dinner | 366.50    | 594.00  | Jose, Ken, Rey    | 122.17     |      |
+| Sat Aug 8    | Poki & Pho | Dinner | 205.75    | 388.00  | Lena, Tom, Rey    | 68.58      |      |
+| Sat Aug 8    | Poki & Pho | Lunch  | 74.00     | 165.25  | Lena              | 74.00      |      |
+| Fri Aug 7    | Sushi      | Dinner | 3,100.00  | 610.00  | Maria, Jose       | 1,550.00   | ⚑    |
+| Fri Aug 7    | Sushi      | Lunch  | 88.50     | 174.00  | Maria             | 88.50      |      |
+| Fri Aug 7    | Poki & Pho | Dinner | 197.25    | 351.50  | Tom, Rey          | 98.63      |      |
+| Thu Aug 6    | Sushi      | Dinner | 344.00    | 561.25  | Maria, Jose, Ken  | 114.67     |      |
+
+Range totals across those ten records: **cash $5,072.25**, **card $4,145.25**,
+10 records. Note that the flagged Friday dinner is the reason the cash total
+looks the way it does — a good design lets a reviewer notice that.
+
+Every per-person figure above is already correct under the §4 rule; reproduce
+them as given. Two of them (`48.13` and `98.63`) land on an exact half-cent and
+are the reason the rounding direction is specified.
+
+**Access state**
+
+| Restaurant | QR sticker rotated | PIN rotated  |
+|------------|--------------------|--------------|
+| Sushi      | Aug 8, 2026        | Aug 8, 2026  |
+| Poki & Pho | never              | Aug 8, 2026  |
+
+---
+
+## 7. Visual context
+
+The phone app these records come from uses a warm, flat, quiet visual language.
+Stating it as fact, not as instruction:
+
+```
+cream background   #f5f1e8      accent / primary   #e84d38
+white cards        #ffffff      accent tint        #fbeae7
+primary text       #1a1a1a      alert text         #c03520
+secondary text     #5f5f5f      muted text         #9c9890
+hairline           rgba(0,0,0,0.06)
+card radius 20px · inner radius 14px · system sans-serif
+no gradients, no drop shadows, no decorative emoji
+```
+
+You may carry this into the dashboard, adapt it for a denser laptop surface, or
+argue for something different — a phone form for one closer and a laptop
+console for the owner are not the same design problem. If you depart from it,
+say so in the variant's thesis.
+
+---
+
+## 8. The three variants
+
+They must be **three genuinely different answers**, not one answer in three
+color schemes. Vary the things that actually change how the page works:
+what gets priority, how much is visible at once versus revealed on demand,
+how editing is entered and confirmed, how dense the data presentation is,
+how the destructive actions are kept away from the routine ones.
+
+For each variant, commit to a thesis and follow it through consistently. A
+variant that is clearly the wrong choice for this user but internally coherent
+and well-argued is more useful to the comparison than three cautious middles.
+
+Do not rank them or mark one as recommended. The point is comparison.
+
+---
+
+## 9. Constraints and non-goals
+
+- No frameworks, no build tooling, no external requests. Plain HTML, CSS, and
+  vanilla JS in one file.
+- No login screen, no authentication flow — assume the owner is already in.
+- No charts library. If a chart earns its place, hand-draw it in SVG.
+- Don't design the phone entry app. It exists; it isn't the deliverable.
+- Don't add features nobody asked for (payroll runs, scheduling, messaging,
+  notifications, multi-tenant settings, dark mode toggles). Depth on the four
+  required areas beats breadth.
+- Keep it accessible: real semantic elements, labeled controls, focus-visible
+  states, and text contrast that holds up. This counts as part of the design.
+
+---
+
+## 10. Before you finish
+
+Check each one honestly:
+
+- [ ] Opens from `file://` with no network and renders identically.
+- [ ] All three variants present, switchable, each with a visible thesis.
+- [ ] Per-person share equals cash ÷ people everywhere it appears. Card is
+      never folded into it.
+- [ ] A first-time viewer can tell, without explanation, which money gets split
+      and which is only logged.
+- [ ] All four functional areas (§5) are present in every variant.
+- [ ] The flagged record is noticeable.
+- [ ] Adding a new hire is quick to find and quick to complete.
+- [ ] Rotating a QR code or PIN reads as consequential, and the one-time reveal
+      of the new secret is handled.
+- [ ] The three variants would lead to visibly different products.
+
+Do not write a summary document, a README, or a report. The HTML file is the
+entire deliverable.

--- a/docs/mockups/tips-dashboard/claude-fable-ledger.html
+++ b/docs/mockups/tips-dashboard/claude-fable-ledger.html
@@ -1,0 +1,1035 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Babytuna Tips — Ledger, finalized (7 styles)</title>
+<style>
+/* ============ reset + shared ============ */
+*{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-text-size-adjust:100%}
+body{font:16px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;background:var(--bg);color:var(--ink);min-width:1000px;font-size:var(--fs)}
+button{font:inherit;cursor:pointer;color:inherit}
+input,select{font:inherit;color:inherit}
+[hidden]{display:none!important}
+:focus-visible{outline:2px solid var(--accent);outline-offset:2px;border-radius:4px}
+.num{font-variant-numeric:tabular-nums}
+.sr{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap}
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+/* ============ theme variables ============ */
+body{ /* classic (default) */
+ --bg:#f7f5f0; --panel:#ffffff; --ink:#1a1a1a; --sec:#5f5f5f; --mut:#9c9890;
+ --line:rgba(0,0,0,.14); --hair:rgba(0,0,0,.07); --line2:rgba(0,0,0,.22);
+ --accent:#e84d38; --tint:#fbeae7; --alert:#c03520; --ok:#2c6e49;
+ --thead:#efece3; --splitH:#f3e7d2; --splitHink:#5a4a24; --cardH:#e7e9ec; --cardHink:#4b5560;
+ --splitBg:#fdf8ee; --cardBg:#f3f4f6; --sub:#efece3; --flagBg:#fbeae7;
+ --grand:#1a1a1a; --grandInk:#ffffff; --revealBg:#1a1a1a; --revealInk:#ffffff;
+ --rad:0px; --radIn:0px; --btnr:8px; --shadow:none; --shadowLg:0 10px 32px rgba(0,0,0,.18);
+ --fs:13.5px; --py:7px; --dash:rgba(0,0,0,.18);
+}
+body[data-theme="modern-a"]{
+ --bg:#f4f5f7; --thead:#f0f2f5; --splitH:#f6ead4; --cardH:#e8ecf1; --sub:#f0f2f5;
+ --line:rgba(16,20,28,.10); --hair:rgba(16,20,28,.06);
+ --rad:14px; --radIn:10px; --btnr:12px;
+ --shadow:0 1px 2px rgba(16,20,28,.06),0 8px 24px rgba(16,20,28,.06);
+ --shadowLg:0 12px 40px rgba(16,20,28,.22); --py:8px;
+}
+body[data-theme="modern-a"] main .toolbar{background:rgba(255,255,255,.8);backdrop-filter:saturate(1.5) blur(14px);-webkit-backdrop-filter:saturate(1.5) blur(14px)}
+body[data-theme="modern-a"] .topbar{background:rgba(255,255,255,.86);backdrop-filter:saturate(1.5) blur(14px);-webkit-backdrop-filter:saturate(1.5) blur(14px)}
+body[data-theme="modern-a"] .seg{border:0;background:#e9ebef;padding:3px;gap:2px;border-radius:11px}
+body[data-theme="modern-a"] .seg button{border-right:0;border-radius:8px;padding:5px 13px}
+body[data-theme="modern-a"] .seg button[aria-pressed="true"]{background:#ffffff;color:var(--ink);box-shadow:0 1px 2px rgba(16,20,28,.14)}
+body[data-theme="modern-b"]{
+ --bg:#fafafa; --panel:#ffffff; --ink:#18181b; --sec:#52525b; --mut:#a1a1aa;
+ --line:#e4e4e7; --hair:#f1f1f4; --line2:#d4d4d8;
+ --accent:#4f46e5; --tint:#eef2ff; --alert:#dc2626; --ok:#16a34a;
+ --thead:#fafafa; --splitH:#eef2ff; --splitHink:#3730a3; --cardH:#f4f4f5; --cardHink:#52525b;
+ --splitBg:#f8faff; --cardBg:#fafafa; --sub:#f4f4f5; --flagBg:#fef2f2;
+ --grand:#18181b; --grandInk:#ffffff; --revealBg:#18181b; --revealInk:#ffffff;
+ --rad:10px; --radIn:8px; --btnr:8px; --shadow:none; --shadowLg:0 16px 48px rgba(24,24,27,.18);
+ --py:7px; --dash:#d4d4d8;
+}
+body[data-theme="modern-b"] .seg button[aria-pressed="true"]{background:#4f46e5;color:#fff}
+body[data-theme="modern-b"] .btn.primary{background:#4f46e5;border-color:#4f46e5;color:#fff}
+body[data-theme="modern-b"] .btn.danger{background:#dc2626;border-color:#dc2626;color:#fff}
+body[data-theme="modern-b"] .sch .dl button[aria-pressed="true"]{background:#4f46e5;border-color:#4f46e5;color:#fff}
+.rail{display:none}
+body[data-theme="modern-b"] .rail{display:block;position:fixed;top:48px;left:0;bottom:0;width:186px;background:var(--panel);border-right:1px solid var(--line);padding:18px 12px;z-index:40;overflow:auto}
+body[data-theme="modern-b"] .wrap{margin-left:186px;max-width:none;padding-left:30px;padding-right:30px}
+.rail h5{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--mut);padding:0 10px 8px}
+.rail a{display:block;padding:7px 10px;border-radius:7px;color:var(--sec);text-decoration:none;font-size:13.5px;font-weight:600}
+.rail a:hover{background:var(--bg);color:var(--ink)}
+.rail p{color:var(--mut);font-size:11.5px;padding:14px 10px 0;line-height:1.5}
+body[data-theme="warm"]{
+ --bg:#f5f1e8; --thead:#f4efe2; --splitH:#f6e6cd; --cardH:#eceade; --sub:#f4efe2;
+ --splitBg:#fdf7ea; --cardBg:#f4f2ea; --line:rgba(0,0,0,.10); --hair:rgba(0,0,0,.06);
+ --rad:18px; --radIn:12px; --btnr:999px;
+ --shadow:0 1px 2px rgba(90,60,20,.05),0 10px 28px rgba(90,60,20,.06);
+ --shadowLg:0 14px 44px rgba(90,60,20,.25); --py:9px;
+}
+body[data-theme="dark"]{
+ --bg:#17150f; --panel:#201d15; --ink:#f2efe6; --sec:#b5afa0; --mut:#7e786b;
+ --line:rgba(255,255,255,.12); --hair:rgba(255,255,255,.07); --line2:rgba(255,255,255,.22);
+ --accent:#ff6a52; --tint:rgba(232,77,56,.16); --alert:#ff7a64; --ok:#7fc79b;
+ --thead:#2a261b; --splitH:#3a3120; --splitHink:#e6c583; --cardH:#252a30; --cardHink:#a9b8c6;
+ --splitBg:rgba(230,180,90,.07); --cardBg:rgba(150,170,190,.07); --sub:#2a261b; --flagBg:rgba(232,77,56,.14);
+ --grand:#f2efe6; --grandInk:#17150f; --revealBg:#f2efe6; --revealInk:#17150f;
+ --rad:12px; --radIn:8px; --btnr:9px; --shadow:none; --shadowLg:0 14px 44px rgba(0,0,0,.6);
+ --dash:rgba(255,255,255,.22);
+}
+body[data-theme="dense"]{ --fs:12px; --py:3px; --btnr:5px; }
+body[data-theme="white"]{ /* GitHub-like: squared-off, shades of white and gray */
+ --bg:#ffffff; --panel:#ffffff; --ink:#1f2328; --sec:#59636e; --mut:#818b98;
+ --line:#d0d7de; --hair:#eaeef2; --line2:#afb8c1;
+ --accent:#0969da; --tint:#ffebe9; --alert:#cf222e; --ok:#1a7f37;
+ --thead:#f6f8fa; --splitH:#ddf4ff; --splitHink:#0550ae; --cardH:#eff2f5; --cardHink:#59636e;
+ --splitBg:#f7fbfe; --cardBg:#f6f8fa; --sub:#f6f8fa; --flagBg:#ffebe9;
+ --grand:#24292f; --grandInk:#ffffff; --revealBg:#24292f; --revealInk:#ffffff;
+ --rad:6px; --radIn:6px; --btnr:6px; --shadow:none; --shadowLg:0 8px 24px rgba(140,149,159,.3);
+ --py:7px; --dash:#afb8c1;
+}
+body[data-theme="white"] .btn{background:#f6f8fa;border-color:#d0d7de}
+body[data-theme="white"] .btn.primary{background:#1f883d;border-color:#1f883d;color:#fff}
+body[data-theme="white"] .btn.danger{background:#cf222e;border-color:#cf222e;color:#fff}
+body[data-theme="white"] .seg button[aria-pressed="true"]{background:#0969da;color:#fff}
+body[data-theme="white"] .sch .dl button[aria-pressed="true"]{background:#0969da;border-color:#0969da;color:#fff}
+body[data-theme="white"] .toolbar{background:#ffffff}
+body[data-theme="white"] .topbar{background:#f6f8fa}
+body[data-theme="white"] .tabs{background:#eaeef2}
+
+/* ============ topbar / version switcher ============ */
+.topbar{position:sticky;top:0;z-index:80;background:var(--panel);border-bottom:1px solid var(--line);display:flex;align-items:center;gap:20px;padding:9px 24px}
+.brand{font-weight:700;font-size:14.5px;white-space:nowrap}
+.brand span{color:var(--mut);font-weight:400}
+.tabs{display:flex;gap:4px;background:var(--bg);padding:4px;border-radius:calc(var(--btnr) + 3px)}
+.tab{border:0;background:transparent;padding:5px 13px;border-radius:var(--btnr);color:var(--sec);font-weight:600;font-size:13px}
+.tab[aria-pressed="true"]{background:var(--panel);color:var(--ink);box-shadow:0 1px 2px rgba(0,0,0,.14)}
+body[data-theme="dark"] .tab[aria-pressed="true"]{box-shadow:0 0 0 1px var(--line)}
+.topnote{margin-left:auto;color:var(--mut);font-size:12px;white-space:nowrap}
+
+/* ============ layout ============ */
+.wrap{max-width:1180px;margin:0 auto;padding:0 24px 100px}
+.sec{margin-bottom:46px}
+.sec>h3{font-size:12.5px;text-transform:uppercase;letter-spacing:.09em;color:var(--sec);margin-bottom:10px;border-bottom:2px solid var(--ink);padding-bottom:5px}
+body[data-theme="modern-a"] .sec>h3, body[data-theme="modern-b"] .sec>h3, body[data-theme="warm"] .sec>h3{text-transform:none;letter-spacing:0;font-size:16px;color:var(--ink);border-bottom:0;font-weight:700;padding-bottom:2px}
+.note{color:var(--mut);font-size:12.5px;max-width:96ch;margin-top:10px}
+
+/* ============ toolbar ============ */
+.toolbar{position:sticky;top:47px;z-index:50;background:var(--bg);padding:12px 0 10px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:24px}
+body[data-theme="modern-a"] .toolbar, body[data-theme="modern-b"] .toolbar, body[data-theme="warm"] .toolbar{background:var(--panel);border:1px solid var(--line);border-radius:var(--rad);box-shadow:var(--shadow);padding:10px 14px;top:56px;margin-top:14px}
+.btn{border:1px solid var(--line2);background:var(--panel);border-radius:var(--btnr);padding:6px 14px;font-size:13px;font-weight:600;color:var(--ink)}
+body[data-theme="modern-a"] .btn, body[data-theme="warm"] .btn{box-shadow:0 1px 1.5px rgba(0,0,0,.05)}
+.btn.primary{background:var(--ink);color:var(--panel);border-color:var(--ink)}
+.btn.danger{background:var(--alert);color:#fff;border-color:var(--alert)}
+body[data-theme="dark"] .btn.danger{color:#17150f}
+.range-btn{display:inline-flex;align-items:center;gap:9px}
+.range-btn .caret{font-size:10px;color:var(--mut)}
+.seg{display:inline-flex;border:1px solid var(--line2);border-radius:var(--btnr);overflow:hidden;background:var(--panel)}
+.seg button{border:0;background:transparent;padding:6px 13px;font-size:13px;color:var(--sec);border-right:1px solid var(--hair)}
+.seg button:last-child{border-right:0}
+.seg button[aria-pressed="true"]{background:var(--ink);color:var(--panel)}
+.totals{margin-left:auto;display:flex;align-items:baseline;gap:16px;font-size:12.5px;color:var(--sec);flex-wrap:wrap}
+.totals strong{font-size:14.5px;color:var(--ink)}
+.flagcount{background:var(--tint);color:var(--alert);border:1px solid var(--alert);border-radius:999px;padding:3px 11px;font-size:12px;font-weight:700}
+
+/* ============ calendar popover ============ */
+.toolbar{position:sticky} .tb-anchor{position:relative}
+.cal{position:absolute;top:calc(100% + 8px);left:0;z-index:70;background:var(--panel);border:1px solid var(--line2);border-radius:max(var(--rad),10px);box-shadow:var(--shadowLg);display:flex;min-width:600px}
+.cal-presets{width:168px;border-right:1px solid var(--hair);padding:10px;display:flex;flex-direction:column;gap:2px}
+.cal-presets h5{font-size:11px;text-transform:uppercase;letter-spacing:.07em;color:var(--mut);padding:4px 8px 6px}
+.cal-presets button{border:0;background:none;text-align:left;padding:6px 10px;border-radius:7px;font-size:13px;color:var(--ink)}
+.cal-presets button:hover{background:var(--bg)}
+.cal-presets button[aria-pressed="true"]{background:var(--ink);color:var(--panel);font-weight:600}
+.cal-main{padding:12px 14px 14px;flex:1}
+.cal-modes{display:flex;gap:3px;background:var(--bg);border-radius:8px;padding:3px;margin-bottom:10px}
+.cal-modes button{flex:1;border:0;background:transparent;border-radius:6px;padding:4px 0;font-size:12.5px;font-weight:600;color:var(--sec)}
+.cal-modes button[aria-pressed="true"]{background:var(--panel);color:var(--ink);box-shadow:0 1px 2px rgba(0,0,0,.12)}
+.cal-nav{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
+.cal-nav strong{font-size:14px}
+.cal-nav button{border:1px solid var(--line);background:var(--panel);border-radius:7px;width:28px;height:26px;font-size:13px;line-height:1;padding:0}
+.cal-dow{display:grid;grid-template-columns:repeat(7,38px);gap:2px;margin-bottom:3px}
+.cal-dow span{text-align:center;font-size:10.5px;font-weight:700;color:var(--mut);text-transform:uppercase}
+.cal-week{display:grid;grid-template-columns:repeat(7,38px);gap:2px;border-radius:8px}
+.cal[data-mode="weeks"] .cal-week:hover{outline:1.5px solid var(--accent);outline-offset:1px}
+.cal-day{position:relative;border:0;background:none;height:34px;border-radius:7px;font-size:12.5px;color:var(--ink)}
+.cal-day:hover{background:var(--bg)}
+.cal-day.out{color:var(--mut);opacity:.45}
+.cal-day.sel{background:var(--tint)}
+.cal-day.edge{background:var(--accent);color:#fff;font-weight:700}
+body[data-theme="dark"] .cal-day.edge{color:#17150f}
+.cal-day.today{box-shadow:inset 0 0 0 1.5px var(--accent)}
+.cal-day .dot{position:absolute;left:50%;bottom:3px;width:4px;height:4px;border-radius:50%;background:var(--accent);transform:translateX(-50%)}
+.cal-day.edge .dot{background:#fff}
+.cal-grid12{display:grid;grid-template-columns:repeat(3,1fr);gap:6px;width:274px}
+.cal-grid12 button,.cal-years button{border:1px solid var(--line);background:var(--panel);border-radius:8px;padding:12px 0;font-size:13px;font-weight:600}
+.cal-grid12 button:hover,.cal-years button:hover{border-color:var(--ink)}
+.cal-grid12 button.on,.cal-years button.on{background:var(--ink);color:var(--panel);border-color:var(--ink)}
+.cal-grid12 button:disabled,.cal-years button:disabled{opacity:.35;cursor:default}
+.cal-years{display:flex;flex-direction:column;gap:6px;width:274px;padding-top:4px}
+.cal-hint{font-size:11.5px;color:var(--mut);margin-top:9px}
+
+/* ============ records table ============ */
+.tablewrap{background:var(--panel);border:1px solid var(--line);border-radius:var(--rad);overflow:hidden;box-shadow:var(--shadow)}
+table.led{width:100%;border-collapse:collapse}
+.led th,.led td{padding:var(--py) 11px;text-align:left;border-bottom:1px solid var(--hair);vertical-align:top}
+.led thead th{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--sec);background:var(--thead);border-bottom:1px solid var(--line);font-weight:700}
+.led thead .grp{text-align:center}
+.led thead .grp-split{background:var(--splitH);color:var(--splitHink)}
+.led thead .grp-card{background:var(--cardH);color:var(--cardHink)}
+.led thead .sub-split{background:var(--splitBg);color:var(--splitHink)}
+.led thead .sub-card{background:var(--cardBg);color:var(--cardHink)}
+.r{text-align:right}
+td.col-split{background:var(--splitBg)}
+td.col-card{background:var(--cardBg);color:var(--sec)}
+th.sub-card,td.col-card{border-left:1px dashed var(--dash)}
+.led td.per{font-weight:700}
+.led .names{color:var(--sec)}
+.led .cnt{color:var(--mut);font-size:.9em}
+.led .meta{color:var(--mut);font-size:.93em;white-space:nowrap}
+tr.flagrow>td{background:var(--flagBg)!important}
+tr.flagrow>td:first-child{box-shadow:inset 3px 0 0 var(--alert)}
+.flagchip{display:inline-block;background:var(--alert);color:#fff;border-radius:5px;font-size:.8em;font-weight:700;padding:1px 7px;margin-left:7px;vertical-align:1px}
+body[data-theme="dark"] .flagchip{color:#17150f}
+.rowbtn{border:1px solid var(--line2);background:var(--panel);border-radius:calc(var(--btnr) - 2px);padding:3px 11px;font-size:.93em;font-weight:600}
+.rowbtn+.rowbtn{margin-left:5px;color:var(--sec)}
+tr.subrow th,tr.subrow td{background:var(--sub)!important;font-weight:700;font-size:.93em;color:var(--sec);border-top:1px solid var(--line)}
+tr.subrow th{text-align:right;color:var(--ink)}
+tr.grand th,tr.grand td{background:var(--grand)!important;color:var(--grandInk)!important;font-weight:700}
+tr.grand th{text-align:right}
+tr.grand td.col-card{border-left-color:var(--dash)}
+tr.emptyrow td{color:var(--mut);padding:22px;text-align:center}
+/* inline editor */
+tr.edrow>td{background:var(--panel);border-top:2px solid var(--ink);border-bottom:2px solid var(--ink);padding:16px 18px}
+.ed-fields{display:flex;gap:26px;flex-wrap:wrap;align-items:flex-start}
+.ed-fields>label{display:flex;flex-direction:column;gap:4px;font-size:11.5px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--splitHink)}
+.ed-fields>label.ed-card{color:var(--cardHink)}
+.ed-fields input[type="text"]{border:1px solid var(--line2);border-radius:var(--radIn);padding:7px 10px;width:130px;font-size:15px;text-align:right;background:var(--panel)}
+.ed-fields fieldset{border:1px solid var(--line);border-radius:var(--radIn);padding:8px 12px 10px;background:var(--panel)}
+.ed-fields legend{font-size:11.5px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--splitHink);padding:0 5px}
+.chk{display:inline-flex;align-items:center;gap:6px;margin-right:14px;font-size:13.5px;font-weight:600}
+.ed-preview{margin-top:12px;font-size:13px;color:var(--sec)}
+.ed-preview strong{font-size:15px;color:var(--ink)}
+.ed-actions{margin-top:12px;display:flex;gap:8px;align-items:center}
+.ed-confirm{margin-top:12px;background:var(--tint);border:1px solid var(--alert);border-radius:var(--radIn);padding:12px 14px;font-size:13px;color:var(--ink)}
+.ed-confirm p{margin-bottom:10px}
+.ed-error{color:var(--alert);font-weight:700}
+
+/* ============ staff ============ */
+.addrow{display:flex;align-items:flex-end;gap:12px;background:var(--panel);border:1px solid var(--line);border-bottom:0;padding:12px 14px;border-radius:var(--rad) var(--rad) 0 0;box-shadow:var(--shadow)}
+.addrow label{display:flex;flex-direction:column;gap:3px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--sec)}
+.addrow input,.addrow select{border:1px solid var(--line2);border-radius:var(--radIn);padding:6px 9px;font-size:13.5px;background:var(--panel)}
+.addrow input{width:190px}
+.addrow .hint{color:var(--mut);font-size:12px;margin-left:auto;max-width:40ch}
+.staffwrap{border-radius:0 0 var(--rad) var(--rad)}
+.works-sel{border:1px solid var(--line);border-radius:var(--radIn);padding:3px 6px;font-size:.95em;background:var(--panel)}
+.inactive-row td{color:var(--mut)}
+.badge-off{display:inline-block;background:var(--bg);border:1px solid var(--line);color:var(--mut);border-radius:5px;font-size:.8em;font-weight:700;padding:1px 7px;margin-left:7px}
+.link{border:0;background:none;color:var(--ink);text-decoration:underline;font-size:.95em;padding:2px 4px}
+.link.dangerlink{color:var(--alert)}
+.link:disabled{color:var(--mut);opacity:.6;text-decoration:none;cursor:default}
+.renform{display:inline-flex;gap:6px}
+.renform input{border:1px solid var(--line2);border-radius:6px;padding:2px 8px;width:130px;background:var(--panel)}
+/* schedule grid */
+.sch,.sch-head{display:flex;gap:3px}
+.sch .day,.sch-head span{width:44px;flex:none;text-align:center}
+.sch-head{margin-top:5px}
+.sch-head span{font-size:10px;color:var(--sec)}
+.sch .dl{display:flex;gap:2px;justify-content:center}
+.sch .dl button{width:20px;height:20px;font-size:10px;font-weight:700;border:1px solid var(--line);border-radius:5px;background:var(--panel);color:var(--mut);padding:0;line-height:1}
+.sch .dl button[aria-pressed="true"]{background:var(--ink);color:var(--panel);border-color:var(--ink)}
+.sch .dl button:disabled{opacity:.35;cursor:default}
+
+/* ============ access ============ */
+.accessgrid{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+.access{background:var(--panel);border:1px solid var(--line);border-radius:var(--rad);padding:16px 18px;box-shadow:var(--shadow)}
+.access h4{font-size:14.5px;margin-bottom:10px;border-bottom:1px solid var(--hair);padding-bottom:7px}
+.access .row{display:flex;align-items:center;gap:10px;padding:7px 0;font-size:13px;border-bottom:1px solid var(--hair)}
+.access .row dt{font-weight:700;width:92px;flex:none}
+.access .row dd{color:var(--sec)}
+.access .row button{margin-left:auto}
+.signout{margin-top:12px;border:1px solid var(--alert);color:var(--alert);background:var(--panel);border-radius:var(--btnr);padding:5px 13px;font-size:12.5px;font-weight:700}
+.confirmbox{margin-top:12px;background:var(--tint);border:1px solid var(--alert);border-radius:var(--radIn);padding:12px 14px;font-size:13px}
+.confirmbox p{margin-bottom:9px}
+.confirmbox label{display:flex;align-items:center;gap:8px;font-weight:700;margin-bottom:9px}
+.confirmbox input{border:1px solid var(--line2);border-radius:7px;padding:5px 9px;width:110px;text-transform:uppercase;letter-spacing:.08em;font-weight:700;background:var(--panel)}
+.reveal{margin-top:12px;background:var(--revealBg);color:var(--revealInk);border-radius:var(--radIn);padding:14px 16px;font-size:13px}
+.reveal .secret{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:26px;letter-spacing:.35em;display:inline-block;margin:4px 0 6px}
+.reveal p{opacity:.78;margin-bottom:10px}
+.reveal p strong{opacity:1}
+.reveal button{border:1px solid currentColor;background:transparent;color:inherit;border-radius:7px;padding:5px 13px;font-size:12.5px;font-weight:600;margin-right:6px}
+.qr{width:132px;height:132px;image-rendering:pixelated;border:1px solid var(--line);border-radius:6px;background:#fff;margin:6px 0 10px;display:block}
+
+#toast{position:fixed;left:50%;bottom:24px;transform:translate(-50%,12px);background:var(--ink);color:var(--panel);padding:10px 18px;border-radius:999px;font-size:14px;opacity:0;pointer-events:none;transition:opacity .18s,transform .18s;z-index:200;max-width:80ch}
+#toast.on{opacity:1;transform:translate(-50%,0)}
+@media (max-width:1120px){ .wrap{max-width:100%} }
+</style>
+</head>
+<body data-theme="classic">
+
+<header class="topbar">
+  <p class="brand">Babytuna <span>· tips ledger</span></p>
+  <div class="tabs" role="group" aria-label="Interface style">
+    <button class="tab" data-thm="classic" aria-pressed="true">1 · Classic</button>
+    <button class="tab" data-thm="modern-a" aria-pressed="false">2 · Modern A</button>
+    <button class="tab" data-thm="modern-b" aria-pressed="false">3 · Modern B</button>
+    <button class="tab" data-thm="warm" aria-pressed="false">4 · Warm</button>
+    <button class="tab" data-thm="dark" aria-pressed="false">5 · Dark</button>
+    <button class="tab" data-thm="dense" aria-pressed="false">6 · Dense</button>
+    <button class="tab" data-thm="white" aria-pressed="false">7 · White</button>
+  </div>
+  <p class="topnote">mockup · data May 1 – Aug 9 · clock pinned to Mon Aug 10, 2026</p>
+</header>
+
+<nav class="rail" aria-label="Sections">
+  <h5>Tips manager</h5>
+  <a href="#recH">Recorded tips</a>
+  <a href="#staffH">Staff &amp; schedule</a>
+  <a href="#accH">Device access</a>
+  <p>Cash pools are split nightly; card tips are logged for payroll and never split.</p>
+</nav>
+
+<main class="wrap">
+
+  <div class="toolbar">
+    <div class="tb-anchor">
+      <button class="btn range-btn" id="rangeBtn" aria-haspopup="dialog" aria-expanded="false">
+        <span id="rangeLabel"></span><span class="caret" aria-hidden="true">▾</span>
+      </button>
+      <div class="cal" id="cal" role="dialog" aria-label="Choose a date range" data-mode="weeks" hidden></div>
+    </div>
+    <div class="seg" role="group" aria-label="Restaurant filter" id="restSeg">
+      <button data-act="rest" data-v="all" aria-pressed="true">Both</button>
+      <button data-act="rest" data-v="sushi" aria-pressed="false">Sushi</button>
+      <button data-act="rest" data-v="poki" aria-pressed="false">Poki &amp; Pho</button>
+    </div>
+    <button class="btn" data-act="export">Export CSV</button>
+    <div class="totals" id="totals"></div>
+  </div>
+
+  <section class="sec" aria-labelledby="recH">
+    <h3 id="recH">Recorded tips</h3>
+    <div class="tablewrap">
+      <table class="led">
+        <thead>
+          <tr>
+            <th rowspan="2" scope="col">Business date</th>
+            <th rowspan="2" scope="col">Restaurant</th>
+            <th rowspan="2" scope="col">Meal</th>
+            <th colspan="3" scope="colgroup" class="grp grp-split">Split pool — cash, handed out nightly</th>
+            <th scope="colgroup" class="grp grp-card">Logged only</th>
+            <th rowspan="2" scope="col">Entered by</th>
+            <th rowspan="2" scope="col"><span class="sr">Actions</span></th>
+          </tr>
+          <tr>
+            <th scope="col" class="r sub-split">Cash</th>
+            <th scope="col" class="sub-split">Split between</th>
+            <th scope="col" class="r sub-split">Per person</th>
+            <th scope="col" class="r sub-card">Card → payroll</th>
+          </tr>
+        </thead>
+        <tbody id="recBody"></tbody>
+      </table>
+    </div>
+    <p class="note">Business dates roll over at 4&nbsp;am. Per-person share = cash ÷ people, rounded to the nearest cent (half-cents up); remainders stay in the drawer. Card tips are logged for payroll and paid separately — never part of the split.</p>
+  </section>
+
+  <section class="sec" aria-labelledby="staffH">
+    <h3 id="staffH">Staff &amp; schedule</h3>
+    <form id="addForm" class="addrow">
+      <label>New hire's name <input name="name" required placeholder="e.g. Dana" autocomplete="off"></label>
+      <label>Works at
+        <select name="works">
+          <option value="sushi">Sushi</option>
+          <option value="poki">Poki &amp; Pho</option>
+          <option value="both">Both</option>
+        </select>
+      </label>
+      <button class="btn primary">Add</button>
+      <span class="hint">New people start with no scheduled days — tick their shifts below so the phone pre-selects them.</span>
+    </form>
+    <div class="tablewrap staffwrap">
+      <table class="led">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Works at</th>
+            <th scope="col">Schedule <span style="font-weight:400;text-transform:none;letter-spacing:0">— pre-selected on the phone that day (L = lunch, D = dinner)</span>
+              <div class="sch-head" aria-hidden="true"><span>Mon</span><span>Tue</span><span>Wed</span><span>Thu</span><span>Fri</span><span>Sat</span><span>Sun</span></div>
+            </th>
+            <th scope="col" class="r">Shifts</th>
+            <th scope="col"><span class="sr">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody id="staffBody"></tbody>
+      </table>
+    </div>
+    <p class="note">Scheduled people come pre-selected when the closer records that day's shift — they can still add or remove anyone before saving. Unscheduled staff sit at the bottom of the phone picker, unselected. People with recorded shifts can only be deactivated (history stays); Delete exists only for someone added by mistake.</p>
+  </section>
+
+  <section class="sec" aria-labelledby="accH">
+    <h3 id="accH">Device access</h3>
+    <div class="accessgrid" id="access"></div>
+    <p class="note">Rotated secrets are shown exactly once — only a hash is stored, so they can't be re-displayed later, only rotated again.</p>
+  </section>
+
+</main>
+
+<div id="toast" role="status" aria-live="polite"></div>
+
+<script>
+/* ==== tips-core.js — data/logic engine (also at docs/mockups/tips-dashboard/core/, with tests) ==== */
+(function(global){
+'use strict';
+
+var DATA_START=new Date(2026,4,1);
+var RESTS={sushi:'Sushi', poki:'Poki & Pho'};
+var DAYKEYS=['sun','mon','tue','wed','thu','fri','sat'];
+var WEEKORDER=['mon','tue','wed','thu','fri','sat','sun'];
+var MONS=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+var MONSFULL=['January','February','March','April','May','June','July','August','September','October','November','December'];
+var DOWS=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+function money(c){return '$'+(c/100).toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2});}
+function parseMoney(v){var n=parseFloat(String(v).replace(/[$,\s]/g,''));return (isFinite(n)&&n>=0)?Math.round(n*100):null;}
+function perShare(cashCents,nPeople){return Math.round(cashCents/nPeople);}
+function sum(a,f){return a.reduce(function(t,x){return t+f(x);},0);}
+function dstamp(d){return new Date(d.getFullYear(),d.getMonth(),d.getDate()).getTime();}
+function fmtDay(t){var d=new Date(t);return DOWS[d.getDay()]+' '+MONS[d.getMonth()]+' '+d.getDate();}
+function addDays(d,n){return new Date(d.getFullYear(),d.getMonth(),d.getDate()+n);}
+function mondayOf(d){return addDays(d,-((d.getDay()+6)%7));}
+function seeded(seed){var s=seed>>>0;return function(){s=(Math.imul(s,1664525)+1013904223)>>>0;return s/4294967296;};}
+function q25(c){return Math.round(c/25)*25;}
+
+function mkSched(spec){
+  var s={}; WEEKORDER.forEach(function(d){s[d]={L:false,D:false};});
+  spec.split(' ').forEach(function(tok){
+    if(!tok)return; var d=tok.slice(0,3), ms=tok.slice(3);
+    if(ms.indexOf('L')>=0)s[d].L=true; if(ms.indexOf('D')>=0)s[d].D=true;
+  });
+  return s;
+}
+
+var STAFF_SEED=[
+ {id:'maria', name:'Maria', works:'sushi', active:true,  sched:mkSched('monL tueL thuLD friLD sunLD')},
+ {id:'jose',  name:'Jose',  works:'sushi', active:true,  sched:mkSched('tueD wedD thuD friD satD sunD')},
+ {id:'ken',   name:'Ken',   works:'both',  active:true,  sched:mkSched('monD wedLD thuD satD sunLD')},
+ {id:'rey',   name:'Rey',   works:'both',  active:true,  sched:mkSched('monL friD satD')},
+ {id:'lena',  name:'Lena',  works:'poki',  active:true,  sched:mkSched('monL wedL friL satLD sunD')},
+ {id:'tom',   name:'Tom',   works:'poki',  active:true,  sched:mkSched('tueD thuD friD satD sunD')},
+ {id:'aiko',  name:'Aiko',  works:'sushi', active:false, sched:mkSched('')}
+];
+
+function generateHistory(staff){
+  staff=staff||STAFF_SEED;
+  var rnd=seeded(20260810), out=[], id=1;
+  var aikoUntil=new Date(2026,6,1).getTime();  /* Aiko left end of June */
+  for(var d=new Date(DATA_START); d<=new Date(2026,7,5); d=addDays(d,1)){
+    var dow=DAYKEYS[d.getDay()];
+    var wk=(d.getDay()===0||d.getDay()>=5);
+    ['sushi','poki'].forEach(function(rest){
+      ['Lunch','Dinner'].forEach(function(meal){
+        var mk=meal==='Lunch'?'L':'D';
+        var pool=staff.filter(function(s){
+          if(s.id==='aiko') return rest==='sushi'&&d.getTime()<aikoUntil&&mk==='D';
+          return (s.works===rest||s.works==='both')&&s.sched[dow][mk];
+        }).map(function(s){return s.name;});
+        if(!pool.length) return;                       /* nobody scheduled → shift not recorded */
+        if(meal==='Lunch'&&rnd()<0.12) return;         /* occasionally lunch goes unrecorded */
+        var n=1+(rnd()<0.7?1:0)+(rnd()<0.3?1:0); if(n>pool.length)n=pool.length;
+        for(var i=pool.length-1;i>0;i--){var j=Math.floor(rnd()*(i+1));var t=pool[i];pool[i]=pool[j];pool[j]=t;}
+        var people=pool.slice(0,n);
+        var range = rest==='sushi'
+          ? (meal==='Dinner'?(wk?[25000,42000]:[18000,33000]):(wk?[7000,14000]:[6000,11000]))
+          : (meal==='Dinner'?(wk?[15000,26000]:[12000,22000]):[5000,11000]);
+        var cash=q25(range[0]+rnd()*(range[1]-range[0]));
+        var card=q25(cash*(1.35+rnd()*0.75));
+        out.push({id:'g'+(id++), t:dstamp(d), rest:rest, meal:meal, cash:cash, card:card,
+                  people:people, by:people[Math.floor(rnd()*people.length)],
+                  mode:rnd()<0.3?'voice':'typed', flag:false});
+      });
+    });
+  }
+  return out;
+}
+
+var REAL_RECORDS=[
+ {id:'r1', t:dstamp(new Date(2026,7,9)), rest:'sushi', meal:'Dinner', cash:41200,  card:68850, people:['Maria','Jose','Ken'], by:'Maria', mode:'voice', flag:false},
+ {id:'r2', t:dstamp(new Date(2026,7,9)), rest:'sushi', meal:'Lunch',  cash:9625,   card:21000, people:['Maria','Ken'],       by:'Ken',   mode:'typed', flag:false},
+ {id:'r3', t:dstamp(new Date(2026,7,9)), rest:'poki',  meal:'Dinner', cash:18800,  card:40275, people:['Lena','Tom'],        by:'Lena',  mode:'typed', flag:false},
+ {id:'r4', t:dstamp(new Date(2026,7,8)), rest:'sushi', meal:'Dinner', cash:36650,  card:59400, people:['Jose','Ken','Rey'],  by:'Ken',   mode:'typed', flag:false},
+ {id:'r5', t:dstamp(new Date(2026,7,8)), rest:'poki',  meal:'Dinner', cash:20575,  card:38800, people:['Lena','Tom','Rey'],  by:'Rey',   mode:'voice', flag:false},
+ {id:'r6', t:dstamp(new Date(2026,7,8)), rest:'poki',  meal:'Lunch',  cash:7400,   card:16525, people:['Lena'],              by:'Lena',  mode:'typed', flag:false},
+ {id:'r7', t:dstamp(new Date(2026,7,7)), rest:'sushi', meal:'Dinner', cash:310000, card:61000, people:['Maria','Jose'],      by:'Jose',  mode:'voice', flag:true},
+ {id:'r8', t:dstamp(new Date(2026,7,7)), rest:'sushi', meal:'Lunch',  cash:8850,   card:17400, people:['Maria'],             by:'Maria', mode:'typed', flag:false},
+ {id:'r9', t:dstamp(new Date(2026,7,7)), rest:'poki',  meal:'Dinner', cash:19725,  card:35150, people:['Tom','Rey'],         by:'Tom',   mode:'typed', flag:false},
+ {id:'r10',t:dstamp(new Date(2026,7,6)), rest:'sushi', meal:'Dinner', cash:34400,  card:56125, people:['Maria','Jose','Ken'],by:'Maria', mode:'typed', flag:false}
+];
+
+function buildRecords(staff){
+  var records=generateHistory(staff||STAFF_SEED).concat(REAL_RECORDS);
+  records.sort(function(a,b){
+    if(a.t!==b.t)return b.t-a.t;
+    if(a.rest!==b.rest)return a.rest==='sushi'?-1:1;
+    return a.meal==='Dinner'?-1:1;
+  });
+  return records;
+}
+
+function filterRecords(records,options){
+  var startT=options.startT, endT=options.endT, rest=options.rest;
+  return records.filter(function(r){
+    if(r.t<startT||r.t>endT)return false;
+    if(rest!=='all'&&r.rest!==rest)return false;
+    return true;
+  });
+}
+
+function grouping(spanDays){
+  if(spanDays<=16) return {mode:'day', key:function(r){return r.t;}, label:function(k){return fmtDay(k)+' — day total';}};
+  if(spanDays<=100) return {mode:'week', key:function(r){return mondayOf(new Date(r.t)).getTime();},
+    label:function(k){var m=new Date(k),e=addDays(m,6);return 'Week of '+MONS[m.getMonth()]+' '+m.getDate()+' – '+(e.getMonth()===m.getMonth()?'':MONS[e.getMonth()]+' ')+e.getDate()+' — total';}};
+  return {mode:'month', key:function(r){var d=new Date(r.t);return new Date(d.getFullYear(),d.getMonth(),1).getTime();},
+    label:function(k){var d=new Date(k);return MONSFULL[d.getMonth()]+' '+d.getFullYear()+' — total';}};
+}
+
+function groupRecords(records,spanDays){
+  var behavior=grouping(spanDays), groups=[];
+  records.forEach(function(r){
+    var key=behavior.key(r), group=null;
+    for(var i=0;i<groups.length;i++)if(groups[i].key===key){group=groups[i];break;}
+    if(!group){
+      group={key:key,label:behavior.label(key),records:[],cashTotal:0,cardTotal:0};
+      groups.push(group);
+    }
+    group.records.push(r);
+    group.cashTotal+=r.cash;
+    group.cardTotal+=r.card;
+  });
+  return groups;
+}
+
+function totals(records){
+  return {
+    cash:sum(records,function(r){return r.cash;}),
+    card:sum(records,function(r){return r.card;}),
+    count:records.length,
+    flagged:records.filter(function(r){return r.flag;}).length
+  };
+}
+
+function csvField(v){v=String(v);return /[",\n]/.test(v)?'"'+v.replace(/"/g,'""')+'"':v;}
+function toCSV(records){
+  var rows=['Business date,Restaurant,Meal,Cash (split pool),Card (logged only),People on split,Names,Per-person share,Flagged,Entered by,Entry method'];
+  records.forEach(function(r){
+    rows.push([fmtDay(r.t)+' '+new Date(r.t).getFullYear(),RESTS[r.rest],r.meal,(r.cash/100).toFixed(2),(r.card/100).toFixed(2),r.people.length,'"'+r.people.join('; ').replace(/"/g,'""')+'"',(perShare(r.cash,r.people.length)/100).toFixed(2),r.flag?'yes':'no',csvField(r.by),r.mode].join(','));
+  });
+  return rows.join('\n');
+}
+
+var api={
+  money:money,
+  parseMoney:parseMoney,
+  perShare:perShare,
+  seeded:seeded,
+  mkSched:mkSched,
+  STAFF_SEED:STAFF_SEED,
+  REAL_RECORDS:REAL_RECORDS,
+  generateHistory:generateHistory,
+  buildRecords:buildRecords,
+  filterRecords:filterRecords,
+  grouping:grouping,
+  groupRecords:groupRecords,
+  totals:totals,
+  toCSV:toCSV
+};
+
+global.TipsCore=api;
+if(typeof module!=='undefined')module.exports=api;
+})(globalThis);
+</script>
+
+<script>
+(function(){
+'use strict';
+
+/* ---------------- constants ---------------- */
+var TODAY=new Date(2026,7,10);           /* mockup clock: Mon Aug 10 2026 */
+var DATA_START=new Date(2026,4,1), DATA_END=new Date(2026,7,9);
+var RESTS={sushi:'Sushi', poki:'Poki & Pho'};
+var WORKS={sushi:'Sushi', poki:'Poki & Pho', both:'Both'};
+var DAYKEYS=['sun','mon','tue','wed','thu','fri','sat'];
+var WEEKORDER=['mon','tue','wed','thu','fri','sat','sun'];
+var MONS=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+var MONSFULL=['January','February','March','April','May','June','July','August','September','October','November','December'];
+var DOWS=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+/* ---------------- utils ---------------- */
+function $(s,el){return (el||document).querySelector(s);}
+function $all(s,el){return Array.prototype.slice.call((el||document).querySelectorAll(s));}
+function esc(s){return String(s).replace(/[&<>"']/g,function(m){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m];});}
+var money=TipsCore.money, parseMoney=TipsCore.parseMoney;
+function perShare(r){return TipsCore.perShare(r.cash,r.people.length);}
+function dstamp(d){return new Date(d.getFullYear(),d.getMonth(),d.getDate()).getTime();}
+function fmtDay(t){var d=new Date(t);return DOWS[d.getDay()]+' '+MONS[d.getMonth()]+' '+d.getDate();}
+function addDays(d,n){return new Date(d.getFullYear(),d.getMonth(),d.getDate()+n);}
+function mondayOf(d){return addDays(d,-((d.getDay()+6)%7));}
+var toastT;
+function toast(msg){var t=$('#toast');t.textContent=msg;t.classList.add('on');clearTimeout(toastT);toastT=setTimeout(function(){t.classList.remove('on');},3200);}
+function newPin(){return String(Math.floor(1000+Math.random()*9000));}
+var seeded=TipsCore.seeded;
+function qrSVG(seed){
+  var rnd=seeded(seed||1), cells='';
+  for(var y=0;y<21;y++)for(var x=0;x<21;x++){
+    var inF=(x<8&&y<8)||(x>=13&&y<8)||(x<8&&y>=13);
+    if(!inF&&rnd()<0.45)cells+='<rect x="'+x+'" y="'+y+'" width="1" height="1"/>';
+  }
+  function fin(x,y){return '<rect x="'+x+'" y="'+y+'" width="7" height="7"/><rect x="'+(x+1)+'" y="'+(y+1)+'" width="5" height="5" fill="#fff"/><rect x="'+(x+2)+'" y="'+(y+2)+'" width="3" height="3"/>';}
+  return '<svg class="qr" viewBox="-1.5 -1.5 24 24" role="img" aria-label="Preview of the new QR sticker" xmlns="http://www.w3.org/2000/svg"><rect x="-1.5" y="-1.5" width="24" height="24" fill="#fff"/><g fill="#1a1a1a">'+cells+fin(0,0)+fin(14,0)+fin(0,14)+'</g></svg>';
+}
+function copyText(txt){
+  if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(txt).then(function(){toast('Copied.');},function(){toast('Copy unavailable here — write it down.');});}
+  else toast('Copy unavailable here — write it down.');
+}
+
+/* ---------------- staff + records (data layer lives in TipsCore) ---------------- */
+var mkSched=TipsCore.mkSched;
+var staff=TipsCore.STAFF_SEED;
+var records=TipsCore.buildRecords(staff);
+var hasDataDay={}; records.forEach(function(r){hasDataDay[r.t]=true;});
+function shiftCount(name){return records.reduce(function(t,r){return t+(r.people.indexOf(name)>=0?1:0);},0);}
+
+/* ---------------- app state ---------------- */
+var st={
+  restFilter:'all',
+  range:{start:new Date(2026,7,3), end:new Date(2026,7,9), preset:'lastweek'},
+  editing:null, pending:null, renaming:null,
+  access:{sushi:{qr:'Aug 8, 2026',pin:'Aug 8, 2026'}, poki:{qr:null,pin:'Aug 8, 2026'}},
+  rotConfirm:null, reveal:null
+};
+var hireSeq=1;
+
+/* ---------------- range label ---------------- */
+function rangeLabel(){
+  var s=st.range.start, e=st.range.end;
+  if(s.getDate()===1){
+    var eom=new Date(e.getFullYear(),e.getMonth()+1,0);
+    if(s.getMonth()===e.getMonth()&&s.getFullYear()===e.getFullYear()&&e.getDate()===eom.getDate())
+      return MONSFULL[s.getMonth()]+' '+s.getFullYear();
+    if(s.getMonth()===0&&e.getMonth()===11&&e.getDate()===31&&s.getFullYear()===e.getFullYear())
+      return 'Year '+s.getFullYear();
+  }
+  if(s.getTime()===e.getTime()) return DOWS[s.getDay()]+' '+MONS[s.getMonth()]+' '+s.getDate()+', '+s.getFullYear();
+  if(s.getMonth()===e.getMonth()&&s.getFullYear()===e.getFullYear())
+    return MONS[s.getMonth()]+' '+s.getDate()+' – '+e.getDate()+', '+e.getFullYear();
+  if(s.getFullYear()===e.getFullYear())
+    return MONS[s.getMonth()]+' '+s.getDate()+' – '+MONS[e.getMonth()]+' '+e.getDate()+', '+e.getFullYear();
+  return MONS[s.getMonth()]+' '+s.getDate()+', '+s.getFullYear()+' – '+MONS[e.getMonth()]+' '+e.getDate()+', '+e.getFullYear();
+}
+
+/* ---------------- filtering + records render ---------------- */
+function visible(){
+  return TipsCore.filterRecords(records,{startT:dstamp(st.range.start), endT:dstamp(st.range.end), rest:st.restFilter});
+}
+function renderTotals(recs){
+  var tt=TipsCore.totals(recs);
+  $('#totals').innerHTML=
+    (tt.flagged?'<button class="flagcount" data-act="jumpflag">⚑ '+tt.flagged+' flagged</button>':'')+
+    '<span>Cash pool <strong class="num">'+money(tt.cash)+'</strong></span>'+
+    '<span>Card logged <strong class="num">'+money(tt.card)+'</strong></span>'+
+    '<span>'+tt.count+' records</span>';
+}
+function edPreview(cashC,n){
+  if(n===0)return '<span class="ed-error">Select at least one person to split between.</span>';
+  if(cashC===null)return '<span class="ed-error">Cash amount doesn’t parse.</span>';
+  return 'New per-person share: <strong class="num">'+money(TipsCore.perShare(cashC,n))+'</strong> each — cash ÷ '+n+'. Card is logged only and stays out of this number.';
+}
+function eligibleNames(rec){
+  var names=staff.filter(function(s){return s.active&&(s.works===rec.rest||s.works==='both');}).map(function(s){return s.name;});
+  rec.people.forEach(function(n){if(names.indexOf(n)<0)names.push(n);});
+  return names;
+}
+function editorRow(r){
+  var names=eligibleNames(r);
+  return '<tr class="edrow"><td colspan="9">'+
+    '<form class="edform" data-id="'+r.id+'">'+
+      '<div class="ed-fields">'+
+        '<label>Cash pool — split ($)<input type="text" class="num" name="cash" inputmode="decimal" value="'+(r.cash/100).toFixed(2)+'"></label>'+
+        '<label class="ed-card">Card — logged only ($)<input type="text" class="num" name="card" inputmode="decimal" value="'+(r.card/100).toFixed(2)+'"></label>'+
+        '<fieldset><legend>Split between</legend>'+names.map(function(n){
+          return '<label class="chk"><input type="checkbox" name="p" value="'+esc(n)+'"'+(r.people.indexOf(n)>=0?' checked':'')+'>'+esc(n)+'</label>';
+        }).join('')+'</fieldset>'+
+      '</div>'+
+      '<p class="ed-preview" data-role="preview">'+edPreview(r.cash,r.people.length)+'</p>'+
+      '<div class="ed-actions" data-role="actions">'+
+        '<button type="button" class="btn" data-act="edcancel">Cancel</button>'+
+        '<button type="submit" class="btn primary">Save correction…</button>'+
+      '</div>'+
+    '</form></td></tr>';
+}
+function renderRecords(){
+  var recs=visible(), html='';
+  var span=(dstamp(st.range.end)-dstamp(st.range.start))/86400000+1;
+  TipsCore.groupRecords(recs,span).forEach(function(g){
+    g.records.forEach(function(r){
+      html+='<tr'+(r.flag?' class="flagrow" id="flagRow"':'')+'>'+
+        '<td>'+fmtDay(r.t)+'</td><td>'+RESTS[r.rest]+'</td><td>'+r.meal+'</td>'+
+        '<td class="r num col-split">'+money(r.cash)+(r.flag?'<span class="flagchip" title="Far outside the usual range for this shift">⚑ check</span>':'')+'</td>'+
+        '<td class="col-split names">'+r.people.map(esc).join(', ')+' <span class="cnt">· '+r.people.length+'</span></td>'+
+        '<td class="r num col-split per">'+money(perShare(r))+'</td>'+
+        '<td class="r num col-card">'+money(r.card)+'</td>'+
+        '<td class="meta">'+esc(r.by)+' · '+(r.mode==='voice'?'dictated':'typed')+'</td>'+
+        '<td><button class="rowbtn" data-act="edit" data-id="'+r.id+'">Fix</button>'+
+          (r.flag?'<button class="rowbtn" data-act="clearflag" data-id="'+r.id+'" title="Keep the amount and clear the flag">Verify</button>':'')+'</td></tr>';
+      if(st.editing===r.id)html+=editorRow(r);
+    });
+    html+='<tr class="subrow"><th scope="row" colspan="3">'+g.label+'</th>'+
+      '<td class="r num col-split">'+money(g.cashTotal)+'</td><td class="col-split"></td><td class="col-split"></td>'+
+      '<td class="r num col-card">'+money(g.cardTotal)+'</td><td colspan="2"></td></tr>';
+  });
+  if(!recs.length) html='<tr class="emptyrow"><td colspan="9">Nothing recorded in this range'+(st.restFilter!=='all'?' for '+RESTS[st.restFilter]:'')+'.</td></tr>';
+  else{
+    var tt=TipsCore.totals(recs);
+    html+='<tr class="grand"><th scope="row" colspan="3">'+rangeLabel()+' — '+tt.count+' records</th>'+
+      '<td class="r num col-split">'+money(tt.cash)+'</td><td class="col-split"></td><td class="col-split"></td>'+
+      '<td class="r num col-card">'+money(tt.card)+'</td><td colspan="2"></td></tr>';
+  }
+  $('#recBody').innerHTML=html;
+  renderTotals(recs);
+  $('#rangeLabel').textContent=rangeLabel();
+}
+
+/* ---------------- staff render ---------------- */
+function renderStaff(){
+  var rows=staff.slice().sort(function(a,b){return (a.active===b.active)?0:(a.active?-1:1);});
+  $('#staffBody').innerHTML=rows.map(function(s){
+    var n=shiftCount(s.name);
+    var nameCell = st.renaming===s.id
+      ? '<form class="renform" data-id="'+s.id+'"><input name="nm" value="'+esc(s.name)+'" aria-label="New name for '+esc(s.name)+'"><button class="btn primary" style="padding:2px 10px;font-size:12px">Save</button></form>'
+      : '<strong>'+esc(s.name)+'</strong>'+(s.active?'':'<span class="badge-off">inactive</span>');
+    var sch='<div class="sch">'+WEEKORDER.map(function(d){
+      return '<div class="day"><div class="dl">'+
+        '<button data-act="sch" data-id="'+s.id+'" data-day="'+d+'" data-meal="L" aria-pressed="'+s.sched[d].L+'"'+(s.active?'':' disabled')+' aria-label="'+esc(s.name)+' '+d+' lunch">L</button>'+
+        '<button data-act="sch" data-id="'+s.id+'" data-day="'+d+'" data-meal="D" aria-pressed="'+s.sched[d].D+'"'+(s.active?'':' disabled')+' aria-label="'+esc(s.name)+' '+d+' dinner">D</button>'+
+      '</div></div>';
+    }).join('')+'</div>';
+    return '<tr'+(s.active?'':' class="inactive-row"')+'>'+
+      '<td>'+nameCell+'</td>'+
+      '<td><select class="works-sel" data-act-sel="works" data-id="'+s.id+'" aria-label="Restaurant for '+esc(s.name)+'"'+(s.active?'':' disabled')+'>'+
+        ['sushi','poki','both'].map(function(w){return '<option value="'+w+'"'+(s.works===w?' selected':'')+'>'+WORKS[w]+'</option>';}).join('')+'</select></td>'+
+      '<td>'+sch+'</td>'+
+      '<td class="r num">'+n+'</td>'+
+      '<td><button class="link" data-act="rename" data-id="'+s.id+'">Rename</button> '+
+        (s.active?'<button class="link" data-act="deact" data-id="'+s.id+'">Deactivate</button> '
+                 :'<button class="link" data-act="react" data-id="'+s.id+'">Reactivate</button> ')+
+        (n===0?'<button class="link dangerlink" data-act="del" data-id="'+s.id+'">Delete</button>'
+              :'<button class="link" disabled title="Has recorded shifts — deactivate instead">Delete</button>')+
+      '</td></tr>';
+  }).join('');
+}
+
+/* ---------------- access render ---------------- */
+function accessPanel(k){
+  var a=st.access[k], name=RESTS[k], word=(k==='sushi')?'SUSHI':'POKI';
+  var html='<div class="access"><h4>'+name+'</h4><dl>'+
+    '<div class="row"><dt>QR sticker</dt><dd>'+(a.qr?'rotated '+a.qr:'never rotated — original from setup')+'</dd>'+
+      '<button class="btn" style="padding:4px 12px;font-size:12.5px" data-act="rot" data-rest="'+k+'" data-kind="qr">Rotate…</button></div>'+
+    '<div class="row"><dt>PIN</dt><dd>rotated '+a.pin+'</dd>'+
+      '<button class="btn" style="padding:4px 12px;font-size:12.5px" data-act="rot" data-rest="'+k+'" data-kind="pin">Rotate…</button></div></dl>'+
+    '<button class="signout" data-act="rot" data-rest="'+k+'" data-kind="signout">Sign out every phone at '+name+'…</button>';
+  if(st.rotConfirm&&st.rotConfirm.rest===k){
+    var kind=st.rotConfirm.kind;
+    var msg = kind==='qr' ? 'The printed sticker by the register stops working the moment you rotate. You’ll need to print and stick the new one.'
+            : kind==='pin' ? 'The old PIN stops working immediately — tonight’s closers need the new number.'
+            : 'Every signed-in phone at '+name+' is signed out and will need the QR sticker and PIN to get back in.';
+    html+='<div class="confirmbox"><p><strong>'+(kind==='qr'?'Rotate QR sticker':kind==='pin'?'Rotate PIN':'Sign out all phones')+' — '+name+'.</strong> '+msg+'</p>'+
+      '<label>Type '+word+' to confirm <input type="text" data-role="typeconf" autocomplete="off" autocapitalize="characters"></label>'+
+      '<button class="btn danger" data-act="rotgo" disabled>'+(kind==='signout'?'Sign everyone out':'Rotate now')+'</button> '+
+      '<button class="btn" data-act="rotcancel">Cancel</button></div>';
+  }
+  if(st.reveal&&st.reveal.rest===k){
+    var rv=st.reveal;
+    if(rv.kind==='pin'){
+      html+='<div class="reveal"><p><strong>New PIN — shown once, then gone.</strong> Only a hash is stored; write it down or copy it now.</p>'+
+        '<span class="secret">'+rv.secret+'</span><br>'+
+        '<button data-act="copysecret" data-secret="'+rv.secret+'">Copy</button>'+
+        '<button data-act="hidesecret">I’ve saved it — hide forever</button></div>';
+    } else {
+      html+='<div class="reveal"><p><strong>New QR sticker — this preview is shown once.</strong> Print it and replace the sticker before tonight; the old one already stopped working.</p>'+
+        qrSVG(rv.seed)+
+        '<button data-act="printsticker">Print sticker</button>'+
+        '<button data-act="hidesecret">Done — sticker printed</button></div>';
+    }
+  }
+  return html+'</div>';
+}
+function renderAccess(){$('#access').innerHTML=accessPanel('sushi')+accessPanel('poki');}
+
+/* ---------------- calendar ---------------- */
+var calEl=$('#cal');
+var cal={open:false, mode:'weeks', viewY:2026, viewM:7, selStart:null};
+var PRESETS=[
+ {id:'thisweek', label:'This week',    f:function(){var m=mondayOf(TODAY);return [m,addDays(m,6)];}},
+ {id:'lastweek', label:'Last week',    f:function(){var m=addDays(mondayOf(TODAY),-7);return [m,addDays(m,6)];}},
+ {id:'thismonth',label:'This month',   f:function(){return [new Date(2026,7,1),new Date(2026,7,31)];}},
+ {id:'lastmonth',label:'Last month',   f:function(){return [new Date(2026,6,1),new Date(2026,6,31)];}},
+ {id:'past90',   label:'Past 3 months',f:function(){return [addDays(TODAY,-89),TODAY];}},
+ {id:'thisyear', label:'This year',    f:function(){return [new Date(2026,0,1),new Date(2026,11,31)];}},
+ {id:'alltime',  label:'All records',  f:function(){return [DATA_START,DATA_END];}}
+];
+function setRange(s,e,preset){
+  if(s>e){var t=s;s=e;e=t;}
+  st.range={start:s,end:e,preset:preset||null};
+  st.editing=null; st.pending=null;
+  renderRecords();
+}
+function calGridHTML(){
+  var y=cal.viewY, m=cal.viewM;
+  var first=new Date(y,m,1), offset=(first.getDay()+6)%7;
+  var startCell=addDays(first,-offset);
+  var selS=dstamp(st.range.start), selE=dstamp(st.range.end);
+  var html='<div class="cal-dow"><span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span></div>';
+  for(var w=0;w<6;w++){
+    html+='<div class="cal-week">';
+    for(var i=0;i<7;i++){
+      var d=addDays(startCell,w*7+i), t=dstamp(d);
+      var cls='cal-day';
+      if(d.getMonth()!==m)cls+=' out';
+      if(t>=selS&&t<=selE)cls+=' sel';
+      if(t===selS||t===selE)cls+=' edge';
+      if(t===dstamp(TODAY))cls+=' today';
+      if(cal.selStart!==null&&t===cal.selStart)cls+=' edge';
+      html+='<button type="button" class="'+cls+'" data-cal-day="'+t+'">'+d.getDate()+(hasDataDay[t]?'<span class="dot"></span>':'')+'</button>';
+    }
+    html+='</div>';
+  }
+  return html;
+}
+function renderCal(){
+  calEl.dataset.mode=cal.mode;
+  var main='';
+  main+='<div class="cal-modes" role="group" aria-label="Selection mode">'+
+    [['days','Days'],['weeks','Weeks'],['months','Months'],['years','Years']].map(function(mm){
+      return '<button data-cal-mode="'+mm[0]+'" aria-pressed="'+(cal.mode===mm[0])+'">'+mm[1]+'</button>';
+    }).join('')+'</div>';
+  if(cal.mode==='days'||cal.mode==='weeks'){
+    main+='<div class="cal-nav"><button data-cal-nav="-1" aria-label="Previous month">‹</button>'+
+      '<strong>'+MONSFULL[cal.viewM]+' '+cal.viewY+'</strong>'+
+      '<button data-cal-nav="1" aria-label="Next month">›</button></div>'+calGridHTML();
+    main+='<p class="cal-hint">'+(cal.mode==='weeks'
+      ?'Click any day to select its Mon–Sun week. Dots mark days with records.'
+      :(cal.selStart===null?'Click a start day, then an end day. Dots mark days with records.':'Now click the end day.'))+'</p>';
+  } else if(cal.mode==='months'){
+    main+='<div class="cal-nav"><button data-cal-nav="-1" aria-label="Previous year">‹</button>'+
+      '<strong>'+cal.viewY+'</strong><button data-cal-nav="1" aria-label="Next year">›</button></div>'+
+      '<div class="cal-grid12">'+MONS.map(function(mn,i){
+        var has=(cal.viewY===2026&&i>=4&&i<=7);
+        var on=(st.range.start.getDate()===1&&st.range.start.getMonth()===i&&st.range.start.getFullYear()===cal.viewY&&st.range.end.getMonth()===i);
+        return '<button data-cal-month="'+i+'"'+(has?'':' ')+' class="'+(on?'on':'')+'">'+mn+(has?' •':'')+'</button>';
+      }).join('')+'</div><p class="cal-hint">• marks months with records.</p>';
+  } else {
+    main+='<div class="cal-years">'+[2025,2026].map(function(yy){
+      return '<button data-cal-year="'+yy+'"'+(yy===2025?' disabled title="No records in 2025"':'')+'>'+yy+(yy===2026?' — May through Aug have records':'')+'</button>';
+    }).join('')+'</div>';
+  }
+  calEl.innerHTML='<div class="cal-presets"><h5>Quick ranges</h5>'+PRESETS.map(function(p){
+      return '<button data-cal-preset="'+p.id+'" aria-pressed="'+(st.range.preset===p.id)+'">'+p.label+'</button>';
+    }).join('')+'</div><div class="cal-main">'+main+'</div>';
+}
+function openCal(){cal.open=true;cal.selStart=null;cal.viewY=st.range.start.getFullYear();cal.viewM=st.range.start.getMonth();renderCal();calEl.hidden=false;$('#rangeBtn').setAttribute('aria-expanded','true');}
+function closeCal(){cal.open=false;calEl.hidden=true;$('#rangeBtn').setAttribute('aria-expanded','false');}
+$('#rangeBtn').addEventListener('click',function(){cal.open?closeCal():openCal();});
+document.addEventListener('click',function(e){
+  if(cal.open&&!calEl.contains(e.target)&&!$('#rangeBtn').contains(e.target))closeCal();
+});
+document.addEventListener('keydown',function(e){if(e.key==='Escape'&&cal.open)closeCal();});
+calEl.addEventListener('click',function(e){
+  var b=e.target.closest('button'); if(!b)return;
+  if(b.dataset.calMode){cal.mode=b.dataset.calMode;cal.selStart=null;renderCal();return;}
+  if(b.dataset.calNav){
+    var dn=Number(b.dataset.calNav);
+    if(cal.mode==='months'){cal.viewY+=dn;}
+    else{cal.viewM+=dn; if(cal.viewM<0){cal.viewM=11;cal.viewY--;} if(cal.viewM>11){cal.viewM=0;cal.viewY++;}}
+    renderCal();return;
+  }
+  if(b.dataset.calPreset){
+    var p=PRESETS.find(function(x){return x.id===b.dataset.calPreset;});
+    var se=p.f(); setRange(se[0],se[1],p.id); closeCal();
+    toast('Range: '+rangeLabel()); return;
+  }
+  if(b.dataset.calDay){
+    var t=Number(b.dataset.calDay), d=new Date(t);
+    if(cal.mode==='weeks'){var mo=mondayOf(d);setRange(mo,addDays(mo,6));closeCal();toast('Range: '+rangeLabel());}
+    else{
+      if(cal.selStart===null){cal.selStart=t;renderCal();}
+      else{setRange(new Date(cal.selStart),d);cal.selStart=null;closeCal();toast('Range: '+rangeLabel());}
+    }
+    return;
+  }
+  if(b.dataset.calMonth!==undefined){
+    var mi=Number(b.dataset.calMonth);
+    setRange(new Date(cal.viewY,mi,1),new Date(cal.viewY,mi+1,0));
+    closeCal();toast('Range: '+rangeLabel());return;
+  }
+  if(b.dataset.calYear){
+    var yy=Number(b.dataset.calYear);
+    setRange(new Date(yy,0,1),new Date(yy,11,31));
+    closeCal();toast('Range: '+rangeLabel());return;
+  }
+});
+
+/* ---------------- export ---------------- */
+function exportCSV(){
+  var recs=visible();
+  var blob=new Blob([TipsCore.toCSV(recs)],{type:'text/csv'});
+  var a=document.createElement('a');a.href=URL.createObjectURL(blob);
+  a.download='babytuna-tips-'+rangeLabel().toLowerCase().replace(/[^a-z0-9]+/g,'-')+'.csv';
+  document.body.appendChild(a);a.click();a.remove();
+  toast('Exported '+recs.length+' record'+(recs.length===1?'':'s')+' to CSV.');
+}
+
+/* ---------------- theme tabs ---------------- */
+$all('.tab').forEach(function(t){
+  t.addEventListener('click',function(){
+    document.body.dataset.theme=t.dataset.thm;
+    $all('.tab').forEach(function(x){x.setAttribute('aria-pressed',x===t?'true':'false');});
+  });
+});
+
+/* ---------------- main event wiring ---------------- */
+document.addEventListener('click',function(e){
+  var b=e.target.closest('[data-act]'); if(!b)return;
+  var act=b.dataset.act, id=b.dataset.id;
+  if(act==='rest'){
+    st.restFilter=b.dataset.v; st.editing=null; st.pending=null;
+    $all('#restSeg button').forEach(function(x){x.setAttribute('aria-pressed',x===b?'true':'false');});
+    renderRecords();
+  }
+  else if(act==='export'){exportCSV();}
+  else if(act==='jumpflag'){var row=$('#flagRow');if(row)row.scrollIntoView({block:'center'});}
+  else if(act==='edit'){st.editing=(st.editing===id?null:id);st.pending=null;renderRecords();var f=$('.edform input');if(f)f.focus();}
+  else if(act==='edcancel'){st.editing=null;st.pending=null;renderRecords();}
+  else if(act==='edback'){
+    st.pending=null;
+    var acts=$('.edform [data-role="actions"]');
+    if(acts)acts.innerHTML='<button type="button" class="btn" data-act="edcancel">Cancel</button><button type="submit" class="btn primary">Save correction…</button>';
+  }
+  else if(act==='edconfirm'){
+    var r=records.find(function(x){return x.id===id;});
+    r.cash=st.pending.cash;r.card=st.pending.card;r.people=st.pending.people.slice();r.flag=false;
+    st.editing=null;st.pending=null;renderRecords();renderStaff();
+    toast('Correction saved — '+fmtDay(r.t)+' '+RESTS[r.rest]+' '+r.meal.toLowerCase()+' now splits '+money(perShare(r))+' each.');
+  }
+  else if(act==='clearflag'){
+    var rec=records.find(function(x){return x.id===id;});
+    if(!b.dataset.armed){b.dataset.armed='1';b.textContent='Really verify?';return;}
+    rec.flag=false;renderRecords();
+    toast(fmtDay(rec.t)+' '+RESTS[rec.rest]+' '+rec.meal.toLowerCase()+': flag cleared, amount kept as entered.');
+  }
+  else if(act==='sch'){
+    var s=staff.find(function(x){return x.id===id;});
+    var cell=s.sched[b.dataset.day];
+    cell[b.dataset.meal]=!cell[b.dataset.meal];
+    b.setAttribute('aria-pressed',cell[b.dataset.meal]?'true':'false');
+  }
+  else if(act==='rename'){st.renaming=id;renderStaff();var inp=$('.renform input');if(inp){inp.focus();inp.select();}}
+  else if(act==='deact'){
+    var s2=staff.find(function(x){return x.id===id;});s2.active=false;renderStaff();
+    toast(s2.name+' deactivated — off the phone picker; history stays.');
+  }
+  else if(act==='react'){
+    var s3=staff.find(function(x){return x.id===id;});s3.active=true;renderStaff();
+    toast(s3.name+' reactivated — back on the phone picker.');
+  }
+  else if(act==='del'){
+    if(!b.dataset.armed){b.dataset.armed='1';b.textContent='Really delete?';return;}
+    var i=staff.findIndex(function(x){return x.id===id;});
+    var nm=staff[i].name;staff.splice(i,1);renderStaff();
+    toast(nm+' deleted. (Only possible because they had no recorded shifts.)');
+  }
+  else if(act==='rot'){st.rotConfirm={rest:b.dataset.rest,kind:b.dataset.kind};st.reveal=null;renderAccess();var ti=$('[data-role="typeconf"]');if(ti)ti.focus();}
+  else if(act==='rotcancel'){st.rotConfirm=null;renderAccess();}
+  else if(act==='rotgo'){
+    var rc=st.rotConfirm, acc=st.access[rc.rest];
+    if(rc.kind==='signout'){st.rotConfirm=null;renderAccess();toast('All phones at '+RESTS[rc.rest]+' signed out. They’ll need the QR sticker and PIN to get back in.');}
+    else{
+      if(rc.kind==='qr')acc.qr='just now (Aug 10)';else acc.pin='just now (Aug 10)';
+      st.reveal={rest:rc.rest,kind:rc.kind,secret:newPin(),seed:Math.floor(Math.random()*1e9)};
+      st.rotConfirm=null;renderAccess();
+    }
+  }
+  else if(act==='copysecret'){copyText(b.dataset.secret);}
+  else if(act==='printsticker'){toast('Printing is inert in this mockup — the real app opens the print dialog.');}
+  else if(act==='hidesecret'){st.reveal=null;renderAccess();toast('Hidden. It can’t be shown again — only rotated again.');}
+});
+document.addEventListener('input',function(e){
+  var form=e.target.closest('.edform');
+  if(form){
+    var cash=parseMoney(form.cash.value);
+    var n=$all('input[name="p"]:checked',form).length;
+    $('[data-role="preview"]',form).innerHTML=edPreview(cash,n);
+    return;
+  }
+  if(e.target.matches('[data-role="typeconf"]')){
+    var want=(st.rotConfirm.rest==='sushi')?'SUSHI':'POKI';
+    var go=$('.confirmbox .danger');
+    if(go)go.disabled=(e.target.value.trim().toUpperCase()!==want);
+  }
+});
+document.addEventListener('change',function(e){
+  if(e.target.matches('[data-act-sel="works"]')){
+    var s=staff.find(function(x){return x.id===e.target.dataset.id;});
+    s.works=e.target.value;
+    toast(s.name+' now works at '+WORKS[s.works]+'.');
+  }
+});
+document.addEventListener('submit',function(e){
+  var f=e.target;
+  if(f.id==='addForm'){
+    e.preventDefault();
+    var nm=f.name.value.trim();if(!nm)return;
+    staff.splice(staff.filter(function(s){return s.active;}).length,0,
+      {id:'new'+(hireSeq++),name:nm,works:f.works.value,active:true,sched:mkSched('')});
+    f.reset();renderStaff();
+    toast(nm+' added — tick their days below so the phone pre-selects them.');
+  }
+  else if(f.classList.contains('renform')){
+    e.preventDefault();
+    var s=staff.find(function(x){return x.id===f.dataset.id;});
+    var nm2=f.nm.value.trim();
+    if(nm2&&nm2!==s.name){
+      var old=s.name;s.name=nm2;
+      records.forEach(function(r){
+        r.people=r.people.map(function(p){return p===old?nm2:p;});
+        if(r.by===old)r.by=nm2;
+      });
+      renderRecords();
+    }
+    st.renaming=null;renderStaff();
+  }
+  else if(f.classList.contains('edform')){
+    e.preventDefault();
+    var cash=parseMoney(f.cash.value),card=parseMoney(f.card.value);
+    var people=$all('input[name="p"]:checked',f).map(function(i){return i.value;});
+    if(cash===null||card===null||!people.length){
+      $('[data-role="preview"]',f).innerHTML=edPreview(cash,people.length);return;
+    }
+    var r=records.find(function(x){return x.id===f.dataset.id;});
+    st.pending={cash:cash,card:card,people:people};
+    var newPer=TipsCore.perShare(cash,people.length);
+    $('[data-role="actions"]',f).innerHTML='<div class="ed-confirm">'+
+      '<p><strong>Check it:</strong> cash '+money(r.cash)+' → <strong class="num">'+money(cash)+'</strong> · card '+money(r.card)+' → '+money(card)+
+      ' · per-person '+money(perShare(r))+' → <strong class="num">'+money(newPer)+'</strong> for '+people.map(esc).join(', ')+
+      '. This changes what people are owed'+(r.flag?' and clears the flag':'')+'.</p>'+
+      '<button type="button" class="btn" data-act="edback">Back</button> '+
+      '<button type="button" class="btn danger" data-act="edconfirm" data-id="'+r.id+'">Confirm correction</button></div>';
+  }
+});
+
+/* ---------------- boot ---------------- */
+renderRecords();renderStaff();renderAccess();
+})();
+</script>
+</body>
+</html>

--- a/docs/mockups/tips-dashboard/claude-fable.html
+++ b/docs/mockups/tips-dashboard/claude-fable.html
@@ -1,0 +1,1423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light">
+<title>Babytuna Tips — Manager Dashboard · three design variants</title>
+<style>
+/* ============ shared ============ */
+*{box-sizing:border-box;margin:0;padding:0}
+html{font:16px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;color:#1a1a1a;background:#f5f1e8;-webkit-text-size-adjust:100%}
+body{min-width:1000px}
+button{font:inherit;cursor:pointer;color:inherit}
+input,select{font:inherit;color:inherit}
+[hidden]{display:none!important}
+:focus-visible{outline:2px solid #e84d38;outline-offset:2px;border-radius:4px}
+.num{font-variant-numeric:tabular-nums}
+.sr{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap}
+@media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
+
+.topbar{position:sticky;top:0;z-index:80;background:#fff;border-bottom:1px solid rgba(0,0,0,.09);display:flex;align-items:center;gap:22px;padding:10px 26px}
+.brand{font-weight:700;font-size:15px;white-space:nowrap}
+.brand span{color:#9c9890;font-weight:400}
+.tabs{display:flex;gap:4px;background:#f0ece1;padding:4px;border-radius:10px}
+.tab{border:0;background:transparent;padding:6px 14px;border-radius:7px;color:#5f5f5f;font-weight:600;font-size:14px}
+.tab[aria-selected="true"]{background:#fff;color:#1a1a1a;box-shadow:0 1px 2px rgba(0,0,0,.10)}
+.topnote{margin-left:auto;color:#9c9890;font-size:12.5px;white-space:nowrap}
+
+.thesis{max-width:1160px;margin:24px auto 4px;padding:2px 24px 2px 21px}
+.thesis-inner{border-left:3px solid #e84d38;padding:2px 0 2px 16px}
+.thesis h2{font-size:15px;margin-bottom:2px}
+.thesis p{color:#5f5f5f;font-size:14px;max-width:78ch}
+
+#toast{position:fixed;left:50%;bottom:24px;transform:translate(-50%,12px);background:#1a1a1a;color:#fff;padding:10px 18px;border-radius:99px;font-size:14px;opacity:0;pointer-events:none;transition:opacity .18s,transform .18s;z-index:200;max-width:80ch}
+#toast.on{opacity:1;transform:translate(-50%,0)}
+
+.rounding-note{color:#9c9890;font-size:12.5px;max-width:88ch;margin-top:10px}
+.qr{width:132px;height:132px;image-rendering:pixelated;border:1px solid rgba(0,0,0,.1);border-radius:6px;background:#fff}
+
+/* ============ Variant A — The Ledger ============ */
+.vA{background:#f7f5f0;padding-bottom:90px;font-size:14px}
+.vA .wrap{max-width:1160px;margin:0 auto;padding:0 24px}
+.a-bar{position:sticky;top:49px;z-index:40;background:#f7f5f0;padding:12px 0 10px;border-bottom:1px solid rgba(0,0,0,.12);display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:22px}
+.a-bar label{font-size:12px;color:#5f5f5f;display:flex;align-items:center;gap:7px;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
+.a-bar select{border:1px solid rgba(0,0,0,.2);border-radius:8px;padding:5px 8px;background:#fff;font-size:13px}
+.seg{display:inline-flex;border:1px solid rgba(0,0,0,.2);border-radius:8px;overflow:hidden;background:#fff}
+.seg button{border:0;background:transparent;padding:5px 13px;font-size:13px;color:#5f5f5f;border-right:1px solid rgba(0,0,0,.12)}
+.seg button:last-child{border-right:0}
+.seg button[aria-pressed="true"]{background:#1a1a1a;color:#fff}
+.a-totals{margin-left:auto;display:flex;align-items:baseline;gap:18px;font-size:13px;color:#5f5f5f}
+.a-totals strong{font-size:15px;color:#1a1a1a}
+.a-flagcount{background:#fbeae7;color:#c03520;border:1px solid rgba(192,53,32,.35);border-radius:99px;padding:3px 11px;font-size:12.5px;font-weight:700}
+.a-export{border:1px solid rgba(0,0,0,.25);background:#fff;border-radius:8px;padding:5px 13px;font-size:13px;font-weight:600}
+.a-section{margin-bottom:44px}
+.a-section>h3{font-size:12.5px;text-transform:uppercase;letter-spacing:.09em;color:#5f5f5f;margin-bottom:10px;border-bottom:2px solid #1a1a1a;padding-bottom:5px}
+.a-table{width:100%;border-collapse:collapse;font-size:13.5px;background:#fff;border:1px solid rgba(0,0,0,.14)}
+.a-table th,.a-table td{padding:7px 11px;text-align:left;border-bottom:1px solid rgba(0,0,0,.07);vertical-align:top}
+.a-table thead th{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:#5f5f5f;background:#efece3;border-bottom:1px solid rgba(0,0,0,.16);font-weight:700}
+.a-table thead .grp{text-align:center}
+.a-table thead .grp-split{background:#f3e7d2;color:#5a4a24}
+.a-table thead .grp-card{background:#e7e9ec;color:#4b5560}
+.a-table thead .sub-split{background:#f8efe0;color:#5a4a24}
+.a-table thead .sub-card{background:#eef0f2;color:#4b5560}
+.r{text-align:right}
+td.col-split{background:#fdf8ee}
+td.col-card{background:#f3f4f6;color:#5f5f5f;border-left:1px dashed rgba(0,0,0,.18)}
+th.sub-card,td.col-card{border-left:1px dashed rgba(0,0,0,.18)}
+.a-table td.per{font-weight:700}
+.a-table .names{color:#3c3a35}
+.a-table .cnt{color:#9c9890;font-size:12px}
+.a-table .meta{color:#9c9890;font-size:12.5px;white-space:nowrap}
+.a-flagrow>td{background:#fbeae7!important}
+.a-flagrow>td:first-child{box-shadow:inset 3px 0 0 #c03520}
+.a-flagchip{display:inline-block;background:#c03520;color:#fff;border-radius:5px;font-size:11px;font-weight:700;padding:1px 7px;margin-left:7px;vertical-align:1px}
+.a-fixbtn,.a-okbtn{border:1px solid rgba(0,0,0,.22);background:#fff;border-radius:7px;padding:3px 11px;font-size:12.5px;font-weight:600}
+.a-okbtn{color:#5f5f5f;margin-left:5px}
+.a-sub th,.a-sub td{background:#efece3!important;font-weight:700;font-size:12.5px;color:#3c3a35;border-top:1px solid rgba(0,0,0,.14)}
+.a-sub th{text-align:right}
+.a-grand th,.a-grand td{background:#1a1a1a!important;color:#fff!important;font-weight:700;font-size:13px}
+.a-grand th{text-align:right}
+.a-grand td.col-card{border-left-color:rgba(255,255,255,.4)}
+.a-empty td{color:#9c9890;padding:20px;text-align:center}
+/* inline editor row */
+.a-edrow>td{background:#fffdf2;border-top:2px solid #1a1a1a;border-bottom:2px solid #1a1a1a;padding:16px 18px}
+.ed-fields{display:flex;gap:26px;flex-wrap:wrap;align-items:flex-start}
+.ed-fields>label{display:flex;flex-direction:column;gap:4px;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:#5a4a24}
+.ed-fields>label.ed-card{color:#4b5560}
+.ed-fields input[type="text"]{border:1px solid rgba(0,0,0,.3);border-radius:8px;padding:7px 10px;width:130px;font-size:15px;text-align:right;background:#fff}
+.ed-fields fieldset{border:1px solid rgba(0,0,0,.18);border-radius:10px;padding:8px 12px 10px;background:#fff}
+.ed-fields legend{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:#5a4a24;padding:0 5px}
+.chk{display:inline-flex;align-items:center;gap:6px;margin-right:14px;font-size:14px;font-weight:600}
+.ed-preview{margin-top:12px;font-size:13.5px;color:#3c3a35}
+.ed-preview strong{font-size:15px}
+.ed-actions{margin-top:12px;display:flex;gap:8px;align-items:center}
+.ed-actions button,.ed-confirm button{border:1px solid rgba(0,0,0,.25);background:#fff;border-radius:8px;padding:6px 15px;font-size:13.5px;font-weight:600}
+button.primary{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+button.danger{background:#c03520;color:#fff;border-color:#c03520}
+.ed-confirm{margin-top:12px;background:#fbeae7;border:1px solid rgba(192,53,32,.4);border-radius:10px;padding:12px 14px;font-size:13.5px}
+.ed-confirm p{margin-bottom:10px}
+.ed-error{color:#c03520;font-weight:700}
+/* staff */
+.a-addrow{display:flex;align-items:flex-end;gap:12px;background:#fff;border:1px solid rgba(0,0,0,.14);border-bottom:0;padding:12px 14px}
+.a-addrow label{display:flex;flex-direction:column;gap:3px;font-size:11.5px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:#5f5f5f}
+.a-addrow input,.a-addrow select{border:1px solid rgba(0,0,0,.25);border-radius:8px;padding:6px 9px;font-size:14px}
+.a-addrow input{width:200px}
+.a-addrow .hint{color:#9c9890;font-size:12.5px;margin-left:auto;max-width:34ch}
+.a-ordbtn{border:1px solid rgba(0,0,0,.2);background:#fff;border-radius:6px;width:24px;height:22px;font-size:11px;line-height:1;padding:0}
+.a-ordbtn:disabled{opacity:.3;cursor:default}
+.a-inactive td{color:#9c9890}
+.a-inactive td:first-child{color:#c9c5bc}
+.a-status-on{color:#2c6e49;font-weight:700;font-size:12.5px}
+.a-status-off{color:#9c9890;font-weight:700;font-size:12.5px}
+.a-link{border:0;background:none;color:#1a1a1a;text-decoration:underline;font-size:13px;padding:2px 4px}
+.a-link.danger-link{color:#c03520;background:none;border:0}
+.a-link:disabled{color:#c9c5bc;text-decoration:none;cursor:default}
+.a-renform{display:inline-flex;gap:6px}
+.a-renform input{border:1px solid rgba(0,0,0,.3);border-radius:6px;padding:2px 8px;width:140px}
+/* access */
+.a-accessgrid{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+.a-access{background:#fff;border:1px solid rgba(0,0,0,.14);padding:16px 18px}
+.a-access h4{font-size:15px;margin-bottom:10px;border-bottom:1px solid rgba(0,0,0,.09);padding-bottom:7px}
+.a-access .row{display:flex;align-items:center;gap:10px;padding:7px 0;font-size:13.5px;border-bottom:1px solid rgba(0,0,0,.05)}
+.a-access .row dt{font-weight:700;width:92px;flex:none}
+.a-access .row dd{color:#5f5f5f}
+.a-access .row button{margin-left:auto}
+.a-rotbtn{border:1px solid rgba(0,0,0,.25);background:#fff;border-radius:7px;padding:4px 12px;font-size:12.5px;font-weight:600}
+.a-signout{margin-top:12px;border:1px solid rgba(192,53,32,.5);color:#c03520;background:#fff;border-radius:7px;padding:5px 13px;font-size:12.5px;font-weight:700}
+.a-confirmbox{margin-top:12px;background:#fbeae7;border:1px solid rgba(192,53,32,.4);border-radius:10px;padding:12px 14px;font-size:13px}
+.a-confirmbox p{margin-bottom:9px}
+.a-confirmbox label{display:flex;align-items:center;gap:8px;font-weight:700;margin-bottom:9px}
+.a-confirmbox input{border:1px solid rgba(0,0,0,.3);border-radius:7px;padding:5px 9px;width:110px;text-transform:uppercase;letter-spacing:.08em;font-weight:700}
+.a-confirmbox button{border:1px solid rgba(0,0,0,.25);background:#fff;border-radius:7px;padding:5px 13px;font-size:12.5px;font-weight:600}
+.a-confirmbox button.danger:disabled{opacity:.4;cursor:default}
+.a-reveal{margin-top:12px;background:#1a1a1a;color:#fff;border-radius:10px;padding:14px 16px;font-size:13px}
+.a-reveal .secret{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:26px;letter-spacing:.35em;display:inline-block;margin:4px 0 6px}
+.a-reveal p{color:rgba(255,255,255,.75);margin-bottom:10px}
+.a-reveal p strong{color:#fff}
+.a-reveal button{border:1px solid rgba(255,255,255,.4);background:transparent;color:#fff;border-radius:7px;padding:5px 13px;font-size:12.5px;font-weight:600;margin-right:6px}
+.a-reveal .qr{margin:6px 0 10px}
+
+/* ============ Variant B — The Daybook ============ */
+.vB{background:#f5f1e8;padding-bottom:110px}
+.b-wrap{max-width:920px;margin:0 auto;padding:0 24px}
+.b-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:20px 0 6px}
+.b-chip{border:1px solid rgba(0,0,0,.14);background:#fff;border-radius:99px;padding:6px 16px;font-size:13.5px;font-weight:600;color:#5f5f5f}
+.b-chip[aria-pressed="true"]{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+.b-controls .b-export{margin-left:auto;border:1px solid rgba(0,0,0,.14);background:#fff;border-radius:99px;padding:6px 16px;font-size:13.5px;font-weight:600}
+.b-rangetotals{color:#5f5f5f;font-size:14px;margin:2px 4px 8px}
+.b-rangetotals strong{color:#1a1a1a}
+.b-day{margin:28px 0 34px}
+.b-dayhead{display:flex;justify-content:space-between;align-items:baseline;padding:0 6px 12px}
+.b-dayhead h4{font-size:18px;letter-spacing:-.01em}
+.b-dayhead p{color:#5f5f5f;font-size:14px}
+.b-dayhead p strong{color:#1a1a1a}
+.b-cards{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.b-card{background:#fff;border-radius:20px;padding:20px 22px;display:flex;flex-direction:column;gap:13px;border:1.5px solid transparent}
+.b-card.flagged{border-color:#e84d38}
+.b-flagbanner{background:#fbeae7;color:#c03520;border-radius:12px;padding:9px 13px;font-size:13px;font-weight:600}
+.b-cardhead{display:flex;justify-content:space-between;align-items:baseline;gap:10px}
+.b-rm{font-weight:700;font-size:15px}
+.b-meta{color:#9c9890;font-size:12.5px;text-align:right}
+.b-cash{display:flex;align-items:baseline;gap:8px}
+.b-cash strong{font-size:30px;letter-spacing:-.02em}
+.b-cash span{color:#5f5f5f;font-size:14px}
+.b-splitline{font-size:14.5px;color:#5f5f5f}
+.b-splitline .b-per{background:#f5f1e8;border-radius:99px;padding:3px 13px;font-weight:700;color:#1a1a1a;font-size:15px;white-space:nowrap}
+.b-chips{list-style:none;display:flex;gap:7px;flex-wrap:wrap}
+.b-chips li{background:#f5f1e8;border-radius:99px;padding:4px 14px;font-size:13px;font-weight:600}
+.b-cardfoot{display:flex;justify-content:space-between;align-items:center;gap:10px;border-top:1px solid rgba(0,0,0,.06);padding-top:12px;color:#9c9890;font-size:13px}
+.b-fix{background:none;border:1px solid rgba(0,0,0,.14);border-radius:99px;padding:5px 15px;font-size:13px;color:#5f5f5f;font-weight:600;flex:none}
+.b-empty{background:#fff;border-radius:20px;padding:30px;text-align:center;color:#9c9890;margin-top:20px}
+.b-h3{font-size:18px;margin:44px 0 4px;letter-spacing:-.01em}
+.b-sub{color:#9c9890;font-size:13.5px;margin-bottom:14px}
+/* staff */
+.b-staffgrid{display:flex;flex-direction:column;gap:10px}
+.b-addtile{background:#fbeae7;border:1.5px dashed rgba(232,77,56,.6);border-radius:20px;padding:16px;font-size:15px;font-weight:700;color:#c03520;text-align:left}
+.b-person{background:#fff;border-radius:20px;padding:13px 18px;display:flex;align-items:center;gap:14px}
+.b-person.inactive{opacity:.62}
+.b-ordnum{color:#9c9890;font-size:12.5px;font-weight:700;width:26px;flex:none;text-align:center}
+.b-ava{width:38px;height:38px;border-radius:50%;background:#f5f1e8;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:16px;flex:none}
+.b-pinfo{flex:1;min-width:0}
+.b-pinfo h4{font-size:15.5px}
+.b-pinfo p{color:#9c9890;font-size:13px}
+.b-porder{display:flex;flex-direction:column;gap:3px}
+.b-porder button{border:1px solid rgba(0,0,0,.12);background:#fff;border-radius:7px;width:26px;height:20px;font-size:10px;line-height:1;padding:0;color:#5f5f5f}
+.b-porder button:disabled{opacity:.3;cursor:default}
+.b-pacts{display:flex;gap:6px}
+.b-pacts button{border:1px solid rgba(0,0,0,.12);background:#fff;border-radius:99px;padding:4px 13px;font-size:12.5px;font-weight:600;color:#5f5f5f}
+.b-pacts button.danger-link{color:#c03520;border-color:rgba(192,53,32,.4)}
+.b-renform{display:flex;gap:6px}
+.b-renform input{border:1px solid rgba(0,0,0,.2);border-radius:9px;padding:4px 10px;width:150px}
+.b-renform button{border:0;background:#1a1a1a;color:#fff;border-radius:9px;padding:4px 12px;font-size:12.5px;font-weight:600}
+/* access */
+.b-accessgrid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.b-access{background:#fff;border-radius:20px;padding:20px 22px}
+.b-access h4{font-size:15.5px;margin-bottom:12px}
+.b-access .row{display:flex;align-items:center;gap:10px;padding:9px 0;border-top:1px solid rgba(0,0,0,.06);font-size:13.5px}
+.b-access .row dt{font-weight:700;width:88px;flex:none}
+.b-access .row dd{color:#9c9890}
+.b-access .row button{margin-left:auto;border:1px solid rgba(0,0,0,.14);background:#fff;border-radius:99px;padding:4px 13px;font-size:12.5px;font-weight:600;color:#5f5f5f}
+.b-signoutrow{margin-top:12px}
+.b-signoutrow button{border:1px solid rgba(192,53,32,.4);color:#c03520;background:#fff;border-radius:99px;padding:5px 14px;font-size:12.5px;font-weight:700}
+/* drawer + dialog */
+.b-scrim{position:fixed;inset:0;background:rgba(26,26,26,.38);z-index:90}
+.b-drawer{position:fixed;top:0;right:0;bottom:0;width:430px;background:#fff;z-index:91;padding:28px;overflow:auto;border-left:1px solid rgba(0,0,0,.08)}
+.b-drawer h4{font-size:18px;margin-bottom:2px}
+.b-drawer .b-dsub{color:#9c9890;font-size:13px;margin-bottom:20px}
+.b-field{display:flex;flex-direction:column;gap:5px;margin-bottom:16px}
+.b-field>span{font-size:13px;font-weight:700}
+.b-field>span small{font-weight:400;color:#9c9890}
+.b-field input[type="text"]{border:1px solid rgba(0,0,0,.18);border-radius:14px;padding:10px 13px;font-size:16px;background:#fff}
+.b-field select{border:1px solid rgba(0,0,0,.18);border-radius:14px;padding:10px 13px;font-size:15px;background:#fff}
+.b-people{display:flex;flex-wrap:wrap;gap:8px}
+.b-people label{border:1px solid rgba(0,0,0,.14);border-radius:99px;padding:6px 14px;font-size:13.5px;font-weight:600;display:inline-flex;gap:7px;align-items:center;background:#fff}
+.b-people label:has(input:checked){background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+.b-dpreview{background:#f5f1e8;border-radius:14px;padding:12px 15px;font-size:14px;margin-bottom:18px}
+.b-dpreview strong{font-size:16px}
+.b-dacts{display:flex;gap:10px;justify-content:flex-end}
+.b-dacts button{border:1px solid rgba(0,0,0,.16);background:#fff;border-radius:99px;padding:9px 20px;font-size:14.5px;font-weight:600}
+.b-dacts button.primary{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+.b-dacts button.danger{background:#c03520;color:#fff;border-color:#c03520}
+.b-delta{width:100%;border-collapse:collapse;font-size:14px;margin-bottom:18px}
+.b-delta th,.b-delta td{padding:7px 4px;border-bottom:1px solid rgba(0,0,0,.07);text-align:left}
+.b-delta thead th{font-size:11.5px;text-transform:uppercase;letter-spacing:.05em;color:#9c9890}
+.b-delta .r{text-align:right}
+.b-delta .chg{font-weight:700}
+.b-delta .removed{color:#9c9890;text-decoration:line-through}
+.b-consequence{background:#fbeae7;border-radius:14px;padding:12px 15px;font-size:13.5px;color:#c03520;font-weight:600;margin-bottom:18px}
+.b-close{position:absolute;top:18px;right:18px;border:0;background:#f5f1e8;border-radius:50%;width:32px;height:32px;font-size:15px;color:#5f5f5f}
+dialog.b-dialog{border:0;border-radius:20px;padding:28px;max-width:460px;width:92%}
+dialog.b-dialog::backdrop{background:rgba(26,26,26,.42)}
+.b-dialog h4{font-size:18px;margin-bottom:12px}
+.b-conseq{list-style:none;margin-bottom:16px}
+.b-conseq li{padding:8px 0 8px 24px;border-bottom:1px solid rgba(0,0,0,.06);font-size:14px;color:#3c3a35;position:relative}
+.b-conseq li::before{content:"→";position:absolute;left:2px;color:#e84d38;font-weight:700}
+.b-ack{display:flex;gap:10px;align-items:flex-start;font-size:14px;font-weight:600;margin-bottom:18px;background:#f5f1e8;padding:12px 14px;border-radius:14px}
+.b-ack input{margin-top:3px;width:16px;height:16px}
+.b-pin{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:44px;letter-spacing:.32em;text-align:center;background:#f5f1e8;border-radius:14px;padding:20px 10px 20px 20px;margin-bottom:14px}
+.b-once{background:#fbeae7;color:#c03520;border-radius:14px;padding:11px 14px;font-size:13.5px;font-weight:600;margin-bottom:18px}
+.b-qrwrap{display:flex;gap:18px;align-items:center;margin-bottom:14px}
+.b-qrwrap .qr{width:150px;height:150px}
+.b-qrwrap p{font-size:13.5px;color:#5f5f5f}
+
+/* ============ Variant C — The Morning Check ============ */
+.vC{background:#fdfcfa;padding-bottom:110px}
+.c-wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+.c-top{display:flex;align-items:center;justify-content:space-between;gap:16px;margin:22px 0 20px;border-bottom:1px solid rgba(0,0,0,.09);padding-bottom:18px}
+.c-top h3{font-size:23px;letter-spacing:-.015em}
+.c-top .c-date{color:#9c9890;font-weight:400}
+.c-actions{display:flex;gap:9px}
+.c-actions .c-add{background:#e84d38;color:#fff;border:0;border-radius:10px;padding:9px 18px;font-size:14px;font-weight:700}
+.c-actions .c-export{background:#fff;border:1px solid rgba(0,0,0,.16);border-radius:10px;padding:9px 16px;font-size:14px;font-weight:600;color:#5f5f5f}
+.c-label{font-size:12px;text-transform:uppercase;letter-spacing:.1em;color:#9c9890;font-weight:700;margin:26px 0 10px}
+.c-reveal{background:#1a1a1a;color:#fff;border-radius:14px;padding:18px 20px;margin-bottom:12px;display:flex;align-items:center;gap:22px}
+.c-reveal h4{font-size:15px;margin-bottom:2px}
+.c-reveal .c-secret{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:30px;letter-spacing:.3em}
+.c-reveal p{color:rgba(255,255,255,.72);font-size:13px;max-width:44ch}
+.c-reveal .qr{width:96px;height:96px;flex:none}
+.c-reveal button{margin-left:auto;border:1px solid rgba(255,255,255,.45);background:transparent;color:#fff;border-radius:9px;padding:7px 15px;font-size:13px;font-weight:600;flex:none}
+.c-flag{background:#fbeae7;border:1px solid rgba(232,77,56,.55);border-radius:14px;padding:17px 20px;margin-bottom:10px}
+.c-flag h4{font-size:15.5px;color:#c03520;margin-bottom:5px}
+.c-flag p{font-size:14px;color:#3c3a35;max-width:92ch;margin-bottom:12px}
+.c-flag .c-flagacts{display:flex;gap:9px}
+.c-flag button{border-radius:9px;padding:7px 16px;font-size:13.5px;font-weight:700;border:1px solid rgba(0,0,0,.16);background:#fff}
+.c-flag button.primary{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+.c-allclear{background:#fff;border:1px dashed rgba(0,0,0,.16);border-radius:14px;padding:16px 20px;color:#9c9890;font-size:14px;margin-bottom:10px}
+.c-tiles{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+.c-tile{background:#fff;border:1px solid rgba(0,0,0,.09);border-radius:14px;padding:15px 16px}
+.c-tile h4{font-size:13px;color:#5f5f5f;margin-bottom:8px;font-weight:700}
+.c-cashline{font-size:15px;margin-bottom:3px}
+.c-cashline strong{font-size:19px;letter-spacing:-.01em}
+.c-perline{font-size:13.5px;color:#3c3a35;margin-bottom:7px}
+.c-perline strong{color:#1a1a1a}
+.c-cardline{font-size:12.5px;color:#9c9890;border-top:1px solid rgba(0,0,0,.06);padding-top:7px}
+.c-tilemeta{font-size:11.5px;color:#c9c5bc;margin-top:5px}
+.c-tile.ghost{border-style:dashed;background:transparent;color:#9c9890;display:flex;align-items:center;justify-content:center;text-align:center;font-size:13px}
+.c-weekbar{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+.c-weekbar .seg{background:#fff}
+.c-weekbar select{border:1px solid rgba(0,0,0,.18);border-radius:9px;padding:5px 9px;background:#fff;font-size:13px}
+.c-dayrow{border:1px solid rgba(0,0,0,.09);border-radius:12px;margin-bottom:8px;background:#fff;overflow:hidden}
+.c-daybtn{width:100%;display:flex;align-items:center;gap:14px;padding:13px 17px;border:0;background:none;font-weight:600;font-size:14.5px;text-align:left}
+.c-daybtn .c-dayname{width:110px;flex:none}
+.c-daybtn .c-daynums{color:#5f5f5f;font-weight:400;font-size:13.5px}
+.c-daybtn .c-daynums strong{color:#1a1a1a;font-weight:700}
+.c-dayflag{background:#c03520;color:#fff;border-radius:5px;font-size:11px;font-weight:700;padding:1px 8px}
+.c-caret{margin-left:auto;color:#9c9890;font-size:12px}
+.c-daybody{border-top:1px solid rgba(0,0,0,.07);padding:4px 17px 10px}
+.c-shift{display:flex;align-items:center;gap:14px;padding:9px 0;border-bottom:1px solid rgba(0,0,0,.05);font-size:14px}
+.c-shift:last-child{border-bottom:0}
+.c-shift .c-sname{width:150px;flex:none;font-weight:600}
+.c-shift .c-scash{width:230px;flex:none}
+.c-shift .c-scash strong{font-variant-numeric:tabular-nums}
+.c-shift .c-speople{color:#5f5f5f;flex:1;font-size:13px}
+.c-shift .c-scard{color:#9c9890;font-size:13px;width:150px;flex:none;text-align:right}
+.c-shift .c-sfix{border:0;background:none;color:#5f5f5f;text-decoration:underline;font-size:13px}
+.c-shift.flagged{background:#fbeae7;border-radius:8px;padding-left:8px;padding-right:8px;margin:0 -8px}
+.c-weektotals{color:#5f5f5f;font-size:13.5px;padding:8px 4px}
+.c-weektotals strong{color:#1a1a1a}
+details.c-panel{border:1px solid rgba(0,0,0,.09);border-radius:12px;background:#fff;margin-top:12px}
+.c-panel summary{padding:15px 17px;font-weight:700;cursor:pointer;font-size:14.5px;list-style:none;display:flex;align-items:baseline;gap:14px}
+.c-panel summary::-webkit-details-marker{display:none}
+.c-panel summary .c-sum{color:#9c9890;font-weight:400;font-size:13.5px;flex:1}
+.c-panel summary .c-caret{margin-left:0}
+.c-panel[open] summary{border-bottom:1px solid rgba(0,0,0,.07)}
+.c-panelbody{padding:8px 17px 16px}
+.c-staffrow{display:flex;align-items:center;gap:12px;padding:9px 0;border-bottom:1px solid rgba(0,0,0,.05);font-size:14px}
+.c-staffrow:last-child{border-bottom:0}
+.c-staffrow .c-stord{color:#9c9890;width:24px;flex:none;font-size:12.5px;font-weight:700;text-align:center}
+.c-staffrow .c-stname{width:170px;flex:none;font-weight:600}
+.c-staffrow .c-stworks{color:#5f5f5f;flex:1;font-size:13px}
+.c-staffrow .c-stacts{display:flex;gap:5px;align-items:center}
+.c-staffrow .c-stacts button{border:1px solid rgba(0,0,0,.14);background:#fff;border-radius:7px;padding:3px 10px;font-size:12px;font-weight:600;color:#5f5f5f}
+.c-staffrow .c-stacts button.danger-link{color:#c03520;border-color:rgba(192,53,32,.4)}
+.c-staffrow.inactive{color:#9c9890}
+.c-staffrow.inactive .c-stname{font-weight:400}
+.c-unlock{display:flex;align-items:center;gap:10px;font-size:13.5px;font-weight:700;padding:12px 0;color:#5f5f5f}
+.c-unlock input{width:16px;height:16px}
+.c-accessgrid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.c-access{border:1px solid rgba(0,0,0,.08);border-radius:10px;padding:13px 15px}
+.c-access h5{font-size:14px;margin-bottom:8px}
+.c-access .row{display:flex;align-items:center;gap:8px;font-size:13px;padding:6px 0;border-top:1px solid rgba(0,0,0,.05)}
+.c-access .row dt{font-weight:700;width:84px;flex:none}
+.c-access .row dd{color:#9c9890}
+.c-access .row button{margin-left:auto;border:1px solid rgba(0,0,0,.16);background:#fff;border-radius:7px;padding:3px 11px;font-size:12px;font-weight:600}
+.c-access .c-signout{margin-top:9px;border:1px solid rgba(192,53,32,.4);color:#c03520;background:#fff;border-radius:7px;padding:4px 12px;font-size:12px;font-weight:700}
+.c-access button:disabled{opacity:.4;cursor:default}
+dialog.c-dialog{border:0;border-radius:16px;padding:26px;max-width:480px;width:92%;border:1px solid rgba(0,0,0,.1)}
+dialog.c-dialog::backdrop{background:rgba(26,26,26,.42)}
+.c-dialog h4{font-size:17px;margin-bottom:14px}
+.c-dialog .b-field input[type="text"],.c-dialog .b-field select{border-radius:10px}
+.c-consequence{background:#fbeae7;border-radius:10px;padding:11px 14px;font-size:13.5px;margin-bottom:16px}
+.c-consequence strong{color:#c03520}
+.c-dlgacts{display:flex;gap:9px;justify-content:flex-end}
+.c-dlgacts button{border:1px solid rgba(0,0,0,.16);background:#fff;border-radius:10px;padding:8px 17px;font-size:14px;font-weight:600}
+.c-dlgacts button.primary{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+.c-dlgacts button.danger{background:#c03520;color:#fff;border-color:#c03520}
+
+@media (max-width:1120px){
+ .vA .wrap,.thesis,.c-wrap{max-width:100%}
+ .c-tiles{grid-template-columns:repeat(2,1fr)}
+}
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <p class="brand">Babytuna <span>· tips — manager dashboard, design comparison</span></p>
+  <div class="tabs" role="tablist" aria-label="Design variants">
+    <button class="tab" id="tabA" role="tab" aria-selected="true" aria-controls="vA" data-variant="A">1 · The Ledger</button>
+    <button class="tab" id="tabB" role="tab" aria-selected="false" aria-controls="vB" data-variant="B">2 · The Daybook</button>
+    <button class="tab" id="tabC" role="tab" aria-selected="false" aria-controls="vC" data-variant="C">3 · The Morning Check</button>
+  </div>
+  <p class="topnote">static mockup · sample week of Aug 3–9, 2026</p>
+</header>
+
+<!-- ================= VARIANT A : THE LEDGER ================= -->
+<section id="vA" class="vA" role="tabpanel" aria-labelledby="tabA">
+  <div class="thesis"><div class="thesis-inner">
+    <h2>Variant 1 — The Ledger</h2>
+    <p>Optimizes for scan speed and cross-day comparison: every record, subtotal and control on one dense bookkeeping surface, with corrections made inline without ever leaving the table. It deliberately trades the phone app's warmth for column-and-hairline austerity — a tool for an owner who reads numbers, not cards.</p>
+  </div></div>
+  <div class="wrap">
+
+    <div class="a-bar">
+      <label>Range
+        <select id="aRange" aria-label="Date range">
+          <option value="all">Aug 3 – Aug 9 · this week</option>
+          <option value="weekend">Aug 8 – Aug 9 · weekend</option>
+          <option value="fri">Aug 7 · Friday only</option>
+        </select>
+      </label>
+      <div class="seg" role="group" aria-label="Restaurant filter" id="aRestSeg">
+        <button data-act="a-rest" data-v="all" aria-pressed="true">Both</button>
+        <button data-act="a-rest" data-v="sushi" aria-pressed="false">Sushi</button>
+        <button data-act="a-rest" data-v="poki" aria-pressed="false">Poki &amp; Pho</button>
+      </div>
+      <button class="a-export" data-act="a-export">Export CSV</button>
+      <div class="a-totals" id="aTotals"></div>
+    </div>
+
+    <section class="a-section" aria-labelledby="aRecH">
+      <h3 id="aRecH">Recorded tips</h3>
+      <table class="a-table" id="aTable">
+        <thead>
+          <tr>
+            <th rowspan="2" scope="col">Business date</th>
+            <th rowspan="2" scope="col">Restaurant</th>
+            <th rowspan="2" scope="col">Meal</th>
+            <th colspan="3" scope="colgroup" class="grp grp-split">Split pool — cash, handed out nightly</th>
+            <th scope="colgroup" class="grp grp-card">Logged only</th>
+            <th rowspan="2" scope="col">Entered by</th>
+            <th rowspan="2" scope="col"><span class="sr">Actions</span></th>
+          </tr>
+          <tr>
+            <th scope="col" class="r sub-split">Cash</th>
+            <th scope="col" class="sub-split">Split between</th>
+            <th scope="col" class="r sub-split">Per person</th>
+            <th scope="col" class="r sub-card">Card → payroll</th>
+          </tr>
+        </thead>
+        <tbody id="aTbody"></tbody>
+      </table>
+      <p class="rounding-note">Per-person share = cash ÷ people, rounded to the nearest cent with exact half-cents rounding up. Rounding remainders stay in the drawer, so shares don't always sum exactly to the cash pool. Card tips are logged for payroll and paid separately — they are never part of the split.</p>
+    </section>
+
+    <section class="a-section" aria-labelledby="aStaffH">
+      <h3 id="aStaffH">Staff &amp; phone-picker order</h3>
+      <form id="aAddForm" class="a-addrow">
+        <label>New hire's name <input name="name" required placeholder="e.g. Dana" autocomplete="off"></label>
+        <label>Works at
+          <select name="works">
+            <option value="sushi">Sushi</option>
+            <option value="poki">Poki &amp; Pho</option>
+            <option value="both">Both</option>
+          </select>
+        </label>
+        <button class="primary" style="border-radius:8px;padding:7px 16px;font-size:13.5px;border:0">Add to picker</button>
+        <span class="hint">New people appear on the phone picker immediately, last in the order.</span>
+      </form>
+      <table class="a-table" aria-describedby="aStaffNote">
+        <thead>
+          <tr>
+            <th scope="col">Picker order</th>
+            <th scope="col">Name</th>
+            <th scope="col">Works at</th>
+            <th scope="col">Status</th>
+            <th scope="col" class="r">Shifts on record</th>
+            <th scope="col"><span class="sr">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody id="aStaffBody"></tbody>
+      </table>
+      <p class="rounding-note" id="aStaffNote">Order is what closers tap through on the phone every night. People with recorded shifts can only be deactivated — their history stays; Delete exists only for someone added by mistake.</p>
+    </section>
+
+    <section class="a-section" aria-labelledby="aAccH">
+      <h3 id="aAccH">Device access</h3>
+      <div class="a-accessgrid" id="aAccess"></div>
+      <p class="rounding-note">Rotated secrets are shown exactly once — only a hash is stored, so they can't be re-displayed later, only rotated again.</p>
+    </section>
+
+  </div>
+</section>
+
+<!-- ================= VARIANT B : THE DAYBOOK ================= -->
+<section id="vB" class="vB" role="tabpanel" aria-labelledby="tabB" hidden>
+  <div class="thesis"><div class="thesis-inner">
+    <h2>Variant 2 — The Daybook</h2>
+    <p>Reads the way the money actually moves: one card per shift, the cash pool and each person's share up front, and card tips typographically demoted to a logged footnote. It carries the phone app's warm, flat language onto the laptop, and trades density — more scrolling — for numbers the owner can trust at a glance.</p>
+  </div></div>
+  <div class="b-wrap">
+
+    <div class="b-controls" role="group" aria-label="Filters">
+      <button class="b-chip" data-act="b-rest" data-v="all" aria-pressed="true">Both restaurants</button>
+      <button class="b-chip" data-act="b-rest" data-v="sushi" aria-pressed="false">Sushi</button>
+      <button class="b-chip" data-act="b-rest" data-v="poki" aria-pressed="false">Poki &amp; Pho</button>
+      <span aria-hidden="true" style="color:#c9c5bc">·</span>
+      <button class="b-chip" data-act="b-range" data-v="all" aria-pressed="true">This week</button>
+      <button class="b-chip" data-act="b-range" data-v="weekend" aria-pressed="false">Weekend</button>
+      <button class="b-chip" data-act="b-range" data-v="custom" aria-pressed="false">Custom…</button>
+      <button class="b-export" data-act="b-export">Export CSV</button>
+    </div>
+    <p class="b-rangetotals" id="bTotals" aria-live="polite"></p>
+
+    <div id="bDays"></div>
+
+    <h3 class="b-h3">Staff</h3>
+    <p class="b-sub">Top-to-bottom is the order closers see on the phone picker every night.</p>
+    <div class="b-staffgrid" id="bStaff"></div>
+
+    <h3 class="b-h3">Device access</h3>
+    <p class="b-sub">Each restaurant signs its phone in with the QR sticker by the register plus a PIN. Rotations are rare and consequential — everything here asks twice.</p>
+    <div class="b-accessgrid" id="bAccess"></div>
+    <p class="rounding-note">A rotated QR or PIN is shown exactly once — only a hash is stored, so it can't be re-displayed, only rotated again.</p>
+
+  </div>
+
+  <div class="b-scrim" id="bScrim" hidden></div>
+  <div class="b-drawer" id="bDrawer" role="dialog" aria-modal="true" aria-labelledby="bDrawerTitle" hidden></div>
+  <dialog class="b-dialog" id="bDialog"></dialog>
+</section>
+
+<!-- ================= VARIANT C : THE MORNING CHECK ================= -->
+<section id="vC" class="vC" role="tabpanel" aria-labelledby="tabC" hidden>
+  <div class="thesis"><div class="thesis-inner">
+    <h2>Variant 3 — The Morning Check</h2>
+    <p>Built for a 90-second check-in between five other things: exceptions and last night's numbers come first, the rest of the week folds into day rows, and staff and device admin stay collapsed until summoned. It trades always-visible completeness for triage speed — on a quiet day the owner reads two lines and closes the tab.</p>
+  </div></div>
+  <div class="c-wrap">
+
+    <header class="c-top">
+      <h3>Morning check <span class="c-date">· Monday, Aug 10</span></h3>
+      <div class="c-actions">
+        <button class="c-add" data-act="c-add-open">＋ New hire</button>
+        <button class="c-export" data-act="c-export">Export week</button>
+      </div>
+    </header>
+
+    <div id="cReveal"></div>
+
+    <h4 class="c-label" id="cAttnH">Needs a look</h4>
+    <div id="cAttn" aria-labelledby="cAttnH"></div>
+
+    <h4 class="c-label">Last night — Sunday, Aug 9</h4>
+    <div class="c-tiles" id="cNight"></div>
+
+    <h4 class="c-label">This week</h4>
+    <div class="c-weekbar">
+      <div class="seg" role="group" aria-label="Restaurant filter" id="cRestSeg">
+        <button data-act="c-rest" data-v="all" aria-pressed="true">Both</button>
+        <button data-act="c-rest" data-v="sushi" aria-pressed="false">Sushi</button>
+        <button data-act="c-rest" data-v="poki" aria-pressed="false">Poki &amp; Pho</button>
+      </div>
+      <select id="cWeekSel" aria-label="Week">
+        <option value="this">Week of Aug 3 – 9</option>
+        <option value="last">Week of Jul 27 – Aug 2</option>
+      </select>
+    </div>
+    <div id="cWeek"></div>
+
+    <details class="c-panel" id="cStaffPanel">
+      <summary>Staff <span class="c-sum" id="cStaffSum"></span><span class="c-caret" aria-hidden="true">▾</span></summary>
+      <div class="c-panelbody" id="cStaffBody"></div>
+    </details>
+
+    <details class="c-panel" id="cAccessPanel">
+      <summary>Device access <span class="c-sum" id="cAccessSum"></span><span class="c-caret" aria-hidden="true">▾</span></summary>
+      <div class="c-panelbody">
+        <label class="c-unlock"><input type="checkbox" id="cUnlock"> Show rotation controls — these break signed-in phones and printed stickers</label>
+        <div class="c-accessgrid" id="cAccessBody"></div>
+        <p class="rounding-note">A new QR or PIN is shown once, pinned to the top of this page until you dismiss it. Only a hash is stored.</p>
+      </div>
+    </details>
+
+  </div>
+  <dialog class="c-dialog" id="cDialog"></dialog>
+</section>
+
+<div id="toast" role="status" aria-live="polite"></div>
+
+<script>
+(function(){
+'use strict';
+
+/* ---------------- shared data ---------------- */
+var RESTS = { sushi:'Sushi', poki:'Poki & Pho' };
+var WORKS = { sushi:'Sushi', poki:'Poki & Pho', both:'Both restaurants' };
+
+var BASE_RECORDS = [
+ {id:'r1', date:'Sun Aug 9', d:9, rest:'sushi', meal:'Dinner', cash:41200,  card:68850, people:['Maria','Jose','Ken'], by:'Maria', mode:'voice', flag:false},
+ {id:'r2', date:'Sun Aug 9', d:9, rest:'sushi', meal:'Lunch',  cash:9625,   card:21000, people:['Maria','Ken'],       by:'Ken',   mode:'typed', flag:false},
+ {id:'r3', date:'Sun Aug 9', d:9, rest:'poki',  meal:'Dinner', cash:18800,  card:40275, people:['Lena','Tom'],        by:'Lena',  mode:'typed', flag:false},
+ {id:'r4', date:'Sat Aug 8', d:8, rest:'sushi', meal:'Dinner', cash:36650,  card:59400, people:['Jose','Ken','Rey'],  by:'Ken',   mode:'typed', flag:false},
+ {id:'r5', date:'Sat Aug 8', d:8, rest:'poki',  meal:'Dinner', cash:20575,  card:38800, people:['Lena','Tom','Rey'],  by:'Rey',   mode:'voice', flag:false},
+ {id:'r6', date:'Sat Aug 8', d:8, rest:'poki',  meal:'Lunch',  cash:7400,   card:16525, people:['Lena'],              by:'Lena',  mode:'typed', flag:false},
+ {id:'r7', date:'Fri Aug 7', d:7, rest:'sushi', meal:'Dinner', cash:310000, card:61000, people:['Maria','Jose'],      by:'Jose',  mode:'voice', flag:true},
+ {id:'r8', date:'Fri Aug 7', d:7, rest:'sushi', meal:'Lunch',  cash:8850,   card:17400, people:['Maria'],             by:'Maria', mode:'typed', flag:false},
+ {id:'r9', date:'Fri Aug 7', d:7, rest:'poki',  meal:'Dinner', cash:19725,  card:35150, people:['Tom','Rey'],         by:'Tom',   mode:'typed', flag:false},
+ {id:'r10',date:'Thu Aug 6', d:6, rest:'sushi', meal:'Dinner', cash:34400,  card:56125, people:['Maria','Jose','Ken'],by:'Maria', mode:'typed', flag:false}
+];
+var BASE_STAFF = [
+ {id:'maria', name:'Maria', works:'sushi', active:true,  shifts:5},
+ {id:'jose',  name:'Jose',  works:'sushi', active:true,  shifts:4},
+ {id:'ken',   name:'Ken',   works:'both',  active:true,  shifts:4},
+ {id:'rey',   name:'Rey',   works:'both',  active:true,  shifts:3},
+ {id:'lena',  name:'Lena',  works:'poki',  active:true,  shifts:3},
+ {id:'tom',   name:'Tom',   works:'poki',  active:true,  shifts:3},
+ {id:'aiko',  name:'Aiko',  works:'sushi', active:false, shifts:112}
+];
+function freshState(){
+  return {
+    records: BASE_RECORDS.map(function(r){ var c={}; for(var k in r) c[k]=r[k]; c.people=r.people.slice(); return c; }),
+    staff:   BASE_STAFF.map(function(s){ var c={}; for(var k in s) c[k]=s[k]; return c; }),
+    access:  { sushi:{qr:'Aug 8, 2026', pin:'Aug 8, 2026'}, poki:{qr:null, pin:'Aug 8, 2026'} },
+    restFilter:'all'
+  };
+}
+
+/* ---------------- shared utils ---------------- */
+function $(sel,el){ return (el||document).querySelector(sel); }
+function $all(sel,el){ return Array.prototype.slice.call((el||document).querySelectorAll(sel)); }
+function esc(s){ return String(s).replace(/[&<>"']/g,function(m){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m];}); }
+function money(c){ return '$'+(c/100).toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}); }
+function perShare(r){ return Math.round(r.cash/r.people.length); }
+function parseMoney(v){ var n=parseFloat(String(v).replace(/[$,\s]/g,'')); return (isFinite(n)&&n>=0)?Math.round(n*100):null; }
+function sum(arr,f){ return arr.reduce(function(t,x){return t+f(x);},0); }
+function groupByDay(recs){
+  var days=[]; recs.forEach(function(r){ if(days.indexOf(r.date)<0) days.push(r.date); });
+  return days.map(function(d){ return {date:d, recs:recs.filter(function(r){return r.date===d;})}; });
+}
+var toastT;
+function toast(msg){
+  var t=$('#toast'); t.textContent=msg; t.classList.add('on');
+  clearTimeout(toastT); toastT=setTimeout(function(){t.classList.remove('on');},3200);
+}
+function newPin(){ return String(Math.floor(1000+Math.random()*9000)); }
+function qrSVG(seed){
+  var s=(seed>>>0)||1;
+  function rnd(){ s=(Math.imul(s,1664525)+1013904223)>>>0; return s/4294967296; }
+  var cells='';
+  for(var y=0;y<21;y++)for(var x=0;x<21;x++){
+    var inF=(x<8&&y<8)||(x>=13&&y<8)||(x<8&&y>=13);
+    if(!inF&&rnd()<0.45) cells+='<rect x="'+x+'" y="'+y+'" width="1" height="1"/>';
+  }
+  function finder(x,y){ return '<rect x="'+x+'" y="'+y+'" width="7" height="7"/><rect x="'+(x+1)+'" y="'+(y+1)+'" width="5" height="5" fill="#fff"/><rect x="'+(x+2)+'" y="'+(y+2)+'" width="3" height="3"/>'; }
+  return '<svg class="qr" viewBox="-1.5 -1.5 24 24" role="img" aria-label="Preview of the new QR sticker" xmlns="http://www.w3.org/2000/svg"><rect x="-1.5" y="-1.5" width="24" height="24" fill="#fff"/><g fill="#1a1a1a">'+cells+finder(0,0)+finder(14,0)+finder(0,14)+'</g></svg>';
+}
+function copyText(txt){
+  if(navigator.clipboard&&navigator.clipboard.writeText){
+    navigator.clipboard.writeText(txt).then(function(){toast('Copied.');},function(){toast('Copy unavailable here — write it down.');});
+  } else toast('Copy unavailable here — write it down.');
+}
+function downloadCSV(recs,label){
+  var rows=['Business date,Restaurant,Meal,Cash (split pool),Card (logged only),People on split,Names,Per-person share,Flagged,Entered by,Entry method'];
+  recs.forEach(function(r){
+    rows.push([r.date,RESTS[r.rest],r.meal,(r.cash/100).toFixed(2),(r.card/100).toFixed(2),r.people.length,'"'+r.people.join('; ')+'"',(perShare(r)/100).toFixed(2),r.flag?'yes':'no',r.by,r.mode].join(','));
+  });
+  var blob=new Blob([rows.join('\n')],{type:'text/csv'});
+  var a=document.createElement('a'); a.href=URL.createObjectURL(blob);
+  a.download='babytuna-tips-'+label+'.csv'; document.body.appendChild(a); a.click(); a.remove();
+  toast('Exported '+recs.length+' record'+(recs.length===1?'':'s')+' to CSV.');
+}
+function applyFix(st,id,next){
+  var r=st.records.find(function(x){return x.id===id;});
+  r.cash=next.cash; r.card=next.card; r.people=next.people.slice(); r.flag=false;
+  return r;
+}
+function eligibleNames(st,rec){
+  var names=st.staff.filter(function(s){return s.active&&(s.works===rec.rest||s.works==='both');}).map(function(s){return s.name;});
+  rec.people.forEach(function(n){ if(names.indexOf(n)<0) names.push(n); });
+  return names;
+}
+function moveStaff(st,id,dir){
+  var i=st.staff.findIndex(function(s){return s.id===id;});
+  var j=i+dir; if(j<0||j>=st.staff.length) return;
+  var tmp=st.staff[i]; st.staff[i]=st.staff[j]; st.staff[j]=tmp;
+}
+function deactivate(st,id){
+  var i=st.staff.findIndex(function(s){return s.id===id;});
+  var s=st.staff.splice(i,1)[0]; s.active=false; st.staff.push(s);
+}
+function reactivate(st,id){
+  var i=st.staff.findIndex(function(s){return s.id===id;});
+  var s=st.staff.splice(i,1)[0]; s.active=true;
+  var firstInactive=st.staff.findIndex(function(x){return !x.active;});
+  if(firstInactive<0) st.staff.push(s); else st.staff.splice(firstInactive,0,s);
+}
+function deleteStaff(st,id){
+  var i=st.staff.findIndex(function(s){return s.id===id;});
+  st.staff.splice(i,1);
+}
+var hireSeq=1;
+function addStaff(st,name,works){
+  st.staff.splice(st.staff.filter(function(s){return s.active;}).length,0,
+    {id:'new'+(hireSeq++), name:name, works:works, active:true, shifts:0});
+}
+function activeStaff(st){ return st.staff.filter(function(s){return s.active;}); }
+
+/* ---------------- variant switching ---------------- */
+var cur='A', scrolls={A:0,B:0,C:0};
+$all('.tab').forEach(function(t){
+  t.addEventListener('click',function(){
+    var k=t.dataset.variant; if(k===cur) return;
+    scrolls[cur]=window.scrollY;
+    $('#v'+cur).hidden=true; $('#v'+k).hidden=false;
+    $all('.tab').forEach(function(x){ x.setAttribute('aria-selected', x.dataset.variant===k ? 'true':'false'); });
+    cur=k; window.scrollTo(0,scrolls[k]||0);
+  });
+});
+
+/* ================================================================
+   VARIANT A — THE LEDGER
+================================================================ */
+var stA=freshState();
+stA.range='all'; stA.editing=null; stA.pending=null; stA.renaming=null;
+stA.rotConfirm=null;   /* {rest,kind} */
+stA.reveal=null;       /* {rest,kind,secret} */
+
+function aVisible(){
+  return stA.records.filter(function(r){
+    if(stA.restFilter!=='all'&&r.rest!==stA.restFilter) return false;
+    if(stA.range==='weekend'&&r.d<8) return false;
+    if(stA.range==='fri'&&r.d!==7) return false;
+    return true;
+  });
+}
+function aRenderTotals(){
+  var recs=aVisible();
+  var flags=recs.filter(function(r){return r.flag;}).length;
+  $('#aTotals').innerHTML=
+    (flags?'<button class="a-flagcount" data-act="a-jumpflag">⚑ '+flags+' flagged</button>':'')+
+    '<span>Cash pool <strong class="num">'+money(sum(recs,function(r){return r.cash;}))+'</strong></span>'+
+    '<span>Card logged <strong class="num">'+money(sum(recs,function(r){return r.card;}))+'</strong></span>'+
+    '<span>'+recs.length+' records</span>';
+}
+function aEdPreview(cashC,n){
+  if(n===0) return '<span class="ed-error">Select at least one person to split between.</span>';
+  if(cashC===null) return '<span class="ed-error">Cash amount doesn’t parse.</span>';
+  return 'New per-person share: <strong class="num">'+money(Math.round(cashC/n))+'</strong> each — cash ÷ '+n+'. Card is logged only and stays out of this number.';
+}
+function aEditorRow(r){
+  var names=eligibleNames(stA,r);
+  return '<tr class="a-edrow"><td colspan="9">'+
+    '<form class="a-edform" data-id="'+r.id+'">'+
+      '<div class="ed-fields">'+
+        '<label>Cash pool — split ($)<input type="text" class="num" name="cash" inputmode="decimal" value="'+(r.cash/100).toFixed(2)+'"></label>'+
+        '<label class="ed-card">Card — logged only ($)<input type="text" class="num" name="card" inputmode="decimal" value="'+(r.card/100).toFixed(2)+'"></label>'+
+        '<fieldset><legend>Split between</legend>'+names.map(function(n){
+          return '<label class="chk"><input type="checkbox" name="p" value="'+esc(n)+'"'+(r.people.indexOf(n)>=0?' checked':'')+'>'+esc(n)+'</label>';
+        }).join('')+'</fieldset>'+
+      '</div>'+
+      '<p class="ed-preview" data-role="preview">'+aEdPreview(r.cash,r.people.length)+'</p>'+
+      '<div class="ed-actions" data-role="actions">'+
+        '<button type="button" data-act="a-cancel">Cancel</button>'+
+        '<button type="submit" class="primary">Save correction…</button>'+
+      '</div>'+
+    '</form>'+
+  '</td></tr>';
+}
+function aRenderTable(){
+  var recs=aVisible(), days=groupByDay(recs), html='';
+  days.forEach(function(g){
+    g.recs.forEach(function(r){
+      var per=perShare(r);
+      html+='<tr'+(r.flag?' class="a-flagrow" id="aFlagRow"':'')+'>'+
+        '<td>'+r.date+'</td><td>'+RESTS[r.rest]+'</td><td>'+r.meal+'</td>'+
+        '<td class="r num col-split">'+money(r.cash)+(r.flag?'<span class="a-flagchip" title="Far outside the usual range for this shift">⚑ check</span>':'')+'</td>'+
+        '<td class="col-split names">'+r.people.map(esc).join(', ')+' <span class="cnt">· '+r.people.length+'</span></td>'+
+        '<td class="r num col-split per">'+money(per)+'</td>'+
+        '<td class="r num col-card">'+money(r.card)+'</td>'+
+        '<td class="meta">'+esc(r.by)+' · '+(r.mode==='voice'?'dictated':'typed')+'</td>'+
+        '<td><button class="a-fixbtn" data-act="a-edit" data-id="'+r.id+'">Fix</button>'+
+            (r.flag?'<button class="a-okbtn" data-act="a-clearflag" data-id="'+r.id+'" title="Keep the amount and clear the flag">Verify</button>':'')+'</td>'+
+      '</tr>';
+      if(stA.editing===r.id) html+=aEditorRow(r);
+    });
+    html+='<tr class="a-sub"><th scope="row" colspan="3">'+g.date+' — day total</th>'+
+      '<td class="r num col-split">'+money(sum(g.recs,function(r){return r.cash;}))+'</td><td class="col-split"></td><td class="col-split"></td>'+
+      '<td class="r num col-card">'+money(sum(g.recs,function(r){return r.card;}))+'</td><td colspan="2"></td></tr>';
+  });
+  if(!recs.length) html='<tr class="a-empty"><td colspan="9">No records in this range.</td></tr>';
+  else html+='<tr class="a-grand"><th scope="row" colspan="3">Range total — '+recs.length+' records</th>'+
+    '<td class="r num col-split">'+money(sum(recs,function(r){return r.cash;}))+'</td><td class="col-split"></td><td class="col-split"></td>'+
+    '<td class="r num col-card">'+money(sum(recs,function(r){return r.card;}))+'</td><td colspan="2"></td></tr>';
+  $('#aTbody').innerHTML=html;
+  aRenderTotals();
+}
+function aRenderStaff(){
+  var order=0;
+  $('#aStaffBody').innerHTML=stA.staff.map(function(s,i){
+    var ord = s.active ? (++order) : null;
+    var actives=activeStaff(stA);
+    var ai=actives.indexOf(s);
+    var nameCell = stA.renaming===s.id
+      ? '<form class="a-renform" data-id="'+s.id+'"><input name="nm" value="'+esc(s.name)+'" aria-label="New name for '+esc(s.name)+'"><button class="primary" style="border:0;border-radius:6px;padding:2px 10px;font-size:12px">Save</button></form>'
+      : '<strong>'+esc(s.name)+'</strong>';
+    return '<tr'+(s.active?'':' class="a-inactive"')+'>'+
+      '<td>'+(s.active
+          ? '#'+ord+' <button class="a-ordbtn" data-act="a-up" data-id="'+s.id+'"'+(ai===0?' disabled':'')+' aria-label="Move '+esc(s.name)+' earlier in picker order">▲</button>'+
+            '<button class="a-ordbtn" data-act="a-down" data-id="'+s.id+'"'+(ai===actives.length-1?' disabled':'')+' aria-label="Move '+esc(s.name)+' later in picker order">▼</button>'
+          : '—')+'</td>'+
+      '<td>'+nameCell+'</td>'+
+      '<td>'+WORKS[s.works]+'</td>'+
+      '<td>'+(s.active?'<span class="a-status-on">active</span>':'<span class="a-status-off">inactive · history kept</span>')+'</td>'+
+      '<td class="r num">'+s.shifts+'</td>'+
+      '<td>'+
+        '<button class="a-link" data-act="a-rename" data-id="'+s.id+'">Rename</button> '+
+        (s.active
+          ? '<button class="a-link" data-act="a-deact" data-id="'+s.id+'">Deactivate</button> '
+          : '<button class="a-link" data-act="a-react" data-id="'+s.id+'">Reactivate</button> ')+
+        (s.shifts===0
+          ? '<button class="a-link danger-link" data-act="a-del" data-id="'+s.id+'">Delete</button>'
+          : '<button class="a-link" disabled title="Has recorded shifts — deactivate instead">Delete</button>')+
+      '</td></tr>';
+  }).join('');
+}
+function aAccessPanel(k){
+  var a=stA.access[k], name=RESTS[k];
+  var word=(k==='sushi')?'SUSHI':'POKI';
+  var html='<div class="a-access"><h4>'+name+'</h4><dl>'+
+    '<div class="row"><dt>QR sticker</dt><dd>'+(a.qr?'rotated '+a.qr:'never rotated — original from setup')+'</dd>'+
+      '<button class="a-rotbtn" data-act="a-rot" data-rest="'+k+'" data-kind="qr">Rotate…</button></div>'+
+    '<div class="row"><dt>PIN</dt><dd>rotated '+a.pin+'</dd>'+
+      '<button class="a-rotbtn" data-act="a-rot" data-rest="'+k+'" data-kind="pin">Rotate…</button></div>'+
+    '</dl>'+
+    '<button class="a-signout" data-act="a-rot" data-rest="'+k+'" data-kind="signout">Sign out every phone at '+name+'…</button>';
+  if(stA.rotConfirm&&stA.rotConfirm.rest===k){
+    var kind=stA.rotConfirm.kind;
+    var msg = kind==='qr' ? 'The printed sticker by the register stops working the moment you rotate. You’ll need to print and stick the new one.'
+            : kind==='pin' ? 'The old PIN stops working immediately — tonight’s closers need the new number.'
+            : 'Every signed-in phone at '+name+' is signed out and will need the QR sticker and PIN to get back in.';
+    html+='<div class="a-confirmbox"><p><strong>'+(kind==='qr'?'Rotate QR sticker':kind==='pin'?'Rotate PIN':'Sign out all phones')+' — '+name+'.</strong> '+msg+'</p>'+
+      '<label>Type '+word+' to confirm <input type="text" data-role="a-typeconf" autocomplete="off" autocapitalize="characters"></label>'+
+      '<button class="danger" data-act="a-rot-go" disabled>'+(kind==='signout'?'Sign everyone out':'Rotate now')+'</button> '+
+      '<button data-act="a-rot-cancel">Cancel</button></div>';
+  }
+  if(stA.reveal&&stA.reveal.rest===k){
+    var rv=stA.reveal;
+    if(rv.kind==='pin'){
+      html+='<div class="a-reveal"><p><strong>New PIN — shown once, then gone.</strong> Only a hash is stored; write it down or copy it now.</p>'+
+        '<span class="secret">'+rv.secret+'</span><br>'+
+        '<button data-act="a-copy" data-secret="'+rv.secret+'">Copy</button>'+
+        '<button data-act="a-hide" >I’ve saved it — hide forever</button></div>';
+    } else {
+      html+='<div class="a-reveal"><p><strong>New QR sticker — this preview is shown once.</strong> Print it and replace the sticker by the register before tonight; the old one already stopped working.</p>'+
+        qrSVG(rv.seed)+'<br>'+
+        '<button data-act="a-print">Print sticker</button>'+
+        '<button data-act="a-hide">Done — sticker printed</button></div>';
+    }
+  }
+  return html+'</div>';
+}
+function aRenderAccess(){ $('#aAccess').innerHTML=aAccessPanel('sushi')+aAccessPanel('poki'); }
+function renderA(){ aRenderTable(); aRenderStaff(); aRenderAccess(); }
+
+$('#aRange').addEventListener('change',function(){ stA.range=this.value; stA.editing=null; stA.pending=null; aRenderTable(); });
+
+$('#vA').addEventListener('click',function(e){
+  var b=e.target.closest('[data-act]'); if(!b) return;
+  var act=b.dataset.act, id=b.dataset.id;
+  if(act==='a-rest'){
+    stA.restFilter=b.dataset.v; stA.editing=null; stA.pending=null;
+    $all('#aRestSeg button').forEach(function(x){x.setAttribute('aria-pressed',x===b?'true':'false');});
+    aRenderTable();
+  }
+  else if(act==='a-export'){ downloadCSV(aVisible(),'ledger'); }
+  else if(act==='a-jumpflag'){ var row=$('#aFlagRow'); if(row) row.scrollIntoView({block:'center'}); }
+  else if(act==='a-edit'){ stA.editing=(stA.editing===id?null:id); stA.pending=null; aRenderTable(); var f=$('.a-edform input'); if(f) f.focus(); }
+  else if(act==='a-cancel'){ stA.editing=null; stA.pending=null; aRenderTable(); }
+  else if(act==='a-back'){
+    stA.pending=null;
+    var acts=$('.a-edform [data-role="actions"]');
+    if(acts) acts.innerHTML='<button type="button" data-act="a-cancel">Cancel</button><button type="submit" class="primary">Save correction…</button>';
+  }
+  else if(act==='a-confirm'){
+    var r=applyFix(stA,id,stA.pending);
+    stA.editing=null; stA.pending=null; aRenderTable();
+    toast('Correction saved — '+r.date+' '+RESTS[r.rest]+' '+r.meal.toLowerCase()+' now splits '+money(perShare(r))+' each.');
+  }
+  else if(act==='a-clearflag'){
+    var rec=stA.records.find(function(x){return x.id===id;});
+    if(!b.dataset.armed){ b.dataset.armed='1'; b.textContent='Really verify?'; return; }
+    rec.flag=false; aRenderTable();
+    toast(rec.date+' '+RESTS[rec.rest]+' dinner: flag cleared, amount kept as entered.');
+  }
+  else if(act==='a-up'){ moveStaff(stA,id,-1); aRenderStaff(); }
+  else if(act==='a-down'){ moveStaff(stA,id,1); aRenderStaff(); }
+  else if(act==='a-deact'){ deactivate(stA,id); aRenderStaff(); toast('Deactivated — removed from the phone picker; history stays.'); }
+  else if(act==='a-react'){ reactivate(stA,id); aRenderStaff(); toast('Reactivated — back on the phone picker.'); }
+  else if(act==='a-del'){
+    if(!b.dataset.armed){ b.dataset.armed='1'; b.textContent='Really delete?'; return; }
+    deleteStaff(stA,id); aRenderStaff(); toast('Deleted. (Only possible because they had no recorded shifts.)');
+  }
+  else if(act==='a-rename'){ stA.renaming=id; aRenderStaff(); var inp=$('.a-renform input'); if(inp){inp.focus(); inp.select();} }
+  else if(act==='a-rot'){ stA.rotConfirm={rest:b.dataset.rest,kind:b.dataset.kind}; stA.reveal=null; aRenderAccess(); var ti=$('[data-role="a-typeconf"]'); if(ti) ti.focus(); }
+  else if(act==='a-rot-cancel'){ stA.rotConfirm=null; aRenderAccess(); }
+  else if(act==='a-rot-go'){
+    var rc=stA.rotConfirm, acc=stA.access[rc.rest];
+    if(rc.kind==='signout'){ stA.rotConfirm=null; aRenderAccess(); toast('All phones at '+RESTS[rc.rest]+' signed out. They’ll need the QR sticker and PIN to get back in.'); }
+    else{
+      if(rc.kind==='qr') acc.qr='just now (Aug 10)'; else acc.pin='just now (Aug 10)';
+      stA.reveal={rest:rc.rest,kind:rc.kind,secret:newPin(),seed:Math.floor(Math.random()*1e9)};
+      stA.rotConfirm=null; aRenderAccess();
+    }
+  }
+  else if(act==='a-copy'){ copyText(b.dataset.secret); }
+  else if(act==='a-print'){ toast('Printing is inert in this mockup — in the real app this opens the print dialog.'); }
+  else if(act==='a-hide'){
+    stA.reveal=null; aRenderAccess();
+    toast('Hidden. It can’t be shown again — only rotated again.');
+  }
+});
+$('#vA').addEventListener('input',function(e){
+  var form=e.target.closest('.a-edform');
+  if(form){
+    var cash=parseMoney(form.cash.value);
+    var n=$all('input[name="p"]:checked',form).length;
+    $('[data-role="preview"]',form).innerHTML=aEdPreview(cash,n);
+    return;
+  }
+  if(e.target.matches('[data-role="a-typeconf"]')){
+    var want=(stA.rotConfirm.rest==='sushi')?'SUSHI':'POKI';
+    var go=$('.a-confirmbox .danger');
+    if(go) go.disabled=(e.target.value.trim().toUpperCase()!==want);
+  }
+});
+$('#vA').addEventListener('submit',function(e){
+  var f=e.target;
+  if(f.id==='aAddForm'){
+    e.preventDefault();
+    var nm=f.name.value.trim(); if(!nm) return;
+    addStaff(stA,nm,f.works.value); f.reset(); aRenderStaff();
+    toast(nm+' added — they’re on the phone picker now, last in the order.');
+  }
+  else if(f.classList.contains('a-renform')){
+    e.preventDefault();
+    var s=stA.staff.find(function(x){return x.id===f.dataset.id;});
+    var nm2=f.nm.value.trim(); if(nm2) s.name=nm2;
+    stA.renaming=null; aRenderStaff();
+  }
+  else if(f.classList.contains('a-edform')){
+    e.preventDefault();
+    var cash=parseMoney(f.cash.value), card=parseMoney(f.card.value);
+    var people=$all('input[name="p"]:checked',f).map(function(i){return i.value;});
+    if(cash===null||card===null||!people.length){
+      $('[data-role="preview"]',f).innerHTML=aEdPreview(cash, people.length); return;
+    }
+    var r=stA.records.find(function(x){return x.id===f.dataset.id;});
+    stA.pending={cash:cash,card:card,people:people};
+    var oldPer=perShare(r), newPer=Math.round(cash/people.length);
+    $('[data-role="actions"]',f).innerHTML='<div class="ed-confirm">'+
+      '<p><strong>Check it:</strong> cash '+money(r.cash)+' → <strong class="num">'+money(cash)+'</strong> · card '+money(r.card)+' → '+money(card)+
+      ' · per-person '+money(oldPer)+' → <strong class="num">'+money(newPer)+'</strong> for '+people.map(esc).join(', ')+
+      '. This changes what people are owed'+(r.flag?' and clears the flag':'')+'.</p>'+
+      '<button type="button" data-act="a-back">Back</button> '+
+      '<button type="button" class="danger" data-act="a-confirm" data-id="'+r.id+'">Confirm correction</button></div>';
+  }
+});
+
+/* ================================================================
+   VARIANT B — THE DAYBOOK
+================================================================ */
+var stB=freshState();
+stB.range='all'; stB.renaming=null;
+stB.drawer=null;   /* {mode:'fix'|'add', id, step} */
+stB.dlg=null;      /* {rest,kind} */
+var bDrawerEl=$('#bDrawer'), bScrimEl=$('#bScrim'), bDialogEl=$('#bDialog');
+var bLastFocus=null;
+
+function bVisible(){
+  return stB.records.filter(function(r){
+    if(stB.restFilter!=='all'&&r.rest!==stB.restFilter) return false;
+    if(stB.range==='weekend'&&r.d<8) return false;
+    return true;
+  });
+}
+function bCard(r){
+  var per=perShare(r), n=r.people.length;
+  return '<article class="b-card'+(r.flag?' flagged':'')+'">'+
+    (r.flag?'<p class="b-flagbanner">⚑ Way above the usual $150–$350 for this shift — check it before payday</p>':'')+
+    '<header class="b-cardhead"><span class="b-rm">'+RESTS[r.rest]+' · '+r.meal+'</span>'+
+      '<span class="b-meta">closed by '+esc(r.by)+'<br>'+(r.mode==='voice'?'dictated':'typed')+'</span></header>'+
+    '<div class="b-cash"><strong class="num">'+money(r.cash)+'</strong><span>cash pool — handed out tonight</span></div>'+
+    '<p class="b-splitline">'+(n===1?'one person, kept whole':'split '+n+' ways')+' → <span class="b-per num">'+money(per)+' each</span></p>'+
+    '<ul class="b-chips">'+r.people.map(function(p){return '<li>'+esc(p)+'</li>';}).join('')+'</ul>'+
+    '<footer class="b-cardfoot"><span>+ <span class="num">'+money(r.card)+'</span> card — logged for payroll, never split</span>'+
+      '<button class="b-fix" data-act="b-fix" data-id="'+r.id+'">Fix this shift</button></footer>'+
+  '</article>';
+}
+function bRenderDays(){
+  var recs=bVisible(), days=groupByDay(recs);
+  $('#bTotals').innerHTML = recs.length
+    ? (stB.range==='weekend'?'Aug 8–9':'Aug 3–9')+' · '+recs.length+' records · cash split <strong class="num">'+money(sum(recs,function(r){return r.cash;}))+'</strong> · card logged <span class="num">'+money(sum(recs,function(r){return r.card;}))+'</span>'
+    : 'No records match.';
+  $('#bDays').innerHTML = days.length ? days.map(function(g){
+    return '<section class="b-day"><header class="b-dayhead"><h4>'+g.date+'</h4>'+
+      '<p><strong class="num">'+money(sum(g.recs,function(r){return r.cash;}))+'</strong> cash split · <span class="num">'+money(sum(g.recs,function(r){return r.card;}))+'</span> card logged</p></header>'+
+      '<div class="b-cards">'+g.recs.map(bCard).join('')+'</div></section>';
+  }).join('') : '<div class="b-empty">Nothing recorded in this range.</div>';
+}
+function bRenderStaff(){
+  var order=0;
+  $('#bStaff').innerHTML='<button class="b-addtile" data-act="b-add-open">＋ Add a new hire — 30 seconds, they’re on the picker tonight</button>'+
+    stB.staff.map(function(s){
+      var ord=s.active?(++order):null;
+      var actives=activeStaff(stB), ai=actives.indexOf(s);
+      var nameHtml = stB.renaming===s.id
+        ? '<form class="b-renform" data-id="'+s.id+'"><input name="nm" value="'+esc(s.name)+'" aria-label="New name"><button>Save</button></form>'
+        : '<h4>'+esc(s.name)+'</h4>';
+      return '<article class="b-person'+(s.active?'':' inactive')+'">'+
+        '<span class="b-ordnum">'+(s.active?'#'+ord:'—')+'</span>'+
+        '<span class="b-ava" aria-hidden="true">'+esc(s.name.charAt(0))+'</span>'+
+        '<div class="b-pinfo">'+nameHtml+'<p>'+WORKS[s.works]+(s.active?'':' · inactive — history kept')+(s.shifts===0?' · no shifts yet':'')+'</p></div>'+
+        (s.active?'<div class="b-porder">'+
+          '<button data-act="b-up" data-id="'+s.id+'"'+(ai===0?' disabled':'')+' aria-label="Move '+esc(s.name)+' earlier in picker order">▲</button>'+
+          '<button data-act="b-down" data-id="'+s.id+'"'+(ai===actives.length-1?' disabled':'')+' aria-label="Move '+esc(s.name)+' later in picker order">▼</button></div>':'')+
+        '<div class="b-pacts">'+
+          '<button data-act="b-rename" data-id="'+s.id+'">Rename</button>'+
+          (s.active?'<button data-act="b-deact" data-id="'+s.id+'">Deactivate</button>'
+                   :'<button data-act="b-react" data-id="'+s.id+'">Reactivate</button>')+
+          (s.shifts===0?'<button class="danger-link" data-act="b-del" data-id="'+s.id+'">Delete</button>':'')+
+        '</div></article>';
+    }).join('');
+}
+function bRenderAccess(){
+  $('#bAccess').innerHTML=['sushi','poki'].map(function(k){
+    var a=stB.access[k];
+    return '<article class="b-access"><h4>'+RESTS[k]+'</h4><dl>'+
+      '<div class="row"><dt>QR sticker</dt><dd>'+(a.qr?'rotated '+a.qr:'never rotated')+'</dd>'+
+        '<button data-act="b-rot" data-rest="'+k+'" data-kind="qr">Rotate…</button></div>'+
+      '<div class="row"><dt>PIN</dt><dd>rotated '+a.pin+'</dd>'+
+        '<button data-act="b-rot" data-rest="'+k+'" data-kind="pin">Rotate…</button></div></dl>'+
+      '<div class="b-signoutrow"><button data-act="b-rot" data-rest="'+k+'" data-kind="signout">Sign out every phone…</button></div>'+
+    '</article>';
+  }).join('');
+}
+function renderB(){ bRenderDays(); bRenderStaff(); bRenderAccess(); }
+
+function bOpenDrawer(html){
+  bLastFocus=document.activeElement;
+  bDrawerEl.innerHTML='<button class="b-close" data-act="b-drawer-close" aria-label="Close">✕</button>'+html;
+  bScrimEl.hidden=false; bDrawerEl.hidden=false;
+  var f=$('input,select,button:not(.b-close)',bDrawerEl); if(f) f.focus();
+}
+function bCloseDrawer(){
+  stB.drawer=null; bScrimEl.hidden=true; bDrawerEl.hidden=true; bDrawerEl.innerHTML='';
+  if(bLastFocus&&bLastFocus.focus) bLastFocus.focus();
+}
+function bFixFormHTML(r){
+  var names=eligibleNames(stB,r);
+  return '<h4 id="bDrawerTitle">Fix '+r.date+' — '+RESTS[r.rest]+' '+r.meal.toLowerCase()+'</h4>'+
+    '<p class="b-dsub">Entered by '+esc(r.by)+' ('+(r.mode==='voice'?'dictated':'typed')+'). Corrections change what people get paid — you’ll see exactly who changes before anything saves.</p>'+
+    '<form data-role="b-fixform" data-id="'+r.id+'">'+
+      '<label class="b-field"><span>Cash pool <small>— split among the shift, handed out nightly</small></span>'+
+        '<input type="text" class="num" name="cash" inputmode="decimal" value="'+(r.cash/100).toFixed(2)+'"></label>'+
+      '<label class="b-field"><span>Card tips <small>— logged for payroll, never split</small></span>'+
+        '<input type="text" class="num" name="card" inputmode="decimal" value="'+(r.card/100).toFixed(2)+'"></label>'+
+      '<div class="b-field"><span>Who was on the split</span><div class="b-people">'+names.map(function(n){
+        return '<label><input type="checkbox" name="p" value="'+esc(n)+'"'+(r.people.indexOf(n)>=0?' checked':'')+' class="sr">'+esc(n)+'</label>';
+      }).join('')+'</div></div>'+
+      '<p class="b-dpreview" data-role="preview">'+bFixPreview(r.cash,r.people.length)+'</p>'+
+      '<div class="b-dacts"><button type="button" data-act="b-drawer-close">Cancel</button>'+
+        '<button type="submit" class="primary">Review change…</button></div>'+
+    '</form>';
+}
+function bFixPreview(cashC,n){
+  if(n===0) return '<span style="color:#c03520;font-weight:700">Pick at least one person.</span>';
+  if(cashC===null) return '<span style="color:#c03520;font-weight:700">Cash amount doesn’t parse.</span>';
+  return 'Per-person share becomes <strong class="num">'+money(Math.round(cashC/n))+'</strong> — cash ÷ '+n+', card excluded.';
+}
+function bDeltaHTML(r,next){
+  var oldPer=perShare(r), newPer=Math.round(next.cash/next.people.length);
+  var names=r.people.slice();
+  next.people.forEach(function(n){ if(names.indexOf(n)<0) names.push(n); });
+  var rows=names.map(function(n){
+    var was=r.people.indexOf(n)>=0, is=next.people.indexOf(n)>=0;
+    var before=was?money(oldPer):'—', after=is?money(newPer):'removed';
+    var cls = (!is)?'removed':((!was||oldPer!==newPer)?'chg':'');
+    return '<tr><td>'+esc(n)+'</td><td class="r num">'+before+'</td><td class="r num '+cls+'">'+after+'</td></tr>';
+  }).join('');
+  return '<table class="b-delta"><thead><tr><th scope="col">Person</th><th scope="col" class="r">Gets now</th><th scope="col" class="r">Would get</th></tr></thead>'+
+    '<tbody>'+rows+
+    '<tr><td>Cash pool</td><td class="r num">'+money(r.cash)+'</td><td class="r num'+(r.cash!==next.cash?' chg':'')+'">'+money(next.cash)+'</td></tr>'+
+    '<tr><td>Card (logged only)</td><td class="r num">'+money(r.card)+'</td><td class="r num'+(r.card!==next.card?' chg':'')+'">'+money(next.card)+'</td></tr>'+
+    '</tbody></table>';
+}
+function bAddFormHTML(){
+  return '<h4 id="bDrawerTitle">Add a new hire</h4>'+
+    '<p class="b-dsub">They’ll show up on the phone picker immediately, last in the order — move them up any time.</p>'+
+    '<form data-role="b-addform">'+
+      '<label class="b-field"><span>Name</span><input type="text" name="name" required placeholder="e.g. Dana" autocomplete="off"></label>'+
+      '<label class="b-field"><span>Works at</span><select name="works">'+
+        '<option value="sushi">Sushi</option><option value="poki">Poki &amp; Pho</option><option value="both">Both</option></select></label>'+
+      '<div class="b-dacts"><button type="button" data-act="b-drawer-close">Cancel</button>'+
+        '<button type="submit" class="primary">Add to picker</button></div></form>';
+}
+function bOpenRotate(rest,kind){
+  stB.dlg={rest:rest,kind:kind};
+  var name=RESTS[rest];
+  var title,points,ack,go;
+  if(kind==='qr'){ title='Rotate the QR sticker — '+name;
+    points=['The printed sticker by the register stops working the moment you confirm.','You’ll see the new code once, to print a new sticker.','Phones already signed in stay signed in.'];
+    ack='the old sticker becomes useless'; go='Rotate QR code'; }
+  else if(kind==='pin'){ title='Rotate the PIN — '+name;
+    points=['The old PIN stops working immediately.','The new PIN is shown once — tonight’s closers need it from you.','Phones already signed in stay signed in.'];
+    ack='closers can’t sign in until I tell them the new PIN'; go='Rotate PIN'; }
+  else { title='Sign out every phone — '+name;
+    points=['Every signed-in phone at '+name+' is signed out right now.','Each phone needs the QR sticker + PIN to get back in.','Nothing recorded is lost.'];
+    ack='closers will have to sign in again tonight'; go='Sign everyone out'; }
+  bDialogEl.innerHTML='<h4>'+title+'</h4><ul class="b-conseq">'+points.map(function(p){return '<li>'+p+'</li>';}).join('')+'</ul>'+
+    '<label class="b-ack"><input type="checkbox" data-role="b-ack"> I understand — '+ack+'.</label>'+
+    '<div class="b-dacts"><button data-act="b-dlg-cancel">Cancel</button>'+
+      '<button class="danger" data-act="b-dlg-go" disabled>'+go+'</button></div>';
+  bDialogEl.showModal();
+}
+function bShowReveal(rest,kind){
+  var name=RESTS[rest];
+  if(kind==='pin'){
+    var pin=newPin();
+    bDialogEl.innerHTML='<h4>New PIN — '+name+'</h4>'+
+      '<p class="b-pin">'+pin.split('').join(' ')+'</p>'+
+      '<p class="b-once">This is the only time it will ever be shown — only a scrambled version is stored. Tell tonight’s closers before you close this.</p>'+
+      '<div class="b-dacts"><button data-act="b-copy" data-secret="'+pin+'">Copy</button>'+
+        '<button class="primary" data-act="b-reveal-done" data-msg="'+name+' PIN rotated — the old PIN stopped working.">I’ve written it down</button></div>';
+  } else {
+    bDialogEl.innerHTML='<h4>New QR sticker — '+name+'</h4>'+
+      '<div class="b-qrwrap">'+qrSVG(Math.floor(Math.random()*1e9))+
+      '<p>Print this and replace the sticker by the register before tonight’s close. The old sticker already stopped working.</p></div>'+
+      '<p class="b-once">Shown once — it can’t be re-displayed later, only rotated again.</p>'+
+      '<div class="b-dacts"><button data-act="b-print">Print sticker</button>'+
+        '<button class="primary" data-act="b-reveal-done" data-msg="'+name+' QR rotated — old sticker is dead until the new one is up.">Done — I’ve printed it</button></div>';
+  }
+}
+$('#vB').addEventListener('click',function(e){
+  var b=e.target.closest('[data-act]'); if(!b) return;
+  var act=b.dataset.act, id=b.dataset.id;
+  if(act==='b-rest'||act==='b-range'){
+    if(act==='b-range'&&b.dataset.v==='custom'){ toast('Custom date pickers are inert in this mockup.'); return; }
+    if(act==='b-rest') stB.restFilter=b.dataset.v; else stB.range=b.dataset.v;
+    $all('.b-chip[data-act="'+act+'"]').forEach(function(x){ x.setAttribute('aria-pressed', x===b?'true':'false'); });
+    bRenderDays();
+  }
+  else if(act==='b-export'){ downloadCSV(bVisible(),'daybook'); }
+  else if(act==='b-fix'){ var r=stB.records.find(function(x){return x.id===id;}); stB.drawer={mode:'fix',id:id}; bOpenDrawer(bFixFormHTML(r)); }
+  else if(act==='b-add-open'){ stB.drawer={mode:'add'}; bOpenDrawer(bAddFormHTML()); }
+  else if(act==='b-drawer-close'){ bCloseDrawer(); }
+  else if(act==='b-fix-back'){ var r2=stB.records.find(function(x){return x.id===stB.drawer.id;}); bOpenDrawer(bFixFormHTML(r2)); }
+  else if(act==='b-fix-confirm'){
+    var r3=applyFix(stB,stB.drawer.id,stB.pendingFix);
+    bCloseDrawer(); bRenderDays();
+    toast('Saved — '+r3.date+' '+RESTS[r3.rest]+' '+r3.meal.toLowerCase()+' now splits '+money(perShare(r3))+' each.');
+  }
+  else if(act==='b-up'){ moveStaff(stB,id,-1); bRenderStaff(); }
+  else if(act==='b-down'){ moveStaff(stB,id,1); bRenderStaff(); }
+  else if(act==='b-rename'){ stB.renaming=id; bRenderStaff(); var i2=$('.b-renform input'); if(i2){i2.focus(); i2.select();} }
+  else if(act==='b-deact'){ deactivate(stB,id); bRenderStaff(); toast('Deactivated — off the picker, history kept.'); }
+  else if(act==='b-react'){ reactivate(stB,id); bRenderStaff(); toast('Reactivated — back on the picker.'); }
+  else if(act==='b-del'){
+    if(!b.dataset.armed){ b.dataset.armed='1'; b.textContent='Really delete?'; return; }
+    deleteStaff(stB,id); bRenderStaff(); toast('Deleted — they had no recorded shifts.');
+  }
+  else if(act==='b-rot'){ bOpenRotate(b.dataset.rest,b.dataset.kind); }
+  else if(act==='b-dlg-cancel'){ bDialogEl.close(); }
+  else if(act==='b-dlg-go'){
+    var d=stB.dlg, acc=stB.access[d.rest];
+    if(d.kind==='signout'){ bDialogEl.close(); toast('All phones at '+RESTS[d.rest]+' signed out.'); }
+    else{
+      if(d.kind==='qr') acc.qr='just now (Aug 10)'; else acc.pin='just now (Aug 10)';
+      bRenderAccess(); bShowReveal(d.rest,d.kind);
+    }
+  }
+  else if(act==='b-copy'){ copyText(b.dataset.secret); }
+  else if(act==='b-print'){ toast('Printing is inert in this mockup.'); }
+  else if(act==='b-reveal-done'){ bDialogEl.close(); toast(b.dataset.msg); }
+});
+$('#vB').addEventListener('change',function(e){
+  if(e.target.matches('[data-role="b-ack"]')){
+    var go=$('[data-act="b-dlg-go"]',bDialogEl); if(go) go.disabled=!e.target.checked;
+  }
+});
+$('#vB').addEventListener('input',function(e){
+  var form=e.target.closest('[data-role="b-fixform"]');
+  if(form){
+    var cash=parseMoney(form.cash.value);
+    var n=$all('input[name="p"]:checked',form).length;
+    $('[data-role="preview"]',form).innerHTML=bFixPreview(cash,n);
+  }
+});
+$('#vB').addEventListener('submit',function(e){
+  var f=e.target;
+  if(f.matches('[data-role="b-fixform"]')){
+    e.preventDefault();
+    var cash=parseMoney(f.cash.value), card=parseMoney(f.card.value);
+    var people=$all('input[name="p"]:checked',f).map(function(i){return i.value;});
+    if(cash===null||card===null||!people.length){ $('[data-role="preview"]',f).innerHTML=bFixPreview(cash,people.length); return; }
+    var r=stB.records.find(function(x){return x.id===f.dataset.id;});
+    stB.pendingFix={cash:cash,card:card,people:people};
+    bOpenDrawer('<h4 id="bDrawerTitle">Before you save</h4>'+
+      '<p class="b-dsub">'+r.date+' — '+RESTS[r.rest]+' '+r.meal.toLowerCase()+'. Here’s exactly who this changes:</p>'+
+      bDeltaHTML(r,stB.pendingFix)+
+      '<p class="b-consequence">This changes what people are owed'+(r.flag?' and clears the flag on this record':'')+'.</p>'+
+      '<div class="b-dacts"><button type="button" data-act="b-fix-back">Back</button>'+
+        '<button type="button" class="danger" data-act="b-fix-confirm">Save the correction</button></div>');
+  }
+  else if(f.matches('[data-role="b-addform"]')){
+    e.preventDefault();
+    var nm=f.name.value.trim(); if(!nm) return;
+    addStaff(stB,nm,f.works.value); bCloseDrawer(); bRenderStaff();
+    toast(nm+' added — on the phone picker now, last in the order.');
+  }
+  else if(f.classList.contains('b-renform')){
+    e.preventDefault();
+    var s=stB.staff.find(function(x){return x.id===f.dataset.id;});
+    var nm2=f.nm.value.trim(); if(nm2) s.name=nm2;
+    stB.renaming=null; bRenderStaff();
+  }
+});
+document.addEventListener('keydown',function(e){
+  if(e.key==='Escape'&&!bDrawerEl.hidden) bCloseDrawer();
+});
+bScrimEl.addEventListener('click',bCloseDrawer);
+
+/* ================================================================
+   VARIANT C — THE MORNING CHECK
+================================================================ */
+var stC=freshState();
+stC.week='this'; stC.openDays={'Sun Aug 9':true}; stC.renaming=null; stC.reveals=[];
+var cDialogEl=$('#cDialog');
+
+function cVisible(){
+  if(stC.week==='last') return [];
+  return stC.records.filter(function(r){ return stC.restFilter==='all'||r.rest===stC.restFilter; });
+}
+function cRenderNight(){
+  var recs=cVisible().filter(function(r){return r.d===9;});
+  var html=recs.map(function(r){
+    return '<article class="c-tile"><h4>'+RESTS[r.rest]+' · '+r.meal+'</h4>'+
+      '<p class="c-cashline"><strong class="num">'+money(r.cash)+'</strong> cash</p>'+
+      '<p class="c-perline">→ <strong class="num">'+money(perShare(r))+'</strong> × '+r.people.length+' ('+r.people.map(esc).join(', ')+')</p>'+
+      '<p class="c-cardline"><span class="num">'+money(r.card)+'</span> card — logged, not split</p>'+
+      '<p class="c-tilemeta">closed by '+esc(r.by)+' · '+(r.mode==='voice'?'dictated':'typed')+'</p></article>';
+  }).join('');
+  var pokiLunchMissing = stC.week==='this' && (stC.restFilter==='all'||stC.restFilter==='poki') &&
+    !stC.records.some(function(r){return r.d===9&&r.rest==='poki'&&r.meal==='Lunch';});
+  if(pokiLunchMissing) html+='<article class="c-tile ghost">Poki &amp; Pho lunch — nothing recorded</article>';
+  $('#cNight').innerHTML=html||'<article class="c-tile ghost">Nothing recorded last night for this filter.</article>';
+}
+function cRenderAttn(){
+  var flags=stC.records.filter(function(r){return r.flag;});
+  $('#cAttn').innerHTML = flags.length ? flags.map(function(r){
+    return '<article class="c-flag"><h4>⚑ '+r.date+' — '+RESTS[r.rest]+' '+r.meal.toLowerCase()+' cash reads '+money(r.cash)+'</h4>'+
+      '<p>'+(r.mode==='voice'?'Dictated':'Typed')+' by '+esc(r.by)+' at close. This slot normally lands between $150 and $350, so it was saved but flagged. '+
+      'As entered, it splits to <strong class="num">'+money(perShare(r))+'</strong> each for '+r.people.map(esc).join(' and ')+' — worth a look before payday.</p>'+
+      '<div class="c-flagacts"><button class="primary" data-act="c-fix-open" data-id="'+r.id+'">Fix the amount</button>'+
+      '<button data-act="c-keep" data-id="'+r.id+'">It’s correct — keep it</button></div></article>';
+  }).join('') : '<p class="c-allclear">Nothing needs attention. All of this week’s records look like their usual selves.</p>';
+}
+function cRenderWeek(){
+  var recs=cVisible();
+  if(stC.week==='last'){ $('#cWeek').innerHTML='<p class="c-allclear">No records — the tips app wasn’t live yet that week.</p>'; return; }
+  var days=groupByDay(recs);
+  var html=days.map(function(g){
+    var open=!!stC.openDays[g.date];
+    var flagged=g.recs.some(function(r){return r.flag;});
+    return '<div class="c-dayrow">'+
+      '<button class="c-daybtn" data-act="c-day" data-date="'+g.date+'" aria-expanded="'+open+'">'+
+        '<span class="c-dayname">'+g.date+'</span>'+
+        '<span class="c-daynums num"><strong>'+money(sum(g.recs,function(r){return r.cash;}))+'</strong> cash · '+money(sum(g.recs,function(r){return r.card;}))+' card · '+g.recs.length+' shift'+(g.recs.length===1?'':'s')+'</span>'+
+        (flagged?'<span class="c-dayflag">⚑ flagged</span>':'')+
+        '<span class="c-caret" aria-hidden="true">'+(open?'▲':'▼')+'</span></button>'+
+      '<div class="c-daybody"'+(open?'':' hidden')+'>'+g.recs.map(function(r){
+        return '<div class="c-shift'+(r.flag?' flagged':'')+'">'+
+          '<span class="c-sname">'+RESTS[r.rest]+' · '+r.meal+(r.flag?' ⚑':'')+'</span>'+
+          '<span class="c-scash num"><strong>'+money(r.cash)+'</strong> cash → '+money(perShare(r))+' each</span>'+
+          '<span class="c-speople">'+r.people.map(esc).join(', ')+'</span>'+
+          '<span class="c-scard num">'+money(r.card)+' card logged</span>'+
+          '<button class="c-sfix" data-act="c-fix-open" data-id="'+r.id+'">fix</button></div>';
+      }).join('')+'</div></div>';
+  }).join('');
+  html+='<p class="c-weektotals num">Week totals — cash split <strong>'+money(sum(recs,function(r){return r.cash;}))+'</strong> · card logged <strong>'+money(sum(recs,function(r){return r.card;}))+'</strong> · '+recs.length+' records. Cash is handed out nightly; card goes through payroll.</p>';
+  $('#cWeek').innerHTML=html;
+}
+function cRenderStaff(){
+  var actives=activeStaff(stC), inactives=stC.staff.filter(function(s){return !s.active;});
+  $('#cStaffSum').textContent=actives.length+' active · '+inactives.length+' inactive — picker order: '+actives.map(function(s){return s.name;}).join(', ');
+  var order=0;
+  $('#cStaffBody').innerHTML=stC.staff.map(function(s){
+    var ord=s.active?(++order):null, ai=actives.indexOf(s);
+    var nameHtml = stC.renaming===s.id
+      ? '<form class="b-renform" data-role="c-renform" data-id="'+s.id+'" style="display:inline-flex"><input name="nm" value="'+esc(s.name)+'" aria-label="New name"><button>Save</button></form>'
+      : esc(s.name);
+    return '<div class="c-staffrow'+(s.active?'':' inactive')+'">'+
+      '<span class="c-stord">'+(s.active?'#'+ord:'—')+'</span>'+
+      '<span class="c-stname">'+nameHtml+'</span>'+
+      '<span class="c-stworks">'+WORKS[s.works]+(s.active?'':' · inactive, history kept')+(s.shifts===0?' · no shifts yet':'')+'</span>'+
+      '<span class="c-stacts">'+
+        (s.active?'<button data-act="c-up" data-id="'+s.id+'"'+(ai===0?' disabled':'')+' aria-label="Move '+esc(s.name)+' earlier">▲</button>'+
+                  '<button data-act="c-down" data-id="'+s.id+'"'+(ai===actives.length-1?' disabled':'')+' aria-label="Move '+esc(s.name)+' later">▼</button>':'')+
+        '<button data-act="c-rename" data-id="'+s.id+'">Rename</button>'+
+        (s.active?'<button data-act="c-deact" data-id="'+s.id+'">Deactivate</button>'
+                 :'<button data-act="c-react" data-id="'+s.id+'">Reactivate</button>')+
+        (s.shifts===0?'<button class="danger-link" data-act="c-del" data-id="'+s.id+'">Delete</button>':'')+
+      '</span></div>';
+  }).join('');
+}
+function cRenderAccess(){
+  var a=stC.access;
+  $('#cAccessSum').textContent='Sushi rotated '+(a.sushi.qr||'never')+' · Poki sticker '+(a.poki.qr?'rotated '+a.poki.qr:'never rotated');
+  var unlocked=$('#cUnlock').checked;
+  $('#cAccessBody').innerHTML=['sushi','poki'].map(function(k){
+    var x=a[k];
+    return '<div class="c-access"><h5>'+RESTS[k]+'</h5><dl>'+
+      '<div class="row"><dt>QR sticker</dt><dd>'+(x.qr?'rotated '+x.qr:'never rotated')+'</dd>'+
+        '<button data-act="c-rot" data-rest="'+k+'" data-kind="qr"'+(unlocked?'':' disabled')+'>Rotate…</button></div>'+
+      '<div class="row"><dt>PIN</dt><dd>rotated '+x.pin+'</dd>'+
+        '<button data-act="c-rot" data-rest="'+k+'" data-kind="pin"'+(unlocked?'':' disabled')+'>Rotate…</button></div></dl>'+
+      '<button class="c-signout" data-act="c-rot" data-rest="'+k+'" data-kind="signout"'+(unlocked?'':' disabled')+'>Sign out every phone…</button>'+
+    '</div>';
+  }).join('');
+}
+function cRenderReveals(){
+  $('#cReveal').innerHTML=stC.reveals.map(function(rv,i){
+    var inner = rv.kind==='pin'
+      ? '<div><h4>New PIN — '+RESTS[rv.rest]+'</h4><p>Shown once — only a hash is stored. Tell tonight’s closers, then dismiss.</p></div><span class="c-secret">'+rv.secret.split('').join(' ')+'</span>'
+      : qrSVG(rv.seed)+'<div><h4>New QR sticker — '+RESTS[rv.rest]+'</h4><p>Print and replace the register sticker before tonight — the old one already stopped working. This preview can’t be re-shown.</p></div>';
+    return '<article class="c-reveal">'+inner+
+      '<button data-act="c-dismiss" data-i="'+i+'">I’ve recorded it — dismiss</button></article>';
+  }).join('');
+}
+function renderC(){ cRenderReveals(); cRenderAttn(); cRenderNight(); cRenderWeek(); cRenderStaff(); cRenderAccess(); }
+
+function cFixDialog(r){
+  var names=eligibleNames(stC,r);
+  cDialogEl.innerHTML='<h4>Correct '+r.date+' — '+RESTS[r.rest]+' '+r.meal.toLowerCase()+'</h4>'+
+    '<form data-role="c-fixform" data-id="'+r.id+'">'+
+      '<label class="b-field"><span>Cash pool <small>— gets split</small></span><input type="text" class="num" name="cash" inputmode="decimal" value="'+(r.cash/100).toFixed(2)+'"></label>'+
+      '<label class="b-field"><span>Card <small>— logged only, never split</small></span><input type="text" class="num" name="card" inputmode="decimal" value="'+(r.card/100).toFixed(2)+'"></label>'+
+      '<div class="b-field"><span>On the split</span><div class="b-people">'+names.map(function(n){
+        return '<label><input type="checkbox" name="p" value="'+esc(n)+'"'+(r.people.indexOf(n)>=0?' checked':'')+' class="sr">'+esc(n)+'</label>';
+      }).join('')+'</div></div>'+
+      '<p class="c-consequence" data-role="preview">'+cFixPreview(r,r.cash,r.people)+'</p>'+
+      '<div class="c-dlgacts"><button type="button" data-act="c-dlg-cancel">Cancel</button>'+
+        '<button type="submit" class="danger">Save correction</button></div></form>';
+  cDialogEl.showModal();
+}
+function cFixPreview(r,cashC,people){
+  if(!people.length) return '<strong>Pick at least one person.</strong>';
+  if(cashC===null) return '<strong>Cash amount doesn’t parse.</strong>';
+  var newPer=Math.round(cashC/people.length);
+  return 'This changes payouts: per-person goes <strong class="num">'+money(perShare(r))+' → '+money(newPer)+'</strong> for '+people.map(esc).join(', ')+'. Saving clears the flag.';
+}
+$('#vC').addEventListener('click',function(e){
+  var b=e.target.closest('[data-act]'); if(!b) return;
+  var act=b.dataset.act, id=b.dataset.id;
+  if(act==='c-rest'){
+    stC.restFilter=b.dataset.v;
+    $all('#cRestSeg button').forEach(function(x){x.setAttribute('aria-pressed',x===b?'true':'false');});
+    cRenderNight(); cRenderWeek();
+  }
+  else if(act==='c-export'){ downloadCSV(cVisible(),'week-aug3-9'); }
+  else if(act==='c-day'){
+    var d=b.dataset.date;
+    if(stC.openDays[d]) delete stC.openDays[d]; else stC.openDays[d]=true;
+    cRenderWeek();
+  }
+  else if(act==='c-fix-open'){ cFixDialog(stC.records.find(function(x){return x.id===id;})); }
+  else if(act==='c-keep'){
+    if(!b.dataset.armed){ b.dataset.armed='1'; b.textContent='Confirm — keep '+'the amount'; return; }
+    stC.records.find(function(x){return x.id===id;}).flag=false;
+    cRenderAttn(); cRenderWeek();
+    toast('Flag cleared — amount kept as entered.');
+  }
+  else if(act==='c-dlg-cancel'){ cDialogEl.close(); }
+  else if(act==='c-add-open'){
+    cDialogEl.innerHTML='<h4>Add a new hire</h4>'+
+      '<form data-role="c-addform">'+
+      '<label class="b-field"><span>Name</span><input type="text" name="name" required placeholder="e.g. Dana" autocomplete="off"></label>'+
+      '<label class="b-field"><span>Works at</span><select name="works"><option value="sushi">Sushi</option><option value="poki">Poki &amp; Pho</option><option value="both">Both</option></select></label>'+
+      '<p class="c-consequence" style="background:#f5f1e8">They’ll appear on the phone picker immediately, last in the order.</p>'+
+      '<div class="c-dlgacts"><button type="button" data-act="c-dlg-cancel">Cancel</button>'+
+      '<button type="submit" class="primary">Add to picker</button></div></form>';
+    cDialogEl.showModal();
+    $('input',cDialogEl).focus();
+  }
+  else if(act==='c-up'){ moveStaff(stC,id,-1); cRenderStaff(); }
+  else if(act==='c-down'){ moveStaff(stC,id,1); cRenderStaff(); }
+  else if(act==='c-rename'){ stC.renaming=id; cRenderStaff(); var i3=$('[data-role="c-renform"] input'); if(i3){i3.focus(); i3.select();} }
+  else if(act==='c-deact'){ deactivate(stC,id); cRenderStaff(); toast('Deactivated — off the picker, history kept.'); }
+  else if(act==='c-react'){ reactivate(stC,id); cRenderStaff(); toast('Reactivated.'); }
+  else if(act==='c-del'){
+    if(!b.dataset.armed){ b.dataset.armed='1'; b.textContent='Really?'; return; }
+    deleteStaff(stC,id); cRenderStaff(); toast('Deleted — no recorded shifts, so nothing was lost.');
+  }
+  else if(act==='c-rot'){
+    var rest=b.dataset.rest, kind=b.dataset.kind, nm=RESTS[rest];
+    var msg = kind==='qr' ? 'The printed sticker at '+nm+' stops working immediately. The new code appears once, pinned to the top of this page until you dismiss it.'
+            : kind==='pin' ? 'The old PIN at '+nm+' stops working immediately. The new PIN appears once, pinned to the top of this page until you dismiss it.'
+            : 'Every signed-in phone at '+nm+' is signed out right now and needs the QR + PIN to get back in.';
+    cDialogEl.innerHTML='<h4>'+(kind==='qr'?'Rotate QR sticker':kind==='pin'?'Rotate PIN':'Sign out every phone')+' — '+nm+'</h4>'+
+      '<p class="c-consequence"><strong>This is disruptive.</strong> '+msg+'</p>'+
+      '<div class="c-dlgacts"><button data-act="c-dlg-cancel">Cancel</button>'+
+      '<button class="danger" data-act="c-rot-go" data-rest="'+rest+'" data-kind="'+kind+'">'+(kind==='signout'?'Sign everyone out':'Rotate now')+'</button></div>';
+    cDialogEl.showModal();
+  }
+  else if(act==='c-rot-go'){
+    var rest2=b.dataset.rest, kind2=b.dataset.kind;
+    cDialogEl.close();
+    if(kind2==='signout'){ toast('All phones at '+RESTS[rest2]+' signed out.'); return; }
+    if(kind2==='qr') stC.access[rest2].qr='just now (Aug 10)'; else stC.access[rest2].pin='just now (Aug 10)';
+    stC.reveals.unshift({rest:rest2,kind:kind2,secret:newPin(),seed:Math.floor(Math.random()*1e9)});
+    cRenderAccess(); cRenderReveals();
+    $('#cReveal').scrollIntoView({block:'center'});
+    toast('Rotated — the new '+(kind2==='qr'?'sticker':'PIN')+' is pinned at the top until you dismiss it.');
+  }
+  else if(act==='c-dismiss'){
+    if(!b.dataset.armed){ b.dataset.armed='1'; b.textContent='Click again — hides it forever'; return; }
+    stC.reveals.splice(Number(b.dataset.i),1); cRenderReveals();
+    toast('Hidden forever — only a hash is stored now.');
+  }
+});
+$('#cWeekSel').addEventListener('change',function(){ stC.week=this.value; cRenderNight(); cRenderWeek(); });
+$('#cUnlock').addEventListener('change',cRenderAccess);
+$('#vC').addEventListener('input',function(e){
+  var form=e.target.closest('[data-role="c-fixform"]');
+  if(form){
+    var r=stC.records.find(function(x){return x.id===form.dataset.id;});
+    var cash=parseMoney(form.cash.value);
+    var people=$all('input[name="p"]:checked',form).map(function(i){return i.value;});
+    $('[data-role="preview"]',form).innerHTML=cFixPreview(r,cash,people);
+  }
+});
+$('#vC').addEventListener('submit',function(e){
+  var f=e.target;
+  if(f.matches('[data-role="c-fixform"]')){
+    e.preventDefault();
+    var cash=parseMoney(f.cash.value), card=parseMoney(f.card.value);
+    var people=$all('input[name="p"]:checked',f).map(function(i){return i.value;});
+    if(cash===null||card===null||!people.length) return;
+    var r=applyFix(stC,f.dataset.id,{cash:cash,card:card,people:people});
+    cDialogEl.close(); cRenderAttn(); cRenderNight(); cRenderWeek();
+    toast('Corrected — '+r.date+' '+RESTS[r.rest]+' '+r.meal.toLowerCase()+' now splits '+money(perShare(r))+' each.');
+  }
+  else if(f.matches('[data-role="c-addform"]')){
+    e.preventDefault();
+    var nm=f.name.value.trim(); if(!nm) return;
+    addStaff(stC,nm,f.works.value); cDialogEl.close(); cRenderStaff();
+    $('#cStaffPanel').open=true;
+    toast(nm+' added — on the phone picker now, last in the order.');
+  }
+  else if(f.matches('[data-role="c-renform"]')){
+    e.preventDefault();
+    var s=stC.staff.find(function(x){return x.id===f.dataset.id;});
+    var nm2=f.nm.value.trim(); if(nm2) s.name=nm2;
+    stC.renaming=null; cRenderStaff();
+  }
+});
+
+/* ---------------- boot ---------------- */
+renderA(); renderB(); renderC();
+})();
+</script>
+</body>
+</html>

--- a/docs/mockups/tips-dashboard/claude-opus.html
+++ b/docs/mockups/tips-dashboard/claude-opus.html
@@ -1,0 +1,2210 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Babytuna — Tips manager dashboard · three design variants</title>
+<style>
+/* ============================================================
+   TOKENS
+   ============================================================ */
+:root{
+  --cream:#f5f1e8;
+  --paper:#ffffff;
+  --ink:#1a1a1a;
+  --ink2:#5f5f5f;
+  --muted:#9c9890;
+  --accent:#e84d38;       /* fills, rules, large numerals only */
+  --accent-deep:#c03520;  /* text + button fills (AA on white/cream) */
+  --accent-tint:#fbeae7;
+  --hair:rgba(0,0,0,0.06);
+  --hair-2:rgba(0,0,0,0.12);
+  --logged-bg:#efece3;    /* the "card / logged only" bucket */
+  --logged-ink:#6c6860;
+  --r-card:20px;
+  --r-in:14px;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;background:var(--cream);color:var(--ink);
+  font-family:var(--sans);font-size:14px;line-height:1.45;
+  font-variant-numeric:tabular-nums;
+}
+h1,h2,h3,h4{margin:0;font-weight:650;letter-spacing:-0.01em}
+p{margin:0}
+button{font:inherit;color:inherit;font-variant-numeric:tabular-nums}
+input,select{font:inherit;color:inherit;font-variant-numeric:tabular-nums}
+a{color:var(--accent-deep)}
+:focus-visible{outline:2.5px solid var(--accent-deep);outline-offset:2px;border-radius:4px}
+.sr{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0}
+.num{font-variant-numeric:tabular-nums}
+.mono{font-family:var(--mono)}
+
+/* ============================================================
+   APP CHROME + VARIANT SWITCHER
+   ============================================================ */
+.topbar{
+  position:sticky;top:0;z-index:60;background:var(--cream);
+  border-bottom:1px solid var(--hair-2);
+}
+.topbar-in{
+  max-width:1420px;margin:0 auto;padding:14px 28px 0;
+  display:flex;align-items:flex-start;gap:28px;flex-wrap:wrap;
+}
+.brand{display:flex;align-items:baseline;gap:10px;padding-bottom:14px}
+.brand-mark{
+  width:26px;height:26px;border-radius:8px;background:var(--accent);
+  display:grid;place-items:center;color:#fff;font-weight:700;font-size:13px;
+  align-self:center;
+}
+.brand-name{font-weight:650;font-size:15px}
+.brand-sub{color:var(--muted);font-size:12.5px}
+.switch{display:flex;gap:2px;margin-left:auto;align-self:flex-end}
+.switch button{
+  background:transparent;border:0;border-bottom:3px solid transparent;
+  padding:9px 18px 11px;cursor:pointer;color:var(--ink2);
+  font-weight:600;font-size:13.5px;border-radius:6px 6px 0 0;
+}
+.switch button:hover{color:var(--ink);background:rgba(0,0,0,0.03)}
+.switch button[aria-selected="true"]{color:var(--ink);border-bottom-color:var(--accent)}
+.switch .sw-idx{color:var(--muted);font-weight:600;margin-right:7px;font-size:12px}
+.switch button[aria-selected="true"] .sw-idx{color:var(--accent-deep)}
+
+main{max-width:1420px;margin:0 auto;padding:0 28px 120px}
+.panel[hidden]{display:none}
+.panel{padding-top:22px}
+
+/* thesis block — read before scrolling into the variant */
+.thesis{
+  border-left:4px solid var(--accent);background:var(--paper);
+  border-radius:6px var(--r-in) var(--r-in) 6px;padding:16px 22px 18px;
+  margin-bottom:24px;max-width:920px;
+}
+.thesis h2{font-size:19px;margin-bottom:5px}
+.thesis .kicker{
+  font-size:11px;letter-spacing:.11em;text-transform:uppercase;
+  color:var(--accent-deep);font-weight:700;margin-bottom:7px;
+}
+.thesis p{color:var(--ink2);font-size:14px;max-width:78ch}
+.thesis .tradeoff{margin-top:7px;color:var(--muted)}
+.thesis .tradeoff b{color:var(--ink2);font-weight:650}
+
+/* ============================================================
+   SHARED PRIMITIVES
+   ============================================================ */
+.card{background:var(--paper);border-radius:var(--r-card);border:1px solid var(--hair)}
+.sec-head{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-bottom:12px}
+.sec-head h3{font-size:16px}
+.sec-head .hint{color:var(--muted);font-size:12.5px}
+.sec-head .spacer{flex:1}
+
+.btn{
+  border:1px solid var(--hair-2);background:var(--paper);color:var(--ink);
+  border-radius:10px;padding:7px 13px;cursor:pointer;font-weight:600;font-size:13px;
+}
+.btn:hover{background:#faf8f4;border-color:rgba(0,0,0,.2)}
+.btn.primary{background:var(--accent-deep);border-color:var(--accent-deep);color:#fff}
+.btn.primary:hover{background:#a82d1b;border-color:#a82d1b}
+.btn.ghost{border-color:transparent;background:transparent;color:var(--ink2)}
+.btn.ghost:hover{background:rgba(0,0,0,.04);color:var(--ink)}
+.btn.danger{color:var(--accent-deep);border-color:rgba(192,53,32,.35);background:#fff}
+.btn.danger:hover{background:var(--accent-tint)}
+.btn.sm{padding:4px 9px;font-size:12px;border-radius:8px}
+.btn:disabled{opacity:.45;cursor:not-allowed}
+.btn-row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+
+.seg{display:inline-flex;background:rgba(0,0,0,.045);border-radius:10px;padding:3px}
+.seg button{
+  border:0;background:transparent;padding:6px 13px;border-radius:8px;
+  cursor:pointer;font-weight:600;font-size:12.5px;color:var(--ink2);
+}
+.seg button[aria-pressed="true"]{background:var(--paper);color:var(--ink);box-shadow:0 0 0 1px var(--hair)}
+.field{display:flex;flex-direction:column;gap:4px}
+.field label{font-size:11.5px;font-weight:650;color:var(--ink2);letter-spacing:.02em}
+.field input,.field select{
+  border:1px solid var(--hair-2);border-radius:10px;padding:7px 10px;background:var(--paper);
+}
+.field input:focus,.field select:focus{border-color:var(--accent-deep)}
+
+.tag{
+  display:inline-block;font-size:11px;font-weight:700;letter-spacing:.05em;
+  text-transform:uppercase;padding:2px 7px;border-radius:6px;
+  background:rgba(0,0,0,.05);color:var(--ink2);
+}
+.tag.flag{background:var(--accent-tint);color:var(--accent-deep)}
+.tag.off{background:rgba(0,0,0,.05);color:var(--muted)}
+
+/* the two money buckets — one motif, expressed differently per variant */
+.cash-ink{color:var(--ink);font-weight:650}
+.card-ink{color:var(--logged-ink)}
+.nosplit{
+  display:inline-flex;align-items:center;gap:5px;color:var(--logged-ink);
+  font-size:11.5px;font-weight:650;
+}
+.nosplit svg{flex:none}
+
+.legend{
+  display:flex;gap:22px;flex-wrap:wrap;align-items:center;
+  font-size:12.5px;color:var(--ink2);
+}
+.legend .sw{display:inline-block;width:11px;height:11px;border-radius:3px;margin-right:7px;vertical-align:-1px}
+.legend .sw.cash{background:var(--accent-tint);box-shadow:inset 0 0 0 1.5px var(--accent)}
+.legend .sw.card{background:var(--logged-bg);box-shadow:inset 0 0 0 1.5px rgba(0,0,0,.16)}
+
+table{border-collapse:collapse;width:100%}
+th{text-align:left;font-weight:650;color:var(--ink2)}
+caption{text-align:left}
+
+.toastwrap{position:fixed;left:24px;bottom:24px;z-index:200;display:flex;flex-direction:column;gap:8px}
+.toast{
+  background:var(--ink);color:#fff;padding:11px 16px;border-radius:12px;
+  font-size:13px;font-weight:500;max-width:420px;
+}
+.toast b{font-weight:700}
+
+/* ============================================================
+   VARIANT A — LEDGER
+   ============================================================ */
+.v-a .a-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:18px}
+.v-a .a-bar{
+  background:var(--paper);border:1px solid var(--hair);border-radius:var(--r-in);
+  padding:12px 16px;display:flex;gap:18px;align-items:flex-end;flex-wrap:wrap;
+}
+.v-a .a-bar .chips{display:flex;gap:6px;align-items:center}
+.v-a .chip{
+  border:1px solid var(--hair-2);background:var(--paper);border-radius:999px;
+  padding:5px 12px;font-size:12.5px;font-weight:600;cursor:pointer;color:var(--ink2);
+}
+.v-a .chip[aria-pressed="true"]{background:var(--ink);border-color:var(--ink);color:#fff}
+
+.v-a .a-totals{
+  display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:1px;
+  background:var(--hair-2);border:1px solid var(--hair-2);border-radius:var(--r-in);overflow:hidden;
+}
+.v-a .a-tot{background:var(--paper);padding:13px 16px}
+.v-a .a-tot.is-cash{background:var(--accent-tint)}
+.v-a .a-tot.is-card{background:var(--logged-bg)}
+.v-a .a-tot dt{font-size:11px;letter-spacing:.08em;text-transform:uppercase;font-weight:700;color:var(--ink2);margin-bottom:3px}
+.v-a .a-tot.is-cash dt{color:var(--accent-deep)}
+.v-a .a-tot dd{margin:0;font-size:26px;font-weight:650;letter-spacing:-.02em}
+.v-a .a-tot .sub{font-size:12px;color:var(--ink2);font-weight:500;margin-top:2px}
+.v-a .a-tot.is-card dd,.v-a .a-tot.is-card .sub{color:var(--logged-ink)}
+
+.v-a .a-chart{padding:14px 16px 10px}
+.v-a .a-chart figcaption{font-size:12.5px;color:var(--ink2);margin-bottom:8px}
+
+.v-a .a-tablewrap{overflow-x:auto}
+.v-a table.ledger{min-width:1080px;font-size:13.5px}
+.v-a table.ledger thead th{
+  position:sticky;top:69px;background:var(--paper);z-index:5;
+  font-size:11px;letter-spacing:.07em;text-transform:uppercase;
+  padding:9px 10px;border-bottom:1.5px solid var(--hair-2);white-space:nowrap;
+}
+.v-a table.ledger thead tr.grp th{
+  top:69px;padding:7px 10px 3px;border-bottom:0;font-size:10.5px;
+}
+.v-a table.ledger thead tr.cols th{top:94px}
+.v-a td.zone-cash{background:var(--accent-tint)}
+.v-a td.zone-card{background:var(--logged-bg);color:var(--logged-ink)}
+/* must outrank `.v-a table.ledger thead th` */
+.v-a table.ledger thead th.zone-cash{background:var(--accent-tint)}
+.v-a table.ledger thead th.zone-card{background:var(--logged-bg);color:var(--logged-ink)}
+.v-a th.zone-cash.first,.v-a td.zone-cash.first{border-left:2px solid var(--accent)}
+.v-a th.zone-card.first,.v-a td.zone-card.first{border-left:2px solid rgba(0,0,0,.18)}
+.v-a table.ledger tbody td{padding:9px 10px;border-bottom:1px solid var(--hair);vertical-align:middle}
+.v-a tr.daybreak td{
+  background:#f0ece2;font-weight:650;font-size:12px;padding:6px 10px;
+  border-bottom:1px solid var(--hair-2);border-top:1px solid var(--hair-2);
+  text-transform:uppercase;letter-spacing:.06em;color:var(--ink2);
+}
+.v-a tr.daybreak .dsum{float:right;font-weight:600;text-transform:none;letter-spacing:0;font-size:12.5px}
+.v-a tr.rec:hover td{background:#fbf9f5}
+.v-a tr.rec:hover td.zone-cash{background:#f8e2de}
+.v-a tr.rec:hover td.zone-card{background:#e9e5db}
+.v-a tr.rec.flagged td:first-child{box-shadow:inset 3px 0 0 var(--accent)}
+.v-a .pp{font-size:15px;font-weight:700}
+.v-a .divsign{color:var(--accent-deep);font-weight:700}
+.v-a .who{color:var(--ink2);font-size:12.5px}
+.v-a .meta{color:var(--muted);font-size:12px;white-space:nowrap}
+.v-a tr.totals td{
+  padding:11px 10px;font-weight:700;border-top:2px solid var(--hair-2);background:#faf8f4;
+}
+.v-a tr.totals td.zone-cash{background:#f8e2de}
+.v-a tr.totals td.zone-card{background:#e9e5db}
+.v-a tr.editrow td{padding:0;background:#fdfbf7}
+.v-a .edit-in{padding:16px 18px;border-top:2px solid var(--accent);border-bottom:2px solid var(--accent)}
+.v-a .edit-grid{display:grid;grid-template-columns:150px 150px minmax(260px,1fr) minmax(280px,340px);gap:20px;align-items:start}
+.v-a .ppl-box{display:flex;flex-wrap:wrap;gap:6px}
+.v-a .roundnote{font-size:12px;color:var(--muted);margin-top:8px}
+
+.chk{
+  display:inline-flex;align-items:center;gap:6px;border:1px solid var(--hair-2);
+  border-radius:999px;padding:5px 11px 5px 8px;cursor:pointer;font-size:13px;background:var(--paper);
+  font-weight:550;
+}
+.chk:hover{border-color:rgba(0,0,0,.25)}
+.chk input{accent-color:var(--accent-deep);margin:0}
+.chk.on{background:var(--accent-tint);border-color:var(--accent)}
+.chk.other{opacity:.72}
+
+.preview{background:var(--paper);border:1px solid var(--hair-2);border-radius:var(--r-in);padding:12px 14px}
+.preview h4{font-size:11px;letter-spacing:.07em;text-transform:uppercase;color:var(--ink2);margin-bottom:9px}
+.delta{display:flex;justify-content:space-between;gap:12px;padding:4px 0;border-bottom:1px dashed var(--hair)}
+.delta:last-child{border-bottom:0}
+.delta .nm{font-weight:600}
+.delta .vals{font-variant-numeric:tabular-nums}
+.delta .was{color:var(--muted);text-decoration:line-through;margin-right:7px}
+.delta .now{font-weight:700}
+.delta.up .now{color:var(--accent-deep)}
+.delta.down .now{color:#1a6b4a}
+.delta.gone .now{color:var(--muted);text-decoration:none}
+.warnline{
+  background:var(--accent-tint);border-radius:10px;padding:9px 12px;color:var(--accent-deep);
+  font-size:12.5px;font-weight:600;margin-top:10px;
+}
+
+.v-a .a-two{display:grid;grid-template-columns:minmax(0,1.35fr) minmax(0,1fr);gap:18px}
+@media (max-width:1180px){.v-a .a-two{grid-template-columns:minmax(0,1fr)}.v-a .a-totals{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.v-a table.staff{font-size:13.5px}
+.v-a table.staff th{font-size:11px;letter-spacing:.07em;text-transform:uppercase;padding:8px 10px;border-bottom:1.5px solid var(--hair-2)}
+.v-a table.staff td{padding:7px 10px;border-bottom:1px solid var(--hair)}
+.v-a tr.newrow td{background:var(--accent-tint);border-bottom:2px solid var(--accent)}
+.v-a tr.inactive td{color:var(--muted)}
+.v-a .ordbtns{display:inline-flex;gap:2px}
+.v-a .ordbtn{
+  border:1px solid var(--hair-2);background:var(--paper);width:24px;height:24px;
+  border-radius:6px;cursor:pointer;line-height:1;padding:0;color:var(--ink2);
+}
+.v-a .ordbtn:hover:not(:disabled){background:#f2efe8;color:var(--ink)}
+.v-a .acc-t td{padding:9px 10px;border-bottom:1px solid var(--hair);font-size:13px}
+.v-a .acc-t th{font-size:11px;letter-spacing:.07em;text-transform:uppercase;padding:8px 10px;border-bottom:1.5px solid var(--hair-2)}
+.v-a .danger-zone{border-top:1px solid var(--hair-2);margin-top:2px;padding:12px 16px 14px;background:#fbf9f5;border-radius:0 0 var(--r-card) var(--r-card)}
+.v-a .never{color:var(--accent-deep);font-weight:650}
+.confirmbar{
+  background:var(--accent-tint);border:1.5px solid var(--accent);border-radius:var(--r-in);
+  padding:11px 14px;margin-top:10px;display:flex;gap:14px;align-items:center;flex-wrap:wrap;
+}
+.confirmbar p{font-size:13px;color:var(--accent-deep);font-weight:600;flex:1;min-width:260px}
+
+/* one-time reveal — shared shell, three different framings */
+.reveal{
+  border:2px solid var(--accent);border-radius:var(--r-in);background:var(--paper);
+  padding:14px 16px;margin-top:10px;
+}
+.reveal .once{
+  display:inline-flex;align-items:center;gap:7px;font-size:11px;font-weight:800;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--accent-deep);margin-bottom:9px;
+}
+.secret{
+  font-family:var(--mono);font-size:19px;font-weight:600;letter-spacing:.06em;
+  background:#f7f4ee;border:1px dashed var(--hair-2);border-radius:10px;
+  padding:11px 14px;word-break:break-all;
+}
+.ackline{display:flex;align-items:center;gap:9px;margin-top:11px;flex-wrap:wrap}
+.ackline label{font-size:13px;font-weight:600;display:inline-flex;gap:7px;align-items:center;cursor:pointer}
+.ackline input{accent-color:var(--accent-deep)}
+
+/* ============================================================
+   VARIANT B — NIGHTLY
+   ============================================================ */
+.v-b{max-width:1120px}
+.v-b .b-hero{margin-bottom:20px}
+.v-b .b-hero-head{display:flex;align-items:baseline;gap:12px;margin-bottom:10px;flex-wrap:wrap}
+.v-b .b-hero-head h3{font-size:20px}
+.v-b .b-hero-head .when{color:var(--muted);font-size:13px}
+.v-b .b-tiles{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}
+@media (max-width:1100px){.v-b .b-tiles{grid-template-columns:repeat(2,minmax(0,1fr))}}
+.v-b .tile{background:var(--paper);border:1px solid var(--hair);border-radius:var(--r-card);padding:16px 18px 14px}
+.v-b .tile .where{display:flex;align-items:center;gap:8px;margin-bottom:12px}
+.v-b .dot{width:9px;height:9px;border-radius:3px;flex:none}
+.v-b .dot.sushi{background:var(--accent)}
+.v-b .dot.poki{background:#2f7d68}
+.v-b .tile .where b{font-size:13.5px;font-weight:650}
+.v-b .tile .where .meal{color:var(--muted);font-size:12.5px}
+.v-b .pp-big{font-size:34px;font-weight:650;letter-spacing:-.025em;line-height:1.05}
+.v-b .pp-cap{font-size:12px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;color:var(--accent-deep);margin-bottom:2px}
+.v-b .pp-math{color:var(--ink2);font-size:13px;margin-top:6px}
+.v-b .tile .cardline{
+  margin-top:12px;padding-top:10px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;align-items:center;gap:10px;
+}
+.v-b .tile .cardline .amt{color:var(--logged-ink);font-weight:650}
+.v-b .names{color:var(--ink2);font-size:12.5px;margin-top:3px}
+
+.v-b .attention{
+  background:var(--accent-tint);border:1.5px solid var(--accent);border-radius:var(--r-in);
+  padding:13px 16px;display:flex;gap:16px;align-items:center;flex-wrap:wrap;margin-bottom:18px;
+}
+.v-b .attention .txt{flex:1;min-width:340px}
+.v-b .attention b{color:var(--accent-deep)}
+.v-b .attention .sub{color:var(--ink2);font-size:13px;margin-top:2px}
+
+.v-b .b-controls{
+  display:flex;gap:16px;align-items:flex-end;flex-wrap:wrap;
+  padding:12px 16px;background:var(--paper);border:1px solid var(--hair);border-radius:var(--r-in);margin-bottom:14px;
+}
+.v-b .day{background:var(--paper);border:1px solid var(--hair);border-radius:var(--r-card);margin-bottom:12px;overflow:hidden}
+.v-b .day-head{
+  display:flex;align-items:baseline;gap:14px;padding:12px 18px;background:#faf8f4;
+  border-bottom:1px solid var(--hair);flex-wrap:wrap;
+}
+.v-b .day-head h4{font-size:14.5px}
+.v-b .day-head .sum{margin-left:auto;display:flex;gap:18px;font-size:12.5px;color:var(--ink2)}
+.v-b .day-head .sum b{color:var(--ink)}
+.v-b .shift{
+  display:grid;grid-template-columns:minmax(180px,1.1fr) minmax(150px,.9fr) minmax(130px,.7fr) minmax(150px,.8fr) auto;
+  gap:16px;align-items:center;padding:13px 18px;border-bottom:1px solid var(--hair);
+  width:100%;text-align:left;background:transparent;border-left:0;border-right:0;border-top:0;cursor:pointer;
+}
+.v-b .shift:last-child{border-bottom:0}
+/* each grid cell stacks its label over its value */
+.v-b .shift>span{display:flex;flex-direction:column;min-width:0}
+.v-b .shift .lbl{display:block}
+.v-b .shift .chev{justify-content:center}
+.v-b .shift:hover{background:#fbf9f5}
+.v-b .shift.flagged{background:#fdf4f2}
+.v-b .shift.flagged:hover{background:#fbeae7}
+.v-b .shift .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);font-weight:700;margin-bottom:1px}
+.v-b .shift .cash-amt{font-size:16px;font-weight:650}
+.v-b .shift .pp-amt{font-size:16px;font-weight:700;color:var(--ink)}
+.v-b .shift .card-amt{font-size:15px;font-weight:600;color:var(--logged-ink)}
+.v-b .shift .cash-cell{border-left:3px solid var(--accent);padding-left:11px}
+.v-b .shift .card-cell{border-left:3px solid rgba(0,0,0,.16);padding-left:11px}
+.v-b .chev{color:var(--muted);font-size:18px;line-height:1}
+
+.v-b .b-sec{margin-top:26px}
+.v-b .roster{padding:6px 0}
+.v-b .rline{display:flex;align-items:center;gap:14px;padding:10px 18px;border-bottom:1px solid var(--hair)}
+.v-b .rline:last-child{border-bottom:0}
+.v-b .rline .grip{color:var(--muted);font-size:12px;width:22px}
+.v-b .rline .nm{font-weight:650;min-width:90px}
+.v-b .rline .at{color:var(--ink2);font-size:13px}
+.v-b .rline .rt{margin-left:auto;display:flex;gap:6px;align-items:center}
+.v-b .rline.inactive .nm,.v-b .rline.inactive .at{color:var(--muted)}
+.v-b .addbox{padding:16px 18px;background:var(--accent-tint);border-bottom:1px solid var(--hair)}
+.v-b .addgrid{display:grid;grid-template-columns:minmax(0,1.2fr) minmax(0,1fr) minmax(0,1fr) auto;gap:12px;align-items:end}
+.v-b .grouplabel{
+  padding:10px 18px 4px;font-size:11px;letter-spacing:.08em;text-transform:uppercase;
+  color:var(--muted);font-weight:700;
+}
+.v-b details.access{background:var(--paper);border:1px solid var(--hair);border-radius:var(--r-card)}
+.v-b details.access>summary{
+  padding:15px 20px;cursor:pointer;font-weight:650;display:flex;align-items:center;gap:10px;list-style:none;
+}
+.v-b details.access>summary::-webkit-details-marker{display:none}
+.v-b details.access>summary .mk{color:var(--muted);font-size:12px;transition:transform .15s}
+.v-b details.access[open]>summary .mk{transform:rotate(90deg)}
+.v-b details.access>summary .sub{color:var(--muted);font-weight:500;font-size:12.5px;margin-left:auto}
+.v-b .accbody{padding:4px 20px 20px;border-top:1px solid var(--hair)}
+.v-b .accrest{padding:16px 0;border-bottom:1px solid var(--hair)}
+.v-b .accrest:last-child{border-bottom:0}
+.v-b .accrow{display:flex;gap:16px;align-items:center;padding:9px 0;flex-wrap:wrap}
+.v-b .accrow .what{min-width:230px}
+.v-b .accrow .what b{display:block;font-size:13.5px}
+.v-b .accrow .what span{color:var(--muted);font-size:12.5px}
+
+/* drawer */
+.scrim{position:fixed;inset:0;background:rgba(26,26,26,.34);z-index:100;opacity:0;animation:fade .16s forwards}
+@keyframes fade{to{opacity:1}}
+.drawer{
+  position:fixed;top:0;right:0;bottom:0;width:min(520px,94vw);background:var(--cream);
+  z-index:101;box-shadow:-1px 0 0 var(--hair-2);display:flex;flex-direction:column;
+  transform:translateX(100%);animation:slide .2s forwards;
+}
+@keyframes slide{to{transform:translateX(0)}}
+@media (prefers-reduced-motion:reduce){.scrim,.drawer{animation:none;opacity:1;transform:none}}
+.drawer-head{padding:18px 22px 14px;border-bottom:1px solid var(--hair-2);display:flex;align-items:flex-start;gap:12px}
+.drawer-head h3{font-size:17px}
+.drawer-head .sub{color:var(--ink2);font-size:13px;margin-top:2px}
+.drawer-body{overflow-y:auto;padding:18px 22px;flex:1}
+.drawer-foot{padding:14px 22px;border-top:1px solid var(--hair-2);background:var(--paper);display:flex;gap:10px;align-items:center}
+.drawer-foot .spacer{flex:1}
+.stepdots{display:flex;gap:6px;align-items:center;font-size:12px;color:var(--muted);font-weight:600}
+.xbtn{border:0;background:transparent;font-size:20px;line-height:1;cursor:pointer;color:var(--ink2);padding:2px 6px;border-radius:8px}
+.xbtn:hover{background:rgba(0,0,0,.05);color:var(--ink)}
+.blk{background:var(--paper);border:1px solid var(--hair);border-radius:var(--r-in);padding:14px 16px;margin-bottom:14px}
+.blk h4{font-size:11px;letter-spacing:.07em;text-transform:uppercase;color:var(--ink2);margin-bottom:10px}
+.money-in{position:relative}
+.money-in span{position:absolute;left:11px;top:50%;transform:translateY(-50%);color:var(--muted);font-weight:600}
+.money-in input{padding-left:24px;width:100%;font-size:16px;font-weight:600}
+.readonly-line{display:flex;justify-content:space-between;padding:5px 0;border-bottom:1px dashed var(--hair);font-size:13.5px}
+.readonly-line:last-child{border-bottom:0}
+.readonly-line .k{color:var(--ink2)}
+.readonly-line .v{font-weight:650}
+
+/* ============================================================
+   VARIANT C — PAYOUT
+   ============================================================ */
+.v-c .c-top{
+  display:flex;gap:18px;align-items:flex-end;flex-wrap:wrap;margin-bottom:18px;
+  padding:14px 18px;background:var(--paper);border:1px solid var(--hair);border-radius:var(--r-in);
+}
+.v-c .c-cols{display:grid;grid-template-columns:minmax(0,1.15fr) minmax(0,1fr);gap:20px;align-items:start}
+@media (max-width:1180px){.v-c .c-cols{grid-template-columns:minmax(0,1fr)}}
+.v-c .payhead{padding:18px 20px 14px;border-bottom:1px solid var(--hair)}
+.v-c .payhead .cap{font-size:11px;letter-spacing:.1em;text-transform:uppercase;font-weight:800;color:var(--accent-deep)}
+.v-c .payhead .big{font-size:38px;font-weight:650;letter-spacing:-.03em;line-height:1.1;margin-top:4px}
+.v-c .payhead .note{color:var(--ink2);font-size:13px;margin-top:4px}
+.v-c .person{border-bottom:1px solid var(--hair)}
+.v-c .person:last-child{border-bottom:0}
+.v-c .pbtn{
+  width:100%;display:flex;align-items:center;gap:14px;padding:13px 20px;background:transparent;
+  border:0;cursor:pointer;text-align:left;
+}
+.v-c .pbtn:hover{background:#fbf9f5}
+.v-c .avatar{
+  width:34px;height:34px;border-radius:11px;background:var(--accent-tint);color:var(--accent-deep);
+  display:grid;place-items:center;font-weight:700;font-size:14px;flex:none;
+}
+.v-c .avatar.poki{background:#e2efe9;color:#1f5c4c}
+.v-c .avatar.both{background:linear-gradient(90deg,var(--accent-tint) 50%,#e2efe9 50%);color:var(--ink)}
+.v-c .pname{font-weight:650;font-size:14.5px}
+.v-c .pmeta{color:var(--muted);font-size:12.5px}
+/* these live inside inline spans — stack them explicitly */
+.v-c .pname,.v-c .pmeta,.v-c .pamt .n,.v-c .pamt .s{display:block}
+.v-c .pamt{margin-left:auto;text-align:right}
+.v-c .pamt .n{font-size:19px;font-weight:700}
+.v-c .pamt .s{color:var(--muted);font-size:12px}
+.v-c .pdetail{padding:2px 20px 16px 68px;background:#fbf9f5;border-top:1px dashed var(--hair)}
+.v-c .pdrow{display:flex;gap:14px;padding:7px 0;border-bottom:1px dashed var(--hair);font-size:13px;align-items:center}
+.v-c .pdrow:last-child{border-bottom:0}
+.v-c .pdrow .d{color:var(--ink2);min-width:130px}
+.v-c .pdrow .m{color:var(--muted);flex:1}
+.v-c .pdrow .a{font-weight:650}
+.v-c .recon{
+  padding:14px 20px;background:#faf8f4;border-top:1px solid var(--hair);font-size:12.5px;color:var(--ink2);
+  border-radius:0 0 var(--r-card) var(--r-card);
+}
+.v-c .recon dl{display:grid;grid-template-columns:auto auto;gap:3px 16px;margin:0 0 7px}
+.v-c .recon dt{color:var(--ink2)}
+.v-c .recon dd{margin:0;font-weight:650;text-align:right}
+
+.v-c .quarantine{
+  background:var(--logged-bg);border:1px solid rgba(0,0,0,.1);border-radius:var(--r-card);
+  padding:16px 18px;
+}
+.v-c .quarantine .qh{display:flex;align-items:center;gap:9px;margin-bottom:4px}
+.v-c .quarantine h3{font-size:14.5px;color:#3d3a34}
+.v-c .quarantine .qtot{font-size:28px;font-weight:650;color:#3d3a34;letter-spacing:-.02em;margin-top:6px}
+.v-c .quarantine p{color:var(--logged-ink);font-size:12.5px;max-width:52ch}
+.v-c .qbreak{display:flex;gap:22px;margin-top:12px;padding-top:11px;border-top:1px solid rgba(0,0,0,.09);flex-wrap:wrap}
+.v-c .qbreak div{font-size:12.5px;color:var(--logged-ink)}
+.v-c .qbreak b{display:block;font-size:16px;color:#3d3a34}
+
+.v-c .reclist .rrow{
+  display:grid;grid-template-columns:minmax(120px,.9fr) minmax(150px,1.1fr) minmax(90px,.7fr) minmax(90px,.7fr) auto;
+  gap:12px;align-items:center;padding:11px 18px;border-bottom:1px solid var(--hair);font-size:13px;
+}
+.v-c .reclist .rrow:last-child{border-bottom:0}
+.v-c .reclist .rrow.flagged{background:#fdf4f2;box-shadow:inset 3px 0 0 var(--accent)}
+.v-c .reclist .rhead{
+  display:grid;grid-template-columns:minmax(120px,.9fr) minmax(150px,1.1fr) minmax(90px,.7fr) minmax(90px,.7fr) auto;
+  gap:12px;padding:9px 18px;border-bottom:1.5px solid var(--hair-2);
+  font-size:10.5px;letter-spacing:.07em;text-transform:uppercase;font-weight:700;color:var(--ink2);
+}
+.v-c .reclist .cashv{font-weight:650}
+.v-c .reclist .cardv{color:var(--logged-ink)}
+.v-c .rrow .ppl{color:var(--ink2);font-size:12.5px}
+
+.v-c .keys{position:relative}
+.v-c .keys.locked .keybody{opacity:.42;pointer-events:none;filter:saturate(.3)}
+.v-c .lockbar{
+  display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--hair);flex-wrap:wrap;
+}
+.v-c .lockbar .lk{flex:1;min-width:240px}
+.v-c .lockbar b{font-size:14px}
+.v-c .lockbar span{display:block;color:var(--muted);font-size:12.5px}
+.v-c .keyrow{display:flex;align-items:center;gap:14px;padding:12px 18px;border-bottom:1px solid var(--hair);flex-wrap:wrap}
+.v-c .keyrow:last-child{border-bottom:0}
+.v-c .keyrow .kw{min-width:210px}
+.v-c .keyrow .kw b{display:block;font-size:13.5px}
+.v-c .keyrow .kw span{color:var(--muted);font-size:12.5px}
+.v-c .keyrow .kb{margin-left:auto;display:flex;gap:8px}
+
+/* modal */
+.modal{
+  position:fixed;z-index:101;top:50%;left:50%;transform:translate(-50%,-50%);
+  width:min(720px,94vw);max-height:88vh;overflow:auto;background:var(--cream);
+  border-radius:var(--r-card);border:1px solid var(--hair-2);
+}
+.modal-head{padding:20px 24px 16px;border-bottom:1px solid var(--hair-2);display:flex;gap:14px;align-items:flex-start}
+.modal-head h3{font-size:18px}
+.modal-head .sub{color:var(--ink2);font-size:13px;margin-top:3px}
+.modal-body{padding:20px 24px}
+.modal-foot{padding:15px 24px;border-top:1px solid var(--hair-2);display:flex;gap:10px;align-items:center;background:var(--paper);border-radius:0 0 var(--r-card) var(--r-card)}
+.modal-foot .spacer{flex:1}
+.difftable{width:100%;font-size:13.5px;background:var(--paper);border-radius:var(--r-in);overflow:hidden;border:1px solid var(--hair)}
+.difftable th{font-size:10.5px;letter-spacing:.07em;text-transform:uppercase;padding:9px 14px;border-bottom:1px solid var(--hair-2);background:#faf8f4}
+.difftable td{padding:10px 14px;border-bottom:1px solid var(--hair)}
+.difftable tr:last-child td{border-bottom:0}
+.difftable .was{color:var(--muted);text-decoration:line-through}
+.difftable .now{font-weight:700}
+.difftable .up .now{color:var(--accent-deep)}
+.difftable .down .now{color:#1a6b4a}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+@media (max-width:640px){.grid2{grid-template-columns:1fr}}
+
+/* takeover (variant C one-time reveal) */
+.takeover{
+  position:fixed;inset:0;z-index:150;background:var(--cream);
+  display:grid;place-items:center;padding:32px;overflow:auto;
+}
+.takeover .sheet{width:min(640px,100%);background:var(--paper);border-radius:var(--r-card);border:2px solid var(--accent);padding:28px 32px 26px}
+.takeover .once{
+  display:inline-flex;gap:8px;align-items:center;background:var(--accent-tint);color:var(--accent-deep);
+  border-radius:999px;padding:6px 14px;font-size:11.5px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;
+}
+.takeover h3{font-size:24px;margin:16px 0 6px;letter-spacing:-.02em}
+.takeover .lede{color:var(--ink2);font-size:14px;max-width:56ch}
+.checklist{margin:20px 0 0;padding:0;list-style:none}
+.checklist li{border-top:1px solid var(--hair);padding:12px 0}
+.checklist label{display:flex;gap:11px;align-items:flex-start;cursor:pointer;font-size:14px;font-weight:600}
+.checklist input{margin-top:3px;accent-color:var(--accent-deep);width:17px;height:17px}
+.checklist .sub{display:block;font-weight:400;color:var(--ink2);font-size:12.5px;margin-top:2px}
+.qrbox{display:flex;gap:22px;align-items:center;margin-top:18px;flex-wrap:wrap}
+.qrbox svg{border:1px solid var(--hair-2);border-radius:12px;background:#fff;padding:8px;flex:none}
+</style>
+</head>
+<body>
+
+<a class="sr" href="#main">Skip to dashboard</a>
+
+<header class="topbar">
+  <div class="topbar-in">
+    <div class="brand">
+      <div class="brand-mark" aria-hidden="true">B</div>
+      <div>
+        <div class="brand-name">Babytuna — Tips</div>
+        <div class="brand-sub">Manager view · Sushi + Poki &amp; Pho</div>
+      </div>
+    </div>
+    <div class="switch" role="tablist" aria-label="Design variant">
+      <button role="tab" id="t-a" aria-controls="p-a" aria-selected="true"  data-v="a"><span class="sw-idx">01</span>Ledger</button>
+      <button role="tab" id="t-b" aria-controls="p-b" aria-selected="false" data-v="b" tabindex="-1"><span class="sw-idx">02</span>Nightly</button>
+      <button role="tab" id="t-c" aria-controls="p-c" aria-selected="false" data-v="c" tabindex="-1"><span class="sw-idx">03</span>Payout</button>
+    </div>
+  </div>
+</header>
+
+<main id="main">
+
+  <section class="panel v-a" id="p-a" role="tabpanel" aria-labelledby="t-a" tabindex="-1">
+    <div class="thesis">
+      <div class="kicker">Variant 01</div>
+      <h2>Ledger</h2>
+      <p>Optimizes for the owner who already knows what he is looking for: every record, every total, and both money buckets are on screen at once in one dense table, and corrections happen inline in the row without leaving the grid.</p>
+      <p class="tradeoff"><b>Trades away:</b> comfort and guidance. Nothing is progressively disclosed, so a first shift with it is busy, and the four areas compete for attention rather than taking turns.</p>
+    </div>
+    <div id="body-a"></div>
+  </section>
+
+  <section class="panel v-b" id="p-b" role="tabpanel" aria-labelledby="t-b" tabindex="-1" hidden>
+    <div class="thesis">
+      <div class="kicker">Variant 02</div>
+      <h2>Nightly</h2>
+      <p>Optimizes for the twenty-second morning glance — last night answers itself before any scrolling, days are the unit of reading, and a correction opens a drawer that makes you look at whose pay changes before it will let you save.</p>
+      <p class="tradeoff"><b>Trades away:</b> density and range work. You cannot scan a month at a glance, and each record costs a click to inspect.</p>
+    </div>
+    <div id="body-b"></div>
+  </section>
+
+  <section class="panel v-c" id="p-c" role="tabpanel" aria-labelledby="t-c" tabindex="-1" hidden>
+    <div class="thesis">
+      <div class="kicker">Variant 03</div>
+      <h2>Payout</h2>
+      <p>Reorganizes the page around the question the cash actually answers — what each person is owed — and demotes shift records to the evidence behind it, with card tips quarantined in a visually separate bucket that can never be mistaken for the split.</p>
+      <p class="tradeoff"><b>Trades away:</b> the familiar shift-first model. "What did Saturday dinner do?" becomes a secondary lookup, and the owner has to learn a structure that does not match the phone app he already knows.</p>
+    </div>
+    <div id="body-c"></div>
+  </section>
+
+</main>
+
+<div class="toastwrap" id="toasts" role="status" aria-live="polite"></div>
+<div id="overlay"></div>
+
+<script>
+"use strict";
+
+/* ============================================================
+   DATA — one seed, cloned per variant so play in one variant
+   never changes the numbers a reviewer sees in another.
+   ============================================================ */
+const TODAY = "2026-08-10";
+const TODAY_LABEL = "Aug 10, 2026";
+
+const STAFF_SEED = [
+  {id:"maria", name:"Maria", at:"sushi", active:true},
+  {id:"jose",  name:"Jose",  at:"sushi", active:true},
+  {id:"ken",   name:"Ken",   at:"both",  active:true},
+  {id:"rey",   name:"Rey",   at:"both",  active:true},
+  {id:"lena",  name:"Lena",  at:"poki",  active:true},
+  {id:"tom",   name:"Tom",   at:"poki",  active:true},
+  {id:"aiko",  name:"Aiko",  at:"sushi", active:false}
+];
+
+/* cash / card held in integer cents throughout */
+const REC_SEED = [
+  {id:"r1",  date:"2026-08-09", dow:"Sun", rest:"sushi", meal:"dinner", cash:41200,  card:68850, people:["maria","jose","ken"], by:"Maria", how:"typed", flag:false},
+  {id:"r2",  date:"2026-08-09", dow:"Sun", rest:"sushi", meal:"lunch",  cash:9625,   card:21000, people:["maria","ken"],         by:"Ken",   how:"voice", flag:false},
+  {id:"r3",  date:"2026-08-09", dow:"Sun", rest:"poki",  meal:"dinner", cash:18800,  card:40275, people:["lena","tom"],          by:"Lena",  how:"typed", flag:false},
+  {id:"r4",  date:"2026-08-08", dow:"Sat", rest:"sushi", meal:"dinner", cash:36650,  card:59400, people:["jose","ken","rey"],    by:"Jose",  how:"typed", flag:false},
+  {id:"r5",  date:"2026-08-08", dow:"Sat", rest:"poki",  meal:"dinner", cash:20575,  card:38800, people:["lena","tom","rey"],    by:"Tom",   how:"voice", flag:false},
+  {id:"r6",  date:"2026-08-08", dow:"Sat", rest:"poki",  meal:"lunch",  cash:7400,   card:16525, people:["lena"],               by:"Lena",  how:"typed", flag:false},
+  {id:"r7",  date:"2026-08-07", dow:"Fri", rest:"sushi", meal:"dinner", cash:310000, card:61000, people:["maria","jose"],        by:"Jose",  how:"voice", flag:true},
+  {id:"r8",  date:"2026-08-07", dow:"Fri", rest:"sushi", meal:"lunch",  cash:8850,   card:17400, people:["maria"],              by:"Maria", how:"typed", flag:false},
+  {id:"r9",  date:"2026-08-07", dow:"Fri", rest:"poki",  meal:"dinner", cash:19725,  card:35150, people:["tom","rey"],           by:"Rey",   how:"typed", flag:false},
+  {id:"r10", date:"2026-08-06", dow:"Thu", rest:"sushi", meal:"dinner", cash:34400,  card:56125, people:["maria","jose","ken"],  by:"Maria", how:"typed", flag:false}
+];
+
+const ACCESS_SEED = {
+  sushi:{qr:"Aug 8, 2026", pin:"Aug 8, 2026", phones:3},
+  poki: {qr:null,          pin:"Aug 8, 2026", phones:2}
+};
+
+const REST = {
+  sushi:{name:"Babytuna Sushi", short:"Sushi"},
+  poki: {name:"Babytuna Poki & Pho", short:"Poki & Pho"}
+};
+
+/* ============================================================
+   MONEY + THE SPLIT RULE
+   Per-person share = cash ÷ people, half-cent rounds UP.
+   Card never enters this function. That is the whole rule.
+   ============================================================ */
+function share(cashCents, n){
+  if(!n) return 0;
+  return Math.floor(cashCents / n + 0.5);
+}
+function money(c){
+  const neg = c < 0; c = Math.abs(c);
+  const s = (c/100).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return (neg ? "-$" : "$") + s;
+}
+function plain(c){ return (c/100).toFixed(2); }
+function parseMoney(str){
+  const v = parseFloat(String(str).replace(/[^0-9.\-]/g,""));
+  if(!isFinite(v) || v < 0) return null;
+  return Math.round(v*100);
+}
+function esc(s){ return String(s).replace(/[&<>"]/g, m => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[m])); }
+function clone(o){ return JSON.parse(JSON.stringify(o)); }
+function dLabel(r){ return r.dow + " " + monthName(r.date) + " " + Number(r.date.slice(8,10)); }
+function monthName(iso){
+  return ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][Number(iso.slice(5,7))-1];
+}
+function nameOf(st, id){ const p = st.staff.find(s=>s.id===id); return p ? p.name : id; }
+function namesOf(st, ids){ return ids.map(i=>nameOf(st,i)).join(", "); }
+function mealName(m){ return m === "lunch" ? "Lunch" : "Dinner"; }
+
+/* typical range for a (restaurant, meal) slot, ignoring flagged rows —
+   this is what makes the flag explainable rather than just decorative */
+function typicalRange(st, rec){
+  const peers = st.records.filter(r => r.rest===rec.rest && r.meal===rec.meal && !r.flag && r.id!==rec.id);
+  if(peers.length < 2) return null;
+  const vals = peers.map(r=>r.cash).sort((a,b)=>a-b);
+  return {lo:vals[0], hi:vals[vals.length-1]};
+}
+
+const NOSPLIT_ICON =
+  '<svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true">' +
+  '<circle cx="8" cy="8" r="6.4" fill="none" stroke="currentColor" stroke-width="1.6"/>' +
+  '<line x1="3.6" y1="12.4" x2="12.4" y2="3.6" stroke="currentColor" stroke-width="1.6"/></svg>';
+
+/* ============================================================
+   PER-VARIANT STATE
+   ============================================================ */
+function freshState(){
+  return {
+    staff: clone(STAFF_SEED),
+    records: clone(REC_SEED),
+    access: clone(ACCESS_SEED),
+    filters:{from:"2026-08-04", to:"2026-08-10", rest:"all", preset:"7d"},
+    ui:{}
+  };
+}
+const S = {a:freshState(), b:freshState(), c:freshState()};
+const scrollMem = {a:0,b:0,c:0};
+let current = "a";
+
+function visible(st){
+  return st.records.filter(r =>
+    r.date >= st.filters.from && r.date <= st.filters.to &&
+    (st.filters.rest === "all" || r.rest === st.filters.rest)
+  );
+}
+function totals(rows){
+  const cash = rows.reduce((a,r)=>a+r.cash,0);
+  const card = rows.reduce((a,r)=>a+r.card,0);
+  const dist = rows.reduce((a,r)=>a+share(r.cash,r.people.length)*r.people.length,0);
+  return {cash, card, dist, n:rows.length};
+}
+function byDay(rows){
+  const map = new Map();
+  rows.forEach(r => { if(!map.has(r.date)) map.set(r.date, []); map.get(r.date).push(r); });
+  return [...map.entries()].sort((a,b)=> a[0] < b[0] ? 1 : -1);
+}
+function payouts(st, rows){
+  const m = new Map();
+  rows.forEach(r => {
+    const per = share(r.cash, r.people.length);
+    r.people.forEach(pid => {
+      if(!m.has(pid)) m.set(pid, {id:pid, total:0, lines:[]});
+      const e = m.get(pid);
+      e.total += per;
+      e.lines.push({rec:r, amt:per});
+    });
+  });
+  return [...m.values()].sort((a,b)=> b.total - a.total);
+}
+
+/* ============================================================
+   TOASTS
+   ============================================================ */
+function toast(html){
+  const wrap = document.getElementById("toasts");
+  const el = document.createElement("div");
+  el.className = "toast";
+  el.innerHTML = html;
+  wrap.appendChild(el);
+  setTimeout(()=>{ el.remove(); }, 5200);
+}
+
+/* ============================================================
+   SECRETS + QR (offline, deterministic-looking, no network)
+   ============================================================ */
+function newToken(rest){
+  const A = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+  let s = "";
+  for(let i=0;i<12;i++){
+    if(i && i%4===0) s += "-";
+    s += A[Math.floor(Math.random()*A.length)];
+  }
+  return "BT-" + (rest==="sushi" ? "SUS" : "PKP") + "-" + s;
+}
+function newPin(){
+  let s = "";
+  for(let i=0;i<6;i++) s += Math.floor(Math.random()*10);
+  return s;
+}
+function hashStr(s){
+  let h = 2166136261;
+  for(let i=0;i<s.length;i++){ h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}
+function qrSvg(seed, px){
+  const n = 25, q = 1, total = n + q*2;
+  let h = hashStr(seed) || 1;
+  const rnd = () => { h ^= h<<13; h>>>=0; h ^= h>>17; h ^= h<<5; h>>>=0; return h/4294967296; };
+  const grid = [];
+  for(let y=0;y<n;y++){ grid.push([]); for(let x=0;x<n;x++) grid[y].push(rnd() > 0.5 ? 1 : 0); }
+  const finder = (ox, oy) => {
+    for(let y=0;y<7;y++) for(let x=0;x<7;x++){
+      const edge = (x===0||x===6||y===0||y===6);
+      const core = (x>=2&&x<=4&&y>=2&&y<=4);
+      grid[oy+y][ox+x] = (edge||core) ? 1 : 0;
+    }
+    for(let i=0;i<8;i++){
+      if(oy+7 < n && ox+i < n) grid[oy+7][ox+i] = 0;
+      if(ox+7 < n && oy+i < n) grid[oy+i][ox+7] = 0;
+    }
+  };
+  finder(0,0); finder(n-7,0); finder(0,n-7);
+  let rects = "";
+  for(let y=0;y<n;y++) for(let x=0;x<n;x++)
+    if(grid[y][x]) rects += '<rect x="'+(x+q)+'" y="'+(y+q)+'" width="1" height="1"/>';
+  return '<svg width="'+px+'" height="'+px+'" viewBox="0 0 '+total+' '+total+'" role="img" ' +
+         'aria-label="New QR sticker code"><rect width="'+total+'" height="'+total+'" fill="#fff"/>' +
+         '<g fill="#1a1a1a" shape-rendering="crispEdges">'+rects+'</g></svg>';
+}
+
+/* ============================================================
+   CSV EXPORT — real, via data: URI, works offline
+   ============================================================ */
+function exportCsv(v){
+  const st = S[v];
+  const rows = visible(st);
+  const head = ["Business date","Restaurant","Meal","Cash pool (split)","Card (logged, not split)","People","Per person","Flagged","Closed by","Method"];
+  /* one header contains a comma — quote them all or the columns shift */
+  const lines = [head.map(h => '"' + h + '"').join(",")];
+  rows.forEach(r => {
+    lines.push([
+      dLabel(r), REST[r.rest].short, mealName(r.meal),
+      plain(r.cash), plain(r.card),
+      '"' + namesOf(st, r.people) + '"',
+      plain(share(r.cash, r.people.length)),
+      r.flag ? "FLAGGED" : "", r.by, r.how
+    ].join(","));
+  });
+  const t = totals(rows);
+  lines.push(["TOTAL","","",plain(t.cash),plain(t.card),"","","","",""].join(","));
+  const uri = "data:text/csv;charset=utf-8," + encodeURIComponent(lines.join("\n"));
+  const a = document.createElement("a");
+  a.href = uri;
+  a.download = "babytuna-tips-" + st.filters.from + "-to-" + st.filters.to + ".csv";
+  document.body.appendChild(a); a.click(); a.remove();
+  toast("Exported <b>" + rows.length + " records</b> to CSV.");
+}
+
+/* ============================================================
+   SHARED: draft editing model
+   ============================================================ */
+function startDraft(v, recId){
+  const st = S[v];
+  const r = st.records.find(x=>x.id===recId);
+  st.ui.draft = {
+    id: r.id,
+    cash: plain(r.cash),
+    card: plain(r.card),
+    people: r.people.slice(),
+    step: 1
+  };
+}
+function draftRec(v){
+  const st = S[v];
+  return st.records.find(x=>x.id===st.ui.draft.id);
+}
+function draftNums(v){
+  const st = S[v], d = st.ui.draft;
+  const cash = parseMoney(d.cash), card = parseMoney(d.card);
+  const n = d.people.length;
+  return {
+    cash, card, n,
+    valid: cash !== null && card !== null && n > 0,
+    per: (cash !== null && n > 0) ? share(cash, n) : null
+  };
+}
+/* who gains, who loses, who drops off — the consequence of a correction */
+function deltas(v){
+  const st = S[v], d = st.ui.draft, r = draftRec(v), nm = draftNums(v);
+  const before = share(r.cash, r.people.length);
+  const out = [];
+  const all = [...new Set([...r.people, ...d.people])];
+  all.forEach(pid => {
+    const was = r.people.includes(pid) ? before : null;
+    const now = d.people.includes(pid) ? nm.per : null;
+    out.push({id:pid, name:nameOf(st,pid), was, now});
+  });
+  return out;
+}
+function commitDraft(v){
+  const st = S[v], d = st.ui.draft, r = draftRec(v), nm = draftNums(v);
+  r.cash = nm.cash; r.card = nm.card; r.people = d.people.slice();
+  const t = typicalRange(st, r);
+  r.flag = !!(t && (r.cash > t.hi * 3));
+  r.edited = true;
+  const per = share(r.cash, r.people.length);
+  st.ui.draft = null;
+  toast("Corrected <b>" + dLabel(r) + " · " + REST[r.rest].short + " " + mealName(r.meal) +
+        "</b>. Each person now gets " + money(per) + ".");
+}
+
+/* ============================================================
+   VARIANT A — LEDGER
+   ============================================================ */
+function renderA(){
+  const st = S.a, rows = visible(st), t = totals(rows), days = byDay(rows);
+  const flagged = rows.filter(r=>r.flag);
+
+  const presets = [
+    {k:"7d",  label:"Last 7 days",   from:"2026-08-04", to:"2026-08-10"},
+    {k:"14d", label:"Last 14 days",  from:"2026-07-28", to:"2026-08-10"},
+    {k:"pp",  label:"Pay period Aug 1–15", from:"2026-08-01", to:"2026-08-15"}
+  ];
+
+  let h = '<div class="a-grid">';
+
+  /* filter bar */
+  h += '<div class="a-bar">' +
+    '<div class="chips" role="group" aria-label="Date range presets">' +
+      presets.map(p => '<button class="chip" data-act="a-preset" data-k="'+p.k+'" aria-pressed="'+(st.filters.preset===p.k)+'">'+p.label+'</button>').join("") +
+    '</div>' +
+    '<div class="field"><label for="a-from">From</label><input id="a-from" type="date" value="'+st.filters.from+'" data-act="a-date" data-which="from"></div>' +
+    '<div class="field"><label for="a-to">To</label><input id="a-to" type="date" value="'+st.filters.to+'" data-act="a-date" data-which="to"></div>' +
+    '<div class="field"><label for="a-rest">Restaurant</label>' +
+      '<select id="a-rest" data-act="a-rest">' +
+        '<option value="all"'+(st.filters.rest==="all"?" selected":"")+'>Both restaurants</option>' +
+        '<option value="sushi"'+(st.filters.rest==="sushi"?" selected":"")+'>Babytuna Sushi</option>' +
+        '<option value="poki"'+(st.filters.rest==="poki"?" selected":"")+'>Babytuna Poki &amp; Pho</option>' +
+      '</select></div>' +
+    '<div style="margin-left:auto"><button class="btn" data-act="export" data-v="a">Export CSV</button></div>' +
+  '</div>';
+
+  /* totals */
+  const roundDelta = t.dist - t.cash;
+  h += '<dl class="a-totals">' +
+    '<div class="a-tot is-cash"><dt>Cash pool — split</dt><dd>'+money(t.cash)+'</dd>' +
+      '<div class="sub">Handed out in shares that night</div></div>' +
+    '<div class="a-tot is-card"><dt>Card — logged only</dt><dd>'+money(t.card)+'</dd>' +
+      '<div class="sub">Never part of a share · paid separately</div></div>' +
+    '<div class="a-tot"><dt>Records</dt><dd>'+t.n+'</dd>' +
+      '<div class="sub">'+days.length+' business days'+(flagged.length?' · <span class="never">'+flagged.length+' flagged</span>':'')+'</div></div>' +
+    '<div class="a-tot"><dt>Shares distributed</dt><dd>'+money(t.dist)+'</dd>' +
+      '<div class="sub">'+(roundDelta===0 ? "Matches the pool exactly"
+        : (roundDelta>0?"+":"")+money(roundDelta).replace("$","$")+" vs pool — half-cent round-ups")+'</div></div>' +
+  '</dl>';
+
+  /* hand-drawn cash-by-day chart, with the flagged day broken so one
+     outlier does not flatten the rest of the scale */
+  h += '<div class="card a-chart">' + chartA(days) + '</div>';
+
+  /* the ledger */
+  h += '<div class="card"><div class="a-tablewrap"><table class="ledger">' +
+    '<caption class="sr">Recorded tips for the selected range</caption>' +
+    '<thead>' +
+      '<tr class="grp">' +
+        '<th colspan="3"></th>' +
+        '<th class="zone-cash first" colspan="3" style="color:var(--accent-deep)">Cash — split evenly, paid that night</th>' +
+        '<th class="zone-card first" colspan="1">Card — logged only</th>' +
+        '<th colspan="3"></th>' +
+      '</tr>' +
+      '<tr class="cols">' +
+        '<th scope="col">Date</th><th scope="col">Meal</th><th scope="col">Restaurant</th>' +
+        '<th scope="col" class="zone-cash first">Pool</th>' +
+        '<th scope="col" class="zone-cash">People</th>' +
+        '<th scope="col" class="zone-cash">Per person</th>' +
+        '<th scope="col" class="zone-card first">Amount</th>' +
+        '<th scope="col">Split between</th>' +
+        '<th scope="col">Closed by</th>' +
+        '<th scope="col"><span class="sr">Actions</span></th>' +
+      '</tr>' +
+    '</thead><tbody>';
+
+  if(!rows.length){
+    h += '<tr><td colspan="10" style="padding:26px;text-align:center;color:var(--muted)">No records in this range.</td></tr>';
+  }
+
+  days.forEach(([date, drows]) => {
+    const dt = totals(drows);
+    const r0 = drows[0];
+    h += '<tr class="daybreak"><td colspan="10">' + dLabel(r0) +
+      '<span class="dsum">' + drows.length + ' record' + (drows.length>1?"s":"") +
+      ' · cash <b>'+money(dt.cash)+'</b> · card '+money(dt.card)+'</span></td></tr>';
+
+    drows.forEach(r => {
+      const n = r.people.length, per = share(r.cash, n);
+      const editing = st.ui.draft && st.ui.draft.id === r.id;
+      h += '<tr class="rec'+(r.flag?" flagged":"")+'">' +
+        '<td>'+dLabel(r)+'</td>' +
+        '<td>'+mealName(r.meal)+'</td>' +
+        '<td>'+REST[r.rest].short+'</td>' +
+        '<td class="zone-cash first"><span class="cash-ink">'+money(r.cash)+'</span>' +
+          (r.flag ? ' <span class="tag flag">flagged</span>' : '') +
+          (r.edited ? ' <span class="tag">edited</span>' : '') + '</td>' +
+        '<td class="zone-cash"><span class="divsign">÷</span> '+n+'</td>' +
+        '<td class="zone-cash"><span class="pp">'+money(per)+'</span></td>' +
+        '<td class="zone-card first">'+money(r.card)+'</td>' +
+        '<td class="who">'+esc(namesOf(st, r.people))+'</td>' +
+        '<td class="meta">'+esc(r.by)+' · '+r.how+'</td>' +
+        '<td style="text-align:right"><button class="btn sm" data-act="a-edit" data-id="'+r.id+'" aria-expanded="'+(editing?"true":"false")+'">'+(editing?"Close":"Correct")+'</button></td>' +
+      '</tr>';
+      if(editing) h += editRowA(r);
+    });
+  });
+
+  h += '<tr class="totals">' +
+      '<td colspan="3">Range total · '+t.n+' records</td>' +
+      '<td class="zone-cash first">'+money(t.cash)+'</td>' +
+      '<td class="zone-cash"></td>' +
+      '<td class="zone-cash" style="font-weight:600;font-size:12px;color:var(--accent-deep)">'+money(t.dist)+' out</td>' +
+      '<td class="zone-card first">'+money(t.card)+'</td>' +
+      '<td colspan="3"></td>' +
+    '</tr>';
+  h += '</tbody></table></div>' +
+    '<div style="padding:12px 16px;border-top:1px solid var(--hair)"><div class="legend">' +
+      '<span><span class="sw cash"></span>Cash — divided by head count, handed out that night</span>' +
+      '<span><span class="sw card"></span>Card — recorded for payroll, never divided</span>' +
+      '<span style="color:var(--muted)">Business day rolls over at 4am</span>' +
+    '</div></div></div>';
+
+  /* staff + access, side by side, below the ledger */
+  h += '<div class="a-two">' + staffA() + accessA() + '</div>';
+  h += '</div>';
+
+  document.getElementById("body-a").innerHTML = h;
+}
+
+function chartA(days){
+  if(!days.length) return '<figcaption>No data in range.</figcaption>';
+  const W = 100, GAP = 26, H = 96, pad = 30;
+  const data = days.slice().reverse().map(([d, rows]) => {
+    const t = totals(rows);
+    return {label: dLabel(rows[0]), cash:t.cash, flagged: rows.some(r=>r.flag)};
+  });
+  const clean = data.filter(d=>!d.flagged).map(d=>d.cash);
+  const scaleMax = Math.max(1, clean.length ? Math.max(...clean) * 1.18 : Math.max(...data.map(d=>d.cash)));
+  let bars = "", x = 0;
+  data.forEach(d => {
+    const over = d.cash > scaleMax;
+    const hgt = Math.max(3, Math.round((Math.min(d.cash, scaleMax) / scaleMax) * H));
+    const y = pad + H - hgt;
+    bars += '<g>';
+    bars += '<rect x="'+x+'" y="'+y+'" width="'+W+'" height="'+hgt+'" rx="4" fill="'+(over?"var(--accent)":"#e9c9c1")+'"/>';
+    if(over){
+      /* break marker: this bar is clipped, do not read it to scale */
+      bars += '<path d="M'+x+' '+(y+13)+' l'+(W/4)+' -7 l'+(W/4)+' 7 l'+(W/4)+' -7 l'+(W/4)+' 7 v9 h-'+W+' z" fill="var(--cream)"/>';
+      bars += '<path d="M'+x+' '+(y+13)+' l'+(W/4)+' -7 l'+(W/4)+' 7 l'+(W/4)+' -7 l'+(W/4)+' 7" fill="none" stroke="var(--accent)" stroke-width="2"/>';
+    }
+    bars += '<text x="'+(x+W/2)+'" y="'+(y-7)+'" text-anchor="middle" font-size="13" font-weight="700" fill="'+(over?"var(--accent-deep)":"#1a1a1a")+'">'+money(d.cash)+'</text>';
+    bars += '<text x="'+(x+W/2)+'" y="'+(pad+H+18)+'" text-anchor="middle" font-size="12" fill="#5f5f5f">'+d.label+'</text>';
+    bars += '</g>';
+    x += W + GAP;
+  });
+  const totalW = data.length * (W+GAP) - GAP;
+  return '<figure style="margin:0">' +
+    '<figcaption>Cash pool by business day. The Friday bar is <b>clipped</b> — it contains the flagged $3,100.00 entry and is not drawn to scale.</figcaption>' +
+    '<svg viewBox="0 0 '+totalW+' '+(pad+H+26)+'" width="100%" height="150" role="img" ' +
+    'aria-label="Cash pool by day: ' + data.map(d=>d.label+" "+money(d.cash)).join("; ") + '">' +
+    '<line x1="0" y1="'+(pad+H)+'" x2="'+totalW+'" y2="'+(pad+H)+'" stroke="rgba(0,0,0,.12)"/>' +
+    bars + '</svg></figure>';
+}
+
+function editRowA(r){
+  const st = S.a, d = st.ui.draft, nm = draftNums("a");
+  const roster = st.staff.filter(s => s.active && (s.at === "both" || s.at === r.rest));
+  const others = st.staff.filter(s => s.active && !(s.at === "both" || s.at === r.rest));
+  const chip = s => {
+    const on = d.people.includes(s.id);
+    return '<label class="chk'+(on?" on":"")+(s.at!=="both"&&s.at!==r.rest?" other":"")+'">' +
+      '<input type="checkbox" data-act="a-person" data-id="'+s.id+'"'+(on?" checked":"")+'> '+esc(s.name)+'</label>';
+  };
+  return '<tr class="editrow"><td colspan="10"><div class="edit-in">' +
+    '<div class="sec-head"><h3>Correct — '+dLabel(r)+' · '+REST[r.rest].name+' '+mealName(r.meal)+'</h3>' +
+      '<span class="hint">Originally closed by '+esc(r.by)+' ('+r.how+')</span></div>' +
+    '<div class="edit-grid">' +
+      '<div class="field"><label for="a-cash">Cash pool (split)</label>' +
+        '<div class="money-in"><span>$</span><input id="a-cash" inputmode="decimal" value="'+d.cash+'" data-act="a-cash"></div></div>' +
+      '<div class="field"><label for="a-card">Card (logged only)</label>' +
+        '<div class="money-in"><span>$</span><input id="a-card" inputmode="decimal" value="'+d.card+'" data-act="a-card"></div></div>' +
+      '<div><div class="field" style="margin-bottom:8px"><label>On the split ('+d.people.length+')</label></div>' +
+        '<div class="ppl-box">'+roster.map(chip).join("")+'</div>' +
+        (others.length ? '<div style="margin-top:9px"><div class="meta" style="margin-bottom:5px">Not normally at this restaurant</div><div class="ppl-box">'+others.map(chip).join("")+'</div></div>' : '') +
+      '</div>' +
+      '<div id="a-preview">'+previewA()+'</div>' +
+    '</div>' +
+    '<div class="btn-row" style="margin-top:14px">' +
+      '<button class="btn primary" data-act="a-apply"'+(nm.valid?"":" disabled")+'>Apply correction</button>' +
+      '<button class="btn ghost" data-act="a-cancel">Cancel</button>' +
+      '<span class="meta" style="margin-left:6px">Changes what these people are owed. No approval step — this saves immediately.</span>' +
+    '</div>' +
+  '</div></td></tr>';
+}
+
+function previewA(){
+  const st = S.a, nm = draftNums("a"), r = draftRec("a");
+  if(!nm.valid){
+    return '<div class="preview"><h4>Result</h4><p style="color:var(--accent-deep);font-weight:600;font-size:13px">' +
+      (nm.n === 0 ? "Pick at least one person." : "Enter a valid amount.") + '</p></div>';
+  }
+  const ds = deltas("a");
+  let rows = ds.map(x => {
+    const cls = x.now === null ? "gone" : (x.was === null || x.now > x.was ? "up" : (x.now < x.was ? "down" : ""));
+    let val;
+    if(x.now === null) val = '<span class="now">removed</span>';
+    else if(x.was === null) val = '<span class="now">'+money(x.now)+'</span> <span class="meta">new</span>';
+    else if(x.was === x.now) val = '<span class="now">'+money(x.now)+'</span> <span class="meta">no change</span>';
+    else val = '<span class="was">'+money(x.was)+'</span><span class="now">'+money(x.now)+'</span>';
+    return '<div class="delta '+cls+'"><span class="nm">'+esc(x.name)+'</span><span class="vals">'+val+'</span></div>';
+  }).join("");
+  const out = nm.per * nm.n, diff = out - nm.cash;
+  let h = '<div class="preview"><h4>Per person after this change</h4>' +
+    '<div style="font-size:24px;font-weight:700;letter-spacing:-.02em;margin-bottom:9px">'+money(nm.per) +
+    ' <span style="font-size:13px;font-weight:500;color:var(--ink2)">= '+money(nm.cash)+' ÷ '+nm.n+'</span></div>' +
+    rows;
+  if(diff !== 0){
+    h += '<div class="roundnote">Shares total '+money(out)+' — ' +
+      (diff>0 ? money(diff)+" over" : money(-diff)+" under") + ' the pool after rounding. The drawer absorbs it.</div>';
+  }
+  if(nm.card !== r.card){
+    h += '<div class="roundnote"><b>Card '+money(r.card)+' → '+money(nm.card)+'.</b> Logged only — no one’s share moves.</div>';
+  }
+  h += '</div>';
+  return h;
+}
+
+function staffA(){
+  const st = S.a;
+  const counts = {};
+  st.records.forEach(r => r.people.forEach(p => counts[p] = (counts[p]||0)+1));
+  const nf = st.ui.newStaff || {name:"", at:"sushi"};
+
+  let h = '<section class="card"><div style="padding:16px 16px 12px"><div class="sec-head">' +
+    '<h3>Staff</h3><span class="hint">Order here is the order the phone picker shows</span></div></div>' +
+    '<table class="staff"><caption class="sr">Staff list</caption><thead><tr>' +
+    '<th scope="col" style="width:52px">Order</th><th scope="col">Name</th><th scope="col">Works at</th>' +
+    '<th scope="col">Shifts</th><th scope="col">Status</th><th scope="col"><span class="sr">Actions</span></th>' +
+    '</tr></thead><tbody>';
+
+  /* add row is always present and always first — a new hire is the common case */
+  h += '<tr class="newrow"><td><span class="meta">new</span></td>' +
+    '<td><input id="a-newname" placeholder="Name" value="'+esc(nf.name)+'" data-act="a-newname" aria-label="New staff name" style="border:1px solid var(--hair-2);border-radius:8px;padding:5px 8px;width:100%;max-width:150px"></td>' +
+    '<td><select id="a-newat" data-act="a-newat" aria-label="New staff works at" style="border:1px solid var(--hair-2);border-radius:8px;padding:5px 8px">' +
+      '<option value="sushi"'+(nf.at==="sushi"?" selected":"")+'>Sushi</option>' +
+      '<option value="poki"'+(nf.at==="poki"?" selected":"")+'>Poki &amp; Pho</option>' +
+      '<option value="both"'+(nf.at==="both"?" selected":"")+'>Both</option></select></td>' +
+    '<td colspan="2" class="meta">Appears in the picker immediately</td>' +
+    '<td style="text-align:right"><button class="btn primary sm" data-act="a-add">Add</button></td></tr>';
+
+  st.staff.forEach((s, i) => {
+    const renaming = st.ui.renaming === s.id;
+    const n = counts[s.id] || 0;
+    h += '<tr class="'+(s.active?"":"inactive")+'">' +
+      '<td><span class="ordbtns">' +
+        '<button class="ordbtn" data-act="a-move" data-id="'+s.id+'" data-dir="-1" '+(i===0?"disabled":"")+' aria-label="Move '+esc(s.name)+' up">↑</button>' +
+        '<button class="ordbtn" data-act="a-move" data-id="'+s.id+'" data-dir="1" '+(i===st.staff.length-1?"disabled":"")+' aria-label="Move '+esc(s.name)+' down">↓</button>' +
+      '</span></td>' +
+      '<td>' + (renaming
+        ? '<input value="'+esc(s.name)+'" data-act="a-renameinput" data-id="'+s.id+'" aria-label="Rename '+esc(s.name)+'" style="border:1px solid var(--accent);border-radius:8px;padding:4px 8px;width:130px">'
+        : '<b>'+esc(s.name)+'</b>') + '</td>' +
+      '<td><select data-act="a-at" data-id="'+s.id+'" aria-label="'+esc(s.name)+' works at" style="border:1px solid var(--hair-2);border-radius:8px;padding:4px 7px;font-size:12.5px">' +
+        '<option value="sushi"'+(s.at==="sushi"?" selected":"")+'>Sushi</option>' +
+        '<option value="poki"'+(s.at==="poki"?" selected":"")+'>Poki &amp; Pho</option>' +
+        '<option value="both"'+(s.at==="both"?" selected":"")+'>Both</option></select></td>' +
+      '<td class="meta">'+(n||"—")+'</td>' +
+      '<td>'+(s.active?'<span class="tag" style="background:#e2efe9;color:#1f5c4c">active</span>':'<span class="tag off">inactive</span>')+'</td>' +
+      '<td style="text-align:right;white-space:nowrap">' +
+        (renaming
+          ? '<button class="btn sm primary" data-act="a-renamesave" data-id="'+s.id+'">Save</button> '
+          : '<button class="btn sm ghost" data-act="a-rename" data-id="'+s.id+'">Rename</button> ') +
+        '<button class="btn sm ghost" data-act="a-active" data-id="'+s.id+'">'+(s.active?"Deactivate":"Reactivate")+'</button> ' +
+        (n === 0
+          ? '<button class="btn sm danger" data-act="a-del" data-id="'+s.id+'">Delete</button>'
+          : '<button class="btn sm" disabled title="Has '+n+' recorded shifts — deactivate instead">Delete</button>') +
+      '</td></tr>';
+  });
+  h += '</tbody></table>' +
+    '<div style="padding:11px 16px;border-top:1px solid var(--hair)" class="meta">' +
+    'Deactivating keeps every past shift and share intact — the person just stops appearing in the phone picker. ' +
+    'Delete is only offered for someone with no recorded shifts.</div></section>';
+  return h;
+}
+
+function accessA(){
+  const st = S.a;
+  const rowFor = (rk, kind) => {
+    const a = st.access[rk];
+    const when = kind === "qr" ? a.qr : a.pin;
+    const pend = st.ui.pending;
+    const isPending = pend && pend.rest === rk && pend.kind === kind;
+    const rev = st.ui.reveal;
+    const isRev = rev && rev.rest === rk && rev.kind === kind;
+    let h = '<tr><td><b>'+REST[rk].short+'</b></td>' +
+      '<td>'+(kind==="qr"?"QR sticker":"Numeric PIN")+'</td>' +
+      '<td>'+(when ? when : '<span class="never">never rotated</span>')+'</td>' +
+      '<td style="text-align:right"><button class="btn sm danger" data-act="a-rotate" data-rest="'+rk+'" data-kind="'+kind+'">Rotate</button></td></tr>';
+    if(isPending){
+      h += '<tr><td colspan="4" style="padding:0 10px 12px"><div class="confirmbar">' +
+        '<p>' + (kind === "qr"
+          ? "Rotating kills the printed sticker at " + REST[rk].name + " immediately. Nobody can sign in until a new one is printed and stuck up."
+          : "Rotating means every closer at " + REST[rk].name + " needs the new number tonight. The old PIN stops working right away.") +
+        ' The new code is shown once and cannot be looked up later.</p>' +
+        '<span class="btn-row"><button class="btn primary sm" data-act="a-rotate-go" data-rest="'+rk+'" data-kind="'+kind+'">Yes, rotate now</button>' +
+        '<button class="btn ghost sm" data-act="a-rotate-cancel">Cancel</button></span></div></td></tr>';
+    }
+    if(isRev){
+      h += '<tr><td colspan="4" style="padding:0 10px 12px"><div class="reveal">' +
+        '<span class="once">' + NOSPLIT_ICON + ' Shown once — not recoverable</span>' +
+        (kind === "qr"
+          ? '<div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap">' + qrSvg(rev.value, 128) +
+            '<div style="flex:1;min-width:220px"><div class="secret">'+rev.value+'</div>' +
+            '<div class="meta" style="margin-top:7px">Print this and replace the sticker by the register at '+REST[rk].name+'.</div></div></div>'
+          : '<div class="secret" style="font-size:30px;letter-spacing:.3em">'+rev.value+'</div>' +
+            '<div class="meta" style="margin-top:7px">Tell tonight’s closers at '+REST[rk].name+'.</div>') +
+        '<div class="ackline">' +
+          '<label><input type="checkbox" data-act="a-ackchk"'+(st.ui.acked?" checked":"")+'> I have ' + (kind==="qr"?"printed or saved it":"written it down") + '</label>' +
+          '<button class="btn primary sm" data-act="a-ackdone"'+(st.ui.acked?"":" disabled")+'>Done</button>' +
+          '<button class="btn sm" data-act="a-copy" data-val="'+rev.value+'">Copy</button>' +
+        '</div></div></td></tr>';
+    }
+    return h;
+  };
+
+  return '<section class="card"><div style="padding:16px 16px 4px"><div class="sec-head">' +
+    '<h3>Device access</h3><span class="hint">How a phone at each register signs in</span></div></div>' +
+    '<table class="acc-t"><caption class="sr">Device access</caption><thead><tr>' +
+    '<th scope="col">Restaurant</th><th scope="col">Credential</th><th scope="col">Last rotated</th>' +
+    '<th scope="col"><span class="sr">Actions</span></th></tr></thead><tbody>' +
+    rowFor("sushi","qr") + rowFor("sushi","pin") + rowFor("poki","qr") + rowFor("poki","pin") +
+    '</tbody></table>' +
+    '<div class="danger-zone"><div class="sec-head" style="margin-bottom:8px"><h3 style="font-size:13px;color:var(--accent-deep)">Sign out every phone</h3></div>' +
+    '<p class="meta" style="margin-bottom:10px">Ends every signed-in session at a restaurant. Closers have to scan the sticker again before the next shift.</p>' +
+    '<div class="btn-row">' +
+      '<button class="btn danger sm" data-act="a-signout" data-rest="sushi">Sushi — '+st.access.sushi.phones+' phones</button>' +
+      '<button class="btn danger sm" data-act="a-signout" data-rest="poki">Poki &amp; Pho — '+st.access.poki.phones+' phones</button>' +
+    '</div></div></section>';
+}
+
+/* ============================================================
+   VARIANT B — NIGHTLY
+   ============================================================ */
+function renderB(){
+  const st = S.b, rows = visible(st), t = totals(rows), days = byDay(rows);
+
+  /* "last night" = the most recent business day that has records */
+  /* comparator must return 0 for same-date rows, otherwise the sort is
+     unstable and the shifts within a night come out in arbitrary order */
+  const all = st.records.slice().sort((a,b)=> a.date === b.date ? 0 : (a.date < b.date ? 1 : -1));
+  const lastDate = all.length ? all[0].date : null;
+  const lastRows = all.filter(r => r.date === lastDate);
+
+  let h = "";
+
+  if(lastRows.length){
+    h += '<section class="b-hero"><div class="b-hero-head">' +
+      '<h3>Last night — '+dLabel(lastRows[0])+'</h3>' +
+      '<span class="when">Recorded after close · business day ends 4am</span></div>' +
+      '<div class="b-tiles">' + lastRows.map(r => {
+        const n = r.people.length, per = share(r.cash, n);
+        return '<article class="tile">' +
+          '<div class="where"><span class="dot '+r.rest+'"></span><b>'+REST[r.rest].short+'</b>' +
+          '<span class="meal">'+mealName(r.meal)+'</span>' + (r.flag?' <span class="tag flag">flagged</span>':'') + '</div>' +
+          '<div class="pp-cap">Each person gets</div>' +
+          '<div class="pp-big">'+money(per)+'</div>' +
+          '<div class="pp-math">'+money(r.cash)+' cash ÷ '+n+'</div>' +
+          '<div class="names">'+esc(namesOf(st, r.people))+'</div>' +
+          '<div class="cardline"><span class="nosplit">'+NOSPLIT_ICON+' Card · logged, not split</span>' +
+          '<span class="amt">'+money(r.card)+'</span></div>' +
+        '</article>';
+      }).join("") + '</div></section>';
+  }
+
+  const flagged = rows.filter(r=>r.flag);
+  if(flagged.length){
+    const f = flagged[0];
+    const tr = typicalRange(st, f);
+    h += '<div class="attention"><div class="txt">' +
+      '<b>'+flagged.length+' entry needs a look.</b> ' + dLabel(f) + ' · ' + REST[f.rest].short + ' ' + mealName(f.meal) +
+      ' recorded <b>'+money(f.cash)+'</b> cash, split ' + money(share(f.cash, f.people.length)) + ' each.' +
+      '<div class="sub">' + (tr ? 'This slot normally runs '+money(tr.lo)+'–'+money(tr.hi)+'. ' : '') +
+      'Entered by '+esc(f.by)+' by '+f.how+'. It is the reason the range total reads '+money(t.cash)+'.</div></div>' +
+      '<button class="btn primary" data-act="b-open" data-id="'+f.id+'">Review this entry</button></div>';
+  }
+
+  /* range controls */
+  h += '<div class="b-controls">' +
+    '<div class="field"><label for="b-from">From</label><input id="b-from" type="date" value="'+st.filters.from+'" data-act="b-date" data-which="from"></div>' +
+    '<div class="field"><label for="b-to">To</label><input id="b-to" type="date" value="'+st.filters.to+'" data-act="b-date" data-which="to"></div>' +
+    '<div class="field"><label id="b-rl">Restaurant</label><div class="seg" role="group" aria-labelledby="b-rl">' +
+      ['all','sushi','poki'].map(k => '<button data-act="b-rest" data-k="'+k+'" aria-pressed="'+(st.filters.rest===k)+'">' +
+        (k==="all"?"Both":REST[k].short)+'</button>').join("") + '</div></div>' +
+    '<div style="margin-left:auto" class="btn-row">' +
+      '<div style="text-align:right;margin-right:8px"><div class="meta">'+t.n+' records</div>' +
+      '<div><b>'+money(t.cash)+'</b> cash · <span class="card-ink">'+money(t.card)+' card</span></div></div>' +
+      '<button class="btn" data-act="export" data-v="b">Export CSV</button></div>' +
+  '</div>';
+
+  if(!rows.length){
+    h += '<div class="card" style="padding:40px;text-align:center;color:var(--muted)">No records in this range.</div>';
+  }
+
+  days.forEach(([date, drows]) => {
+    const dt = totals(drows);
+    h += '<section class="day"><div class="day-head"><h4>'+dLabel(drows[0])+'</h4>' +
+      '<span class="meta">'+drows.length+' shift'+(drows.length>1?"s":"")+'</span>' +
+      '<div class="sum"><span>Cash pool <b>'+money(dt.cash)+'</b></span>' +
+      '<span class="card-ink">Card logged <b class="card-ink">'+money(dt.card)+'</b></span></div></div>';
+    drows.forEach(r => {
+      const n = r.people.length, per = share(r.cash, n);
+      h += '<button class="shift'+(r.flag?" flagged":"")+'" data-act="b-open" data-id="'+r.id+'">' +
+        '<span><span class="lbl">Shift</span><span style="display:flex;align-items:center;gap:8px">' +
+          '<span class="dot '+r.rest+'"></span><b>'+REST[r.rest].short+'</b> <span style="color:var(--ink2)">'+mealName(r.meal)+'</span>' +
+          (r.flag?' <span class="tag flag">flagged</span>':'') + (r.edited?' <span class="tag">edited</span>':'') + '</span>' +
+          '<span class="lbl" style="text-transform:none;letter-spacing:0;font-weight:400;color:var(--muted);margin-top:3px">'+esc(r.by)+' · '+r.how+'</span></span>' +
+        '<span class="cash-cell"><span class="lbl">Cash pool ÷ '+n+'</span><span class="cash-amt">'+money(r.cash)+'</span>' +
+          '<span class="lbl" style="text-transform:none;letter-spacing:0;font-weight:400;color:var(--ink2);margin-top:2px">'+esc(namesOf(st,r.people))+'</span></span>' +
+        '<span><span class="lbl">Each person</span><span class="pp-amt">'+money(per)+'</span></span>' +
+        '<span class="card-cell"><span class="lbl">Card · not split</span><span class="card-amt">'+money(r.card)+'</span></span>' +
+        '<span class="chev" aria-hidden="true">›</span></button>';
+    });
+    h += '</section>';
+  });
+
+  /* staff */
+  const counts = {};
+  st.records.forEach(r => r.people.forEach(p => counts[p] = (counts[p]||0)+1));
+  const adding = !!st.ui.adding;
+  const nf = st.ui.newStaff || {name:"", at:"sushi", pos:"end"};
+  const actives = st.staff.filter(s=>s.active), inactives = st.staff.filter(s=>!s.active);
+
+  h += '<section class="b-sec"><div class="sec-head"><h3>Staff</h3>' +
+    '<span class="hint">Listed in the order the phone picker shows them</span><span class="spacer"></span>' +
+    '<button class="btn primary" data-act="b-addopen">Add someone</button></div>' +
+    '<div class="card roster">';
+
+  if(adding){
+    h += '<div class="addbox"><div class="addgrid">' +
+      '<div class="field"><label for="b-nn">Name</label><input id="b-nn" value="'+esc(nf.name)+'" data-act="b-newname" placeholder="New hire" autofocus></div>' +
+      '<div class="field"><label for="b-na">Works at</label><select id="b-na" data-act="b-newat">' +
+        '<option value="sushi"'+(nf.at==="sushi"?" selected":"")+'>Sushi</option>' +
+        '<option value="poki"'+(nf.at==="poki"?" selected":"")+'>Poki &amp; Pho</option>' +
+        '<option value="both"'+(nf.at==="both"?" selected":"")+'>Both</option></select></div>' +
+      '<div class="field"><label for="b-np">Position in picker</label><select id="b-np" data-act="b-newpos">' +
+        '<option value="end"'+(nf.pos==="end"?" selected":"")+'>Last</option>' +
+        '<option value="start"'+(nf.pos==="start"?" selected":"")+'>First</option></select></div>' +
+      '<div class="btn-row"><button class="btn primary" data-act="b-add">Add</button>' +
+      '<button class="btn ghost" data-act="b-addclose">Cancel</button></div>' +
+    '</div><div class="meta" style="margin-top:9px">They can be picked on the phone straight away — no shift required first.</div></div>';
+  }
+
+  h += '<div class="grouplabel">In the picker</div>';
+  actives.forEach((s,i) => {
+    h += '<div class="rline"><span class="grip">'+(i+1)+'</span>' +
+      '<span class="nm">'+esc(s.name)+'</span>' +
+      '<span class="at">'+(s.at==="both"?"Both restaurants":REST[s.at].short)+'</span>' +
+      '<span class="meta">'+(counts[s.id]||0)+' shifts in range</span>' +
+      '<span class="rt">' +
+        '<button class="ordbtn btn sm" data-act="b-move" data-id="'+s.id+'" data-dir="-1" '+(i===0?"disabled":"")+' aria-label="Move '+esc(s.name)+' up">↑</button>' +
+        '<button class="ordbtn btn sm" data-act="b-move" data-id="'+s.id+'" data-dir="1" '+(i===actives.length-1?"disabled":"")+' aria-label="Move '+esc(s.name)+' down">↓</button>' +
+        '<button class="btn sm ghost" data-act="b-rename" data-id="'+s.id+'">Rename</button>' +
+        '<select data-act="b-at" data-id="'+s.id+'" aria-label="'+esc(s.name)+' works at" class="btn sm" style="padding:4px 6px">' +
+          '<option value="sushi"'+(s.at==="sushi"?" selected":"")+'>Sushi</option>' +
+          '<option value="poki"'+(s.at==="poki"?" selected":"")+'>Poki</option>' +
+          '<option value="both"'+(s.at==="both"?" selected":"")+'>Both</option></select>' +
+        '<button class="btn sm" data-act="b-active" data-id="'+s.id+'">Deactivate</button>' +
+      '</span></div>';
+  });
+  if(inactives.length){
+    h += '<div class="grouplabel">No longer on the picker · history kept</div>';
+    inactives.forEach(s => {
+      const n = counts[s.id]||0;
+      h += '<div class="rline inactive"><span class="grip">—</span><span class="nm">'+esc(s.name)+'</span>' +
+        '<span class="at">'+(s.at==="both"?"Both":REST[s.at].short)+'</span>' +
+        '<span class="meta">'+(n?n+" shifts kept":"never worked a shift")+'</span>' +
+        '<span class="rt"><button class="btn sm" data-act="b-active" data-id="'+s.id+'">Reactivate</button>' +
+        (n===0 ? '<button class="btn sm danger" data-act="b-del" data-id="'+s.id+'">Delete</button>'
+               : '<button class="btn sm" disabled title="Has recorded shifts">Delete</button>') +
+        '</span></div>';
+    });
+  }
+  h += '</div></section>';
+
+  /* access — deliberately last, collapsed, quiet */
+  const A = st.access;
+  h += '<section class="b-sec"><details class="access"'+(st.ui.accOpen?" open":"")+' data-act="b-accdetails">' +
+    '<summary><span class="mk">▶</span> Device access ' +
+    '<span class="sub">QR stickers, PINs, signed-in phones · rarely needs touching</span></summary>' +
+    '<div class="accbody">' +
+    ['sushi','poki'].map(rk => {
+      const a = A[rk];
+      return '<div class="accrest"><h4 style="font-size:14.5px;margin-bottom:6px">'+REST[rk].name+'</h4>' +
+        '<div class="accrow"><div class="what"><b>QR sticker</b><span>' +
+          (a.qr ? "Last rotated "+a.qr : "Never rotated — still the original sticker") + '</span></div>' +
+          '<div class="btn-row"><button class="btn danger sm" data-act="b-rotate" data-rest="'+rk+'" data-kind="qr">Rotate QR</button></div></div>' +
+        '<div class="accrow"><div class="what"><b>Numeric PIN</b><span>Last rotated '+a.pin+'</span></div>' +
+          '<div class="btn-row"><button class="btn danger sm" data-act="b-rotate" data-rest="'+rk+'" data-kind="pin">Rotate PIN</button></div></div>' +
+        '<div class="accrow"><div class="what"><b>Signed-in phones</b><span>'+a.phones+' device'+(a.phones===1?"":"s")+' currently signed in</span></div>' +
+          '<div class="btn-row"><button class="btn danger sm" data-act="b-signout" data-rest="'+rk+'">Sign out all phones</button></div></div>' +
+      '</div>';
+    }).join("") +
+    '</div></details></section>';
+
+  document.getElementById("body-b").innerHTML = h;
+}
+
+/* B drawer */
+function drawerB(){
+  const st = S.b;
+  if(!st.ui.draft) return "";
+  const r = draftRec("b"), d = st.ui.draft, nm = draftNums("b");
+  const roster = st.staff.filter(s => s.active && (s.at === "both" || s.at === r.rest));
+  const others = st.staff.filter(s => s.active && !(s.at === "both" || s.at === r.rest));
+  const tr = typicalRange(st, r);
+
+  let body = "";
+  if(d.step === 1){
+    const chip = s => {
+      const on = d.people.includes(s.id);
+      return '<label class="chk'+(on?" on":"")+'"><input type="checkbox" data-act="b-person" data-id="'+s.id+'"'+(on?" checked":"")+'> '+esc(s.name)+'</label>';
+    };
+    body =
+      (r.flag && tr ? '<div class="warnline" style="margin:0 0 14px">Flagged: this slot normally runs '+money(tr.lo)+'–'+money(tr.hi)+'.</div>' : '') +
+      '<div class="blk"><h4>Cash — this is what gets split</h4>' +
+        '<div class="money-in"><span>$</span><input id="b-cash" inputmode="decimal" value="'+d.cash+'" data-act="b-cash" aria-label="Cash pool"></div>' +
+        '<p class="meta" style="margin-top:7px">Divided evenly and handed out that night.</p></div>' +
+      '<div class="blk" style="background:var(--logged-bg);border-color:rgba(0,0,0,.1)"><h4>Card — logged only</h4>' +
+        '<div class="money-in"><span>$</span><input id="b-card" inputmode="decimal" value="'+d.card+'" data-act="b-card" aria-label="Card amount"></div>' +
+        '<p class="meta" style="margin-top:7px">Recorded for payroll. Changing it moves nobody’s share.</p></div>' +
+      '<div class="blk"><h4>On the split — '+d.people.length+' '+(d.people.length===1?"person":"people")+'</h4>' +
+        '<div class="ppl-box" style="display:flex;flex-wrap:wrap;gap:7px">'+roster.map(chip).join("")+'</div>' +
+        (others.length ? '<p class="meta" style="margin:11px 0 6px">Not normally at '+REST[r.rest].short+'</p><div style="display:flex;flex-wrap:wrap;gap:7px">'+others.map(chip).join("")+'</div>' : '') +
+      '</div>' +
+      '<div class="blk" style="border-color:var(--accent);border-width:1.5px"><h4>Result</h4>' +
+        (nm.valid
+          ? '<div style="font-size:30px;font-weight:700;letter-spacing:-.02em">'+money(nm.per)+'</div>' +
+            '<p class="meta">each · '+money(nm.cash)+' ÷ '+nm.n+'</p>'
+          : '<p style="color:var(--accent-deep);font-weight:600">'+(nm.n===0?"Pick at least one person.":"Enter a valid cash amount.")+'</p>') +
+      '</div>';
+  } else {
+    const ds = deltas("b");
+    const out = nm.per * nm.n, diff = out - nm.cash;
+    body = '<div class="blk"><h4>What you are changing</h4>' +
+      '<div class="readonly-line"><span class="k">Cash pool</span><span class="v">' +
+        (nm.cash === r.cash ? money(r.cash)+' <span class="meta">unchanged</span>' : money(r.cash)+' → '+money(nm.cash)) + '</span></div>' +
+      '<div class="readonly-line"><span class="k">Card (logged)</span><span class="v">' +
+        (nm.card === r.card ? money(r.card)+' <span class="meta">unchanged</span>' : money(r.card)+' → '+money(nm.card)) + '</span></div>' +
+      '<div class="readonly-line"><span class="k">People</span><span class="v">'+r.people.length+' → '+nm.n+'</span></div>' +
+    '</div>' +
+    '<div class="blk" style="border-color:var(--accent);border-width:1.5px"><h4>Who this pays differently</h4>' +
+      ds.map(x => {
+        const cls = x.now === null ? "gone" : (x.was === null || x.now > x.was ? "up" : (x.now < x.was ? "down" : ""));
+        let val;
+        if(x.now === null) val = '<span class="was">'+money(x.was)+'</span><span class="now">removed from split</span>';
+        else if(x.was === null) val = '<span class="now">'+money(x.now)+'</span> <span class="meta">added</span>';
+        else if(x.was === x.now) val = '<span class="now">'+money(x.now)+'</span> <span class="meta">no change</span>';
+        else val = '<span class="was">'+money(x.was)+'</span><span class="now">'+money(x.now)+'</span>';
+        return '<div class="delta '+cls+'"><span class="nm">'+esc(x.name)+'</span><span class="vals">'+val+'</span></div>';
+      }).join("") +
+      (diff !== 0 ? '<div class="roundnote">Shares add up to '+money(out)+' — '+(diff>0?money(diff)+" more than":money(-diff)+" less than")+' the '+money(nm.cash)+' pool, because shares round up at the half-cent. The drawer covers the difference.</div>' : '') +
+    '</div>' +
+    '<p class="meta">Saving takes effect immediately. There is no approval step and no undo — if this is wrong, you will have to correct it again.</p>';
+  }
+
+  return '<div class="scrim" data-act="b-close"></div>' +
+    '<aside class="drawer" role="dialog" aria-modal="true" aria-labelledby="b-dtitle" id="b-drawer">' +
+      '<div class="drawer-head"><div style="flex:1">' +
+        '<h3 id="b-dtitle">'+(d.step===1?"Correct this shift":"Confirm the correction")+'</h3>' +
+        '<div class="sub">'+dLabel(r)+' · '+REST[r.rest].name+' · '+mealName(r.meal)+'</div></div>' +
+        '<button class="xbtn" data-act="b-close" aria-label="Close">×</button></div>' +
+      '<div class="drawer-body">'+body+'</div>' +
+      '<div class="drawer-foot"><span class="stepdots">Step '+d.step+' of 2</span><span class="spacer"></span>' +
+        (d.step === 1
+          ? '<button class="btn ghost" data-act="b-close">Cancel</button>' +
+            '<button class="btn primary" data-act="b-step2"'+(nm.valid?"":" disabled")+'>Review change</button>'
+          : '<button class="btn ghost" data-act="b-step1">Back</button>' +
+            '<button class="btn primary" data-act="b-apply">Apply correction</button>') +
+      '</div></aside>';
+}
+
+/* B rotation modal + one-time reveal */
+function modalB(){
+  const st = S.b;
+  const p = st.ui.pending, rev = st.ui.reveal;
+  if(!p && !rev) return "";
+
+  if(rev){
+    const isQr = rev.kind === "qr";
+    return '<div class="scrim"></div><div class="modal" role="dialog" aria-modal="true" aria-labelledby="b-mt">' +
+      '<div class="modal-head" style="border-color:var(--accent)"><div style="flex:1">' +
+        '<span class="tag flag">Shown once</span>' +
+        '<h3 id="b-mt" style="margin-top:8px">New '+(isQr?"QR sticker":"PIN")+' for '+REST[rev.rest].name+'</h3>' +
+        '<div class="sub">Only a hash is stored. Close this and it is gone for good — you would have to rotate again.</div>' +
+      '</div></div>' +
+      '<div class="modal-body">' +
+        (isQr
+          ? '<div class="qrbox">'+qrSvg(rev.value,168)+'<div style="flex:1;min-width:230px">' +
+            '<div class="secret">'+rev.value+'</div>' +
+            '<p class="meta" style="margin-top:9px">The old sticker at the register stopped working the moment you rotated. Nobody at '+REST[rev.rest].short+' can sign a new phone in until this one is up.</p></div></div>'
+          : '<div class="secret" style="font-size:38px;letter-spacing:.34em;text-align:center">'+rev.value+'</div>' +
+            '<p class="meta" style="margin-top:12px">The old PIN stopped working the moment you rotated. Tonight’s closers at '+REST[rev.rest].short+' need this number before they can record tips.</p>') +
+        '<div class="blk" style="margin-top:18px;margin-bottom:0"><h4>Before you close this</h4>' +
+        '<label style="display:flex;gap:10px;align-items:flex-start;cursor:pointer;font-weight:600">' +
+          '<input type="checkbox" data-act="b-ackchk" style="margin-top:3px;accent-color:var(--accent-deep)"'+(st.ui.acked?" checked":"")+'>' +
+          '<span>'+(isQr?"I have printed or saved this sticker":"I have written this number down")+
+          '<span style="display:block;font-weight:400;color:var(--ink2);font-size:12.5px;margin-top:2px">There is no way to see it again.</span></span></label></div>' +
+      '</div>' +
+      '<div class="modal-foot">' +
+        '<button class="btn" data-act="b-copy" data-val="'+rev.value+'">Copy '+(isQr?"code":"PIN")+'</button>' +
+        (isQr ? '<button class="btn" data-act="b-print">Print sticker sheet</button>' : '') +
+        '<span class="spacer"></span>' +
+        '<button class="btn primary" data-act="b-ackdone"'+(st.ui.acked?"":" disabled")+'>Done</button>' +
+      '</div></div>';
+  }
+
+  const isQr = p.kind === "qr";
+  const isSignout = p.kind === "signout";
+  const a = st.access[p.rest];
+  let title, lede, list, cta;
+  if(isSignout){
+    title = "Sign out every phone at " + REST[p.rest].name + "?";
+    lede = a.phones + " device" + (a.phones===1?"":"s") + " signed in right now.";
+    list = ["Every phone at this restaurant is signed out immediately.",
+            "Tonight's closer has to scan the QR sticker again before they can record anything.",
+            "Nothing already recorded is affected."];
+    cta = "Sign out " + a.phones + " phones";
+  } else if(isQr){
+    title = "Rotate the QR sticker for " + REST[p.rest].name + "?";
+    lede = a.qr ? "Last rotated " + a.qr + "." : "This sticker has never been rotated.";
+    list = ["The sticker currently by the register stops working immediately.",
+            "You have to print the new one and physically replace it.",
+            "The new code is shown once and cannot be looked up afterwards."];
+    cta = "Rotate QR sticker";
+  } else {
+    title = "Rotate the PIN for " + REST[p.rest].name + "?";
+    lede = "Last rotated " + a.pin + ".";
+    list = ["The current PIN stops working immediately.",
+            "Every closer needs the new number before their next shift.",
+            "The new PIN is shown once and cannot be looked up afterwards."];
+    cta = "Rotate PIN";
+  }
+  return '<div class="scrim" data-act="b-mclose"></div><div class="modal" role="dialog" aria-modal="true" aria-labelledby="b-mt2">' +
+    '<div class="modal-head"><div style="flex:1"><h3 id="b-mt2">'+title+'</h3><div class="sub">'+lede+'</div></div>' +
+    '<button class="xbtn" data-act="b-mclose" aria-label="Close">×</button></div>' +
+    '<div class="modal-body"><ul style="margin:0;padding-left:20px;color:var(--ink2);font-size:13.5px;line-height:1.8">' +
+      list.map(x=>'<li>'+x+'</li>').join("") + '</ul></div>' +
+    '<div class="modal-foot"><span class="spacer"></span>' +
+      '<button class="btn ghost" data-act="b-mclose">Cancel</button>' +
+      '<button class="btn primary" data-act="b-rotate-go">'+cta+'</button></div></div>';
+}
+
+/* ============================================================
+   VARIANT C — PAYOUT
+   ============================================================ */
+function renderC(){
+  const st = S.c, rows = visible(st), t = totals(rows);
+  const pays = payouts(st, rows);
+  const roundDelta = t.dist - t.cash;
+
+  let h = '<div class="c-top">' +
+    '<div class="field"><label for="c-from">From</label><input id="c-from" type="date" value="'+st.filters.from+'" data-act="c-date" data-which="from"></div>' +
+    '<div class="field"><label for="c-to">To</label><input id="c-to" type="date" value="'+st.filters.to+'" data-act="c-date" data-which="to"></div>' +
+    '<div class="field"><label id="c-rl">Restaurant</label><div class="seg" role="group" aria-labelledby="c-rl">' +
+      ['all','sushi','poki'].map(k => '<button data-act="c-rest" data-k="'+k+'" aria-pressed="'+(st.filters.rest===k)+'">' +
+        (k==="all"?"Both":REST[k].short)+'</button>').join("") + '</div></div>' +
+    '<div style="margin-left:auto" class="btn-row"><button class="btn" data-act="export" data-v="c">Export CSV</button></div>' +
+  '</div>';
+
+  h += '<div class="c-cols"><div>';
+
+  /* LEFT: people and what they are owed */
+  h += '<section class="card"><div class="payhead">' +
+    '<div class="cap">Cash to hand out · '+t.n+' shifts</div>' +
+    '<div class="big">'+money(t.dist)+'</div>' +
+    '<p class="note">Across '+pays.length+' '+(pays.length===1?"person":"people")+'. This is cash only — card tips are in the grey box and are never part of it.</p></div>';
+
+  if(!pays.length){
+    h += '<div style="padding:34px;text-align:center;color:var(--muted)">Nobody worked a recorded shift in this range.</div>';
+  }
+
+  pays.forEach(p => {
+    const s = st.staff.find(x=>x.id===p.id) || {name:p.id, at:"sushi"};
+    const open = st.ui.openPerson === p.id;
+    const flaggedIn = p.lines.some(l => l.rec.flag);
+    h += '<div class="person">' +
+      '<button class="pbtn" data-act="c-person" data-id="'+p.id+'" aria-expanded="'+open+'">' +
+        '<span class="avatar '+(s.at==="both"?"both":s.at)+'" aria-hidden="true">'+esc(s.name.slice(0,1))+'</span>' +
+        '<span><span class="pname">'+esc(s.name)+(s.active?"":' <span class="tag off">inactive</span>')+'</span>' +
+        '<span class="pmeta">'+p.lines.length+' shift'+(p.lines.length===1?"":"s")+
+        (flaggedIn?' · <span style="color:var(--accent-deep);font-weight:650">includes a flagged shift</span>':'')+'</span></span>' +
+        '<span class="pamt"><span class="n">'+money(p.total)+'</span><span class="s">'+(open?"hide":"show")+' shifts</span></span>' +
+      '</button>';
+    if(open){
+      h += '<div class="pdetail">' + p.lines.map(l =>
+        '<div class="pdrow"><span class="d">'+dLabel(l.rec)+'</span>' +
+        '<span class="m">'+REST[l.rec.rest].short+' '+mealName(l.rec.meal)+' · '+money(l.rec.cash)+' ÷ '+l.rec.people.length +
+        (l.rec.flag?' <span class="tag flag">flagged</span>':'')+'</span>' +
+        '<span class="a">'+money(l.amt)+'</span>' +
+        '<button class="btn sm ghost" data-act="c-edit" data-id="'+l.rec.id+'">Correct</button></div>'
+      ).join("") + '</div>';
+    }
+    h += '</div>';
+  });
+
+  h += '<div class="recon"><dl>' +
+    '<dt>Cash pool recorded</dt><dd>'+money(t.cash)+'</dd>' +
+    '<dt>Sum of everyone’s shares</dt><dd>'+money(t.dist)+'</dd>' +
+    '<dt>Difference</dt><dd style="color:'+(roundDelta===0?"var(--ink2)":"var(--accent-deep)")+'">'+(roundDelta>0?"+":"")+money(roundDelta)+'</dd>' +
+    '</dl>' +
+    (roundDelta === 0
+      ? 'Shares divided evenly with nothing left over.'
+      : (roundDelta > 0
+        ? 'Two shifts landed on an exact half-cent and rounded <b>up</b>, so the shares come to '+money(roundDelta)+' more than the pool. The drawer covers it.'
+        : 'Remainders of '+money(-roundDelta)+' could not be divided and stayed in the drawer.')) +
+    ' This is expected — shares are rounded to the cent per shift, not reconciled across the range.</div>';
+  h += '</section>';
+
+  /* staff, under the payouts — same people, different job */
+  const counts = {};
+  st.records.forEach(r => r.people.forEach(p => counts[p] = (counts[p]||0)+1));
+  const nf = st.ui.newStaff || {name:"", at:"sushi"};
+  h += '<section class="card" style="margin-top:20px">' +
+    '<div style="padding:18px 20px 14px;border-bottom:1px solid var(--hair)"><div class="sec-head" style="margin:0">' +
+    '<h3>Roster</h3><span class="hint">Order = the phone picker</span></div></div>' +
+    '<div style="padding:14px 20px;background:var(--accent-tint);border-bottom:1px solid var(--hair)">' +
+      '<div style="display:grid;grid-template-columns:minmax(0,1.4fr) minmax(0,1fr) auto;gap:12px;align-items:end">' +
+      '<div class="field"><label for="c-nn">Add a new hire</label><input id="c-nn" placeholder="Name" value="'+esc(nf.name)+'" data-act="c-newname"></div>' +
+      '<div class="field"><label for="c-na">Works at</label><select id="c-na" data-act="c-newat">' +
+        '<option value="sushi"'+(nf.at==="sushi"?" selected":"")+'>Sushi</option>' +
+        '<option value="poki"'+(nf.at==="poki"?" selected":"")+'>Poki &amp; Pho</option>' +
+        '<option value="both"'+(nf.at==="both"?" selected":"")+'>Both</option></select></div>' +
+      '<button class="btn primary" data-act="c-add">Add to picker</button></div></div>';
+
+  st.staff.forEach((s,i) => {
+    const n = counts[s.id]||0;
+    const renaming = st.ui.renaming === s.id;
+    h += '<div class="keyrow" style="border-bottom:1px solid var(--hair)">' +
+      '<span class="grip meta" style="width:20px">'+(s.active?i+1:"—")+'</span>' +
+      '<span class="kw" style="min-width:170px">' +
+        (renaming
+          ? '<input value="'+esc(s.name)+'" data-act="c-renameinput" data-id="'+s.id+'" aria-label="Rename '+esc(s.name)+'" style="border:1px solid var(--accent);border-radius:8px;padding:4px 8px;width:130px">'
+          : '<b>'+esc(s.name)+'</b>') +
+        '<span>'+(s.at==="both"?"Both restaurants":REST[s.at].short)+' · '+(s.active?n+" shifts":"inactive · "+n+" shifts kept")+'</span></span>' +
+      '<span class="kb">' +
+        '<button class="btn sm" data-act="c-move" data-id="'+s.id+'" data-dir="-1" '+(i===0?"disabled":"")+' aria-label="Move '+esc(s.name)+' up">↑</button>' +
+        '<button class="btn sm" data-act="c-move" data-id="'+s.id+'" data-dir="1" '+(i===st.staff.length-1?"disabled":"")+' aria-label="Move '+esc(s.name)+' down">↓</button>' +
+        (renaming ? '<button class="btn sm primary" data-act="c-renamesave" data-id="'+s.id+'">Save</button>'
+                  : '<button class="btn sm ghost" data-act="c-rename" data-id="'+s.id+'">Rename</button>') +
+        '<select data-act="c-at" data-id="'+s.id+'" aria-label="'+esc(s.name)+' works at" class="btn sm" style="padding:4px 6px">' +
+          '<option value="sushi"'+(s.at==="sushi"?" selected":"")+'>Sushi</option>' +
+          '<option value="poki"'+(s.at==="poki"?" selected":"")+'>Poki</option>' +
+          '<option value="both"'+(s.at==="both"?" selected":"")+'>Both</option></select>' +
+        '<button class="btn sm" data-act="c-active" data-id="'+s.id+'">'+(s.active?"Deactivate":"Reactivate")+'</button>' +
+        (n===0 ? '<button class="btn sm danger" data-act="c-del" data-id="'+s.id+'">Delete</button>'
+               : '<button class="btn sm" disabled title="'+n+' recorded shifts — deactivate instead">Delete</button>') +
+      '</span></div>';
+  });
+  h += '<div style="padding:12px 20px" class="meta">Deactivate keeps every share they were ever paid. Delete is only possible before someone has worked a shift.</div></section>';
+
+  h += '</div><div>';
+
+  /* RIGHT: card quarantine, then the records as evidence, then keys */
+  h += '<section class="quarantine"><div class="qh">' +
+    '<span class="nosplit">'+NOSPLIT_ICON+'</span>' +
+    '<h3>Card tips — logged, never split</h3></div>' +
+    '<p>Recorded for payroll and reporting only. No part of this number is divided among staff or handed out at the end of a shift.</p>' +
+    '<div class="qtot">'+money(t.card)+'</div>' +
+    '<div class="qbreak">' +
+      ['sushi','poki'].map(rk => {
+        const sub = rows.filter(r=>r.rest===rk);
+        return '<div><b>'+money(totals(sub).card)+'</b>'+REST[rk].short+' · '+sub.length+' shifts</div>';
+      }).join("") +
+    '</div></section>';
+
+  h += '<section class="card" style="margin-top:20px">' +
+    '<div style="padding:18px 20px 14px"><div class="sec-head" style="margin:0"><h3>The shifts behind it</h3>' +
+    '<span class="hint">'+t.n+' records</span></div></div>' +
+    '<div class="reclist"><div class="rhead"><span>Date</span><span>Shift</span><span>Cash</span><span>Each</span><span></span></div>';
+  rows.forEach(r => {
+    const n = r.people.length, per = share(r.cash, n);
+    h += '<div class="rrow'+(r.flag?" flagged":"")+'">' +
+      '<span>'+dLabel(r)+'</span>' +
+      '<span><b>'+REST[r.rest].short+'</b> '+mealName(r.meal)+(r.flag?' <span class="tag flag">flagged</span>':'')+(r.edited?' <span class="tag">edited</span>':'') +
+        '<span class="ppl" style="display:block">'+esc(namesOf(st,r.people))+' · by '+esc(r.by)+' ('+r.how+')</span></span>' +
+      '<span class="cashv">'+money(r.cash)+'<span class="ppl" style="display:block">card '+money(r.card)+'</span></span>' +
+      '<span><b>'+money(per)+'</b><span class="ppl" style="display:block">÷ '+n+'</span></span>' +
+      '<span><button class="btn sm" data-act="c-edit" data-id="'+r.id+'">Correct</button></span>' +
+    '</div>';
+  });
+  if(!rows.length) h += '<div style="padding:30px;text-align:center;color:var(--muted)">No records in this range.</div>';
+  h += '</div></section>';
+
+  /* keys — locked until deliberately unlocked */
+  const unlocked = !!st.ui.keysUnlocked;
+  h += '<section class="card keys'+(unlocked?"":" locked")+'" style="margin-top:20px">' +
+    '<div class="lockbar"><span class="lk"><b>Device access</b>' +
+    '<span>QR stickers and PINs. Rotating one takes a restaurant offline until it is replaced.</span></span>' +
+    '<button class="btn '+(unlocked?"":"danger")+'" data-act="c-unlock" aria-pressed="'+unlocked+'">' +
+      (unlocked ? "Lock controls" : "Unlock controls") + '</button></div>' +
+    '<div class="keybody"'+(unlocked?"":' aria-hidden="true"')+'>' +
+    ['sushi','poki'].map(rk => {
+      const a = st.access[rk];
+      return '<div class="keyrow"><span class="kw"><b>'+REST[rk].short+' · QR sticker</b>' +
+          '<span>'+(a.qr ? "rotated "+a.qr : '<span style="color:var(--accent-deep);font-weight:650">never rotated</span>')+'</span></span>' +
+          '<span class="kb"><button class="btn sm danger" data-act="c-rotate" data-rest="'+rk+'" data-kind="qr"'+(unlocked?"":" tabindex=\"-1\"")+'>Rotate</button></span></div>' +
+        '<div class="keyrow"><span class="kw"><b>'+REST[rk].short+' · PIN</b><span>rotated '+a.pin+'</span></span>' +
+          '<span class="kb"><button class="btn sm danger" data-act="c-rotate" data-rest="'+rk+'" data-kind="pin"'+(unlocked?"":" tabindex=\"-1\"")+'>Rotate</button></span></div>' +
+        '<div class="keyrow"><span class="kw"><b>'+REST[rk].short+' · signed-in phones</b><span>'+a.phones+' active</span></span>' +
+          '<span class="kb"><button class="btn sm danger" data-act="c-signout" data-rest="'+rk+'"'+(unlocked?"":" tabindex=\"-1\"")+'>Sign out all</button></span></div>';
+    }).join("") + '</div></section>';
+
+  h += '</div></div>';
+  document.getElementById("body-c").innerHTML = h;
+}
+
+/* C correction modal — a full before/after diff */
+function modalC(){
+  const st = S.c;
+  if(!st.ui.draft) return "";
+  const r = draftRec("c"), d = st.ui.draft, nm = draftNums("c");
+  const roster = st.staff.filter(s => s.active && (s.at === "both" || s.at === r.rest));
+  const others = st.staff.filter(s => s.active && !(s.at === "both" || s.at === r.rest));
+  const ds = deltas("c");
+  const tr = typicalRange(st, r);
+  const chip = s => {
+    const on = d.people.includes(s.id);
+    return '<label class="chk'+(on?" on":"")+'"><input type="checkbox" data-act="c-person" data-id="'+s.id+'"'+(on?" checked":"")+'> '+esc(s.name)+'</label>';
+  };
+  const out = nm.valid ? nm.per * nm.n : 0, diff = nm.valid ? out - nm.cash : 0;
+
+  return '<div class="scrim" data-act="c-close"></div>' +
+    '<div class="modal" role="dialog" aria-modal="true" aria-labelledby="c-mt">' +
+    '<div class="modal-head"><div style="flex:1"><h3 id="c-mt">Correct a recorded shift</h3>' +
+      '<div class="sub">'+dLabel(r)+' · '+REST[r.rest].name+' · '+mealName(r.meal)+' · closed by '+esc(r.by)+' ('+r.how+')</div></div>' +
+      '<button class="xbtn" data-act="c-close" aria-label="Close">×</button></div>' +
+    '<div class="modal-body">' +
+      (r.flag && tr ? '<div class="warnline" style="margin:0 0 16px">Flagged as a possible typo — this slot normally runs '+money(tr.lo)+'–'+money(tr.hi)+'.</div>' : '') +
+      '<div class="grid2">' +
+        '<div class="blk" style="border-color:var(--accent);border-width:1.5px;margin:0">' +
+          '<h4 style="color:var(--accent-deep)">Cash — gets split</h4>' +
+          '<div class="money-in"><span>$</span><input id="c-cash" inputmode="decimal" value="'+d.cash+'" data-act="c-cash" aria-label="Cash pool"></div></div>' +
+        '<div class="blk" style="background:var(--logged-bg);border-color:rgba(0,0,0,.12);margin:0">' +
+          '<h4>Card — logged only</h4>' +
+          '<div class="money-in"><span>$</span><input id="c-card" inputmode="decimal" value="'+d.card+'" data-act="c-card" aria-label="Card amount"></div></div>' +
+      '</div>' +
+      '<div class="blk" style="margin-top:16px"><h4>On the split</h4>' +
+        '<div style="display:flex;flex-wrap:wrap;gap:7px">'+roster.map(chip).join("")+'</div>' +
+        (others.length ? '<p class="meta" style="margin:11px 0 6px">Not normally at '+REST[r.rest].short+'</p><div style="display:flex;flex-wrap:wrap;gap:7px">'+others.map(chip).join("")+'</div>' : '') +
+      '</div>' +
+      '<h4 style="font-size:11px;letter-spacing:.07em;text-transform:uppercase;color:var(--ink2);margin:20px 0 9px">What each person gets paid</h4>' +
+      (nm.valid
+        ? '<table class="difftable"><thead><tr><th scope="col">Person</th><th scope="col">Was</th><th scope="col">Becomes</th><th scope="col">Change</th></tr></thead><tbody>' +
+          ds.map(x => {
+            const cls = x.now === null ? "" : (x.was === null || x.now > x.was ? "up" : (x.now < x.was ? "down" : ""));
+            const delta = (x.was !== null && x.now !== null) ? x.now - x.was : null;
+            return '<tr class="'+cls+'"><td><b>'+esc(x.name)+'</b></td>' +
+              '<td>'+(x.was === null ? '<span class="meta">not on this shift</span>' : '<span class="was">'+money(x.was)+'</span>')+'</td>' +
+              '<td>'+(x.now === null ? '<span class="meta">removed</span>' : '<span class="now">'+money(x.now)+'</span>')+'</td>' +
+              '<td>'+(delta === null ? '<span class="meta">'+(x.now===null?"loses "+money(x.was):"gains "+money(x.now))+'</span>'
+                    : (delta === 0 ? '<span class="meta">no change</span>' : '<b>'+(delta>0?"+":"−")+money(Math.abs(delta))+'</b>'))+'</td></tr>';
+          }).join("") + '</tbody></table>' +
+          (diff !== 0 ? '<p class="meta" style="margin-top:10px">Shares total '+money(out)+' against a '+money(nm.cash)+' pool — a '+money(Math.abs(diff))+' rounding difference the drawer absorbs.</p>' : '') +
+          (nm.card !== r.card ? '<p class="meta" style="margin-top:6px">Card moves '+money(r.card)+' → '+money(nm.card)+'. It is logged only, so no row above changes because of it.</p>' : '')
+        : '<p style="color:var(--accent-deep);font-weight:600">'+(nm.n===0?"Pick at least one person before this can be saved.":"Enter a valid cash amount.")+'</p>') +
+    '</div>' +
+    '<div class="modal-foot"><span class="meta" style="flex:1">Applies immediately. No undo.</span>' +
+      '<button class="btn ghost" data-act="c-close">Cancel</button>' +
+      '<button class="btn primary" data-act="c-apply"'+(nm.valid?"":" disabled")+'>Apply — change what '+(nm.valid?nm.n:0)+' '+(nm.n===1?"person is":"people are")+' paid</button>' +
+    '</div></div>';
+}
+
+/* C rotation: confirm modal, then a full takeover for the one-time reveal */
+function overlayC(){
+  const st = S.c;
+  if(st.ui.draft) return modalC();
+  const rev = st.ui.reveal, p = st.ui.pending;
+
+  if(rev){
+    const isQr = rev.kind === "qr";
+    const steps = isQr
+      ? [{k:"print", t:"Print the new sticker", s:"The old one by the register at "+REST[rev.rest].short+" is already dead."},
+         {k:"stick", t:"Replace the sticker tonight, before close", s:"No phone can sign in at "+REST[rev.rest].short+" until it is up."},
+         {k:"saved", t:"I have saved or printed this code", s:"Only a hash is stored. This screen is the only time it exists."}]
+      : [{k:"tell",  t:"Tell tonight's closers the new number", s:"The old PIN stopped working the moment you rotated."},
+         {k:"saved", t:"I have written this number down", s:"Only a hash is stored. This screen is the only time it exists."}];
+    const done = steps.every(x => st.ui.checks && st.ui.checks[x.k]);
+    return '<div class="takeover" role="dialog" aria-modal="true" aria-labelledby="c-tk">' +
+      '<div class="sheet">' +
+        '<span class="once">'+NOSPLIT_ICON+' Shown once · unrecoverable</span>' +
+        '<h3 id="c-tk">New '+(isQr?"QR sticker":"PIN")+' — '+REST[rev.rest].name+'</h3>' +
+        '<p class="lede">Everything else on the dashboard is hidden until you have dealt with this, because there is no second chance to read it.</p>' +
+        (isQr
+          ? '<div class="qrbox">'+qrSvg(rev.value,180)+'<div style="flex:1;min-width:220px"><div class="secret">'+rev.value+'</div>' +
+            '<div class="btn-row" style="margin-top:12px"><button class="btn" data-act="c-copy" data-val="'+rev.value+'">Copy code</button>' +
+            '<button class="btn" data-act="c-print">Print sticker sheet</button></div></div></div>'
+          : '<div style="margin-top:18px"><div class="secret" style="font-size:40px;letter-spacing:.34em;text-align:center">'+rev.value+'</div>' +
+            '<div class="btn-row" style="margin-top:12px;justify-content:center"><button class="btn" data-act="c-copy" data-val="'+rev.value+'">Copy PIN</button></div></div>') +
+        '<ul class="checklist">' + steps.map(x =>
+          '<li><label><input type="checkbox" data-act="c-check" data-k="'+x.k+'"'+((st.ui.checks&&st.ui.checks[x.k])?" checked":"")+'>' +
+          '<span>'+x.t+'<span class="sub">'+x.s+'</span></span></label></li>').join("") + '</ul>' +
+        '<div class="btn-row" style="margin-top:20px;justify-content:flex-end">' +
+          '<button class="btn primary" data-act="c-ackdone"'+(done?"":" disabled")+'>' +
+          (done ? "Done — hide this forever" : "Check every box to continue") + '</button></div>' +
+      '</div></div>';
+  }
+
+  if(p){
+    const a = st.access[p.rest];
+    let title, list, cta;
+    if(p.kind === "signout"){
+      title = "Sign out all "+a.phones+" phones at "+REST[p.rest].short+"?";
+      list = ["Every signed-in phone is ended immediately.",
+              "Tonight's closer re-scans the QR sticker to get back in.",
+              "Records already saved are untouched."];
+      cta = "Sign out "+a.phones+" phones";
+    } else if(p.kind === "qr"){
+      title = "Rotate the QR sticker at "+REST[p.rest].short+"?";
+      list = ["The printed sticker stops working the instant you confirm.",
+              "You must print and physically replace it before the next close.",
+              "The new code appears once and is never retrievable."];
+      cta = "Rotate — the current sticker dies now";
+    } else {
+      title = "Rotate the PIN at "+REST[p.rest].short+"?";
+      list = ["The current PIN stops working the instant you confirm.",
+              "Every closer needs the new number before their next shift.",
+              "The new PIN appears once and is never retrievable."];
+      cta = "Rotate — the current PIN dies now";
+    }
+    return '<div class="scrim" data-act="c-mclose"></div><div class="modal" role="dialog" aria-modal="true" aria-labelledby="c-mt2">' +
+      '<div class="modal-head"><div style="flex:1"><h3 id="c-mt2">'+title+'</h3>' +
+      '<div class="sub">Infrequent and destructive. Read the three lines below.</div></div>' +
+      '<button class="xbtn" data-act="c-mclose" aria-label="Close">×</button></div>' +
+      '<div class="modal-body"><ul style="margin:0;padding-left:20px;color:var(--ink2);font-size:13.5px;line-height:1.85">' +
+        list.map(x=>'<li>'+x+'</li>').join("")+'</ul></div>' +
+      '<div class="modal-foot"><span class="spacer"></span><button class="btn ghost" data-act="c-mclose">Cancel</button>' +
+      '<button class="btn primary" data-act="c-rotate-go">'+cta+'</button></div></div>';
+  }
+  return "";
+}
+
+/* ============================================================
+   RENDER DISPATCH
+   ============================================================ */
+function renderOverlay(){
+  let h = "";
+  if(current === "b") h = drawerB() || modalB();
+  else if(current === "c") h = overlayC();
+  const o = document.getElementById("overlay");
+  const had = o.innerHTML !== "";
+  o.innerHTML = h;
+  if(h && !had){
+    const dlg = o.querySelector('[role="dialog"]');
+    if(dlg){
+      const f = dlg.querySelector('input,button,select,[tabindex]');
+      if(f) f.focus();
+    }
+  }
+  document.body.style.overflow = h ? "hidden" : "";
+}
+function render(v){
+  if(v === "a") renderA();
+  if(v === "b") renderB();
+  if(v === "c") renderC();
+  renderOverlay();
+}
+
+/* ============================================================
+   VARIANT SWITCHING
+   ============================================================ */
+function showVariant(v, focusPanel){
+  if(v === current) return;
+  scrollMem[current] = window.scrollY;
+  ["a","b","c"].forEach(k => {
+    document.getElementById("p-"+k).hidden = (k !== v);
+    const tab = document.getElementById("t-"+k);
+    tab.setAttribute("aria-selected", String(k === v));
+    tab.tabIndex = (k === v) ? 0 : -1;
+  });
+  current = v;
+  render(v);
+  window.scrollTo({top: scrollMem[v] || 0, behavior:"instant" in window ? "auto" : "auto"});
+  if(focusPanel) document.getElementById("t-"+v).focus();
+}
+document.querySelector(".switch").addEventListener("click", e => {
+  const b = e.target.closest("button[data-v]");
+  if(b) showVariant(b.dataset.v, false);
+});
+document.querySelector(".switch").addEventListener("keydown", e => {
+  if(e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+  const order = ["a","b","c"];
+  const i = order.indexOf(current);
+  const next = order[(i + (e.key === "ArrowRight" ? 1 : order.length-1)) % order.length];
+  e.preventDefault();
+  showVariant(next, true);
+});
+
+/* ============================================================
+   EVENTS — delegated once, dispatched by data-act
+   ============================================================ */
+function setPreset(st, k){
+  const map = {"7d":["2026-08-04","2026-08-10"], "14d":["2026-07-28","2026-08-10"], "pp":["2026-08-01","2026-08-15"]};
+  st.filters.preset = k; st.filters.from = map[k][0]; st.filters.to = map[k][1];
+}
+function moveStaff(st, id, dir){
+  const i = st.staff.findIndex(s=>s.id===id);
+  const j = i + dir;
+  if(j < 0 || j >= st.staff.length) return;
+  const t = st.staff[i]; st.staff[i] = st.staff[j]; st.staff[j] = t;
+}
+function addStaff(v, atStart){
+  const st = S[v];
+  const nf = st.ui.newStaff || {};
+  const name = (nf.name || "").trim();
+  if(!name){ toast("Give the new hire a name first."); return; }
+  const id = name.toLowerCase().replace(/[^a-z0-9]/g,"") + "-" + st.staff.length;
+  const person = {id, name, at: nf.at || "sushi", active:true};
+  if(atStart) st.staff.unshift(person); else st.staff.push(person);
+  st.ui.newStaff = {name:"", at: nf.at || "sushi", pos: nf.pos || "end"};
+  st.ui.adding = false;
+  toast("<b>"+esc(name)+"</b> added — they show in the "+
+    (person.at==="both" ? "picker at both restaurants" : REST[person.at].short+" picker") + " tonight.");
+  render(v);
+}
+function doRotate(v, rest, kind){
+  const st = S[v];
+  if(kind === "signout"){
+    const n = st.access[rest].phones;
+    st.access[rest].phones = 0;
+    st.ui.pending = null;
+    toast("Signed out <b>"+n+" phone"+(n===1?"":"s")+"</b> at "+REST[rest].name+". They must scan the sticker again.");
+    render(v); return;
+  }
+  const value = kind === "qr" ? newToken(rest) : newPin();
+  st.access[rest][kind] = "Today · " + TODAY_LABEL;
+  st.ui.pending = null;
+  st.ui.reveal = {rest, kind, value};
+  st.ui.acked = false;
+  st.ui.checks = {};
+  render(v);
+}
+function copyVal(val){
+  if(navigator.clipboard && navigator.clipboard.writeText){
+    navigator.clipboard.writeText(val).then(()=>toast("Copied."), ()=>toast("Copy blocked — select it by hand."));
+  } else toast("Copy blocked here — select it by hand.");
+}
+
+document.addEventListener("click", e => {
+  const el = e.target.closest("[data-act]");
+  if(!el) return;
+  const act = el.dataset.act;
+  const st = S[current];
+
+  /* shared */
+  if(act === "export"){ exportCsv(el.dataset.v); return; }
+
+  /* ---------- variant A ---------- */
+  if(act === "a-preset"){ setPreset(S.a, el.dataset.k); render("a"); return; }
+  if(act === "a-edit"){
+    if(S.a.ui.draft && S.a.ui.draft.id === el.dataset.id) S.a.ui.draft = null;
+    else startDraft("a", el.dataset.id);
+    render("a");
+    const inp = document.getElementById("a-cash"); if(inp) inp.focus();
+    return;
+  }
+  if(act === "a-cancel"){ S.a.ui.draft = null; render("a"); return; }
+  if(act === "a-apply"){ commitDraft("a"); render("a"); return; }
+  if(act === "a-move"){ moveStaff(S.a, el.dataset.id, Number(el.dataset.dir)); render("a"); return; }
+  if(act === "a-add"){ addStaff("a", false); return; }
+  if(act === "a-rename"){ S.a.ui.renaming = el.dataset.id; render("a");
+    const i = document.querySelector('[data-act="a-renameinput"]'); if(i){i.focus(); i.select();} return; }
+  if(act === "a-renamesave"){ S.a.ui.renaming = null; render("a"); toast("Name updated."); return; }
+  if(act === "a-active"){
+    const s = S.a.staff.find(x=>x.id===el.dataset.id); s.active = !s.active;
+    toast(s.active ? "<b>"+esc(s.name)+"</b> is back in the picker."
+      : "<b>"+esc(s.name)+"</b> removed from the picker. Every past shift and share is kept.");
+    render("a"); return;
+  }
+  if(act === "a-del"){
+    const s = S.a.staff.find(x=>x.id===el.dataset.id);
+    S.a.staff = S.a.staff.filter(x=>x.id!==el.dataset.id);
+    toast("<b>"+esc(s.name)+"</b> deleted — they had no recorded shifts.");
+    render("a"); return;
+  }
+  if(act === "a-rotate"){ S.a.ui.pending = {rest:el.dataset.rest, kind:el.dataset.kind}; S.a.ui.reveal = null; render("a"); return; }
+  if(act === "a-rotate-cancel"){ S.a.ui.pending = null; render("a"); return; }
+  if(act === "a-rotate-go"){ doRotate("a", el.dataset.rest, el.dataset.kind); return; }
+  if(act === "a-ackdone"){ S.a.ui.reveal = null; S.a.ui.acked = false; toast("Rotated. The code is gone — rotate again if you lost it."); render("a"); return; }
+  if(act === "a-copy"){ copyVal(el.dataset.val); return; }
+  if(act === "a-signout"){
+    const rk = el.dataset.rest;
+    if(S.a.ui.confirmSignout === rk){ S.a.ui.confirmSignout = null; doRotate("a", rk, "signout"); }
+    else { S.a.ui.confirmSignout = rk;
+      toast("Click again to sign out all phones at <b>"+REST[rk].short+"</b> — they will need the sticker to get back in.");
+      setTimeout(()=>{ S.a.ui.confirmSignout = null; }, 6000); }
+    return;
+  }
+
+  /* ---------- variant B ---------- */
+  if(act === "b-rest"){ S.b.filters.rest = el.dataset.k; render("b"); return; }
+  if(act === "b-open"){ startDraft("b", el.dataset.id); S.b.ui.trigger = el; render("b"); return; }
+  if(act === "b-close"){ S.b.ui.draft = null; render("b"); if(S.b.ui.trigger && document.body.contains(S.b.ui.trigger)) S.b.ui.trigger.focus(); return; }
+  if(act === "b-step2"){ S.b.ui.draft.step = 2; render("b"); return; }
+  if(act === "b-step1"){ S.b.ui.draft.step = 1; render("b"); return; }
+  if(act === "b-apply"){ commitDraft("b"); render("b"); return; }
+  if(act === "b-addopen"){ S.b.ui.adding = true; render("b"); const i = document.getElementById("b-nn"); if(i) i.focus(); return; }
+  if(act === "b-addclose"){ S.b.ui.adding = false; render("b"); return; }
+  if(act === "b-add"){ addStaff("b", (S.b.ui.newStaff||{}).pos === "start"); return; }
+  if(act === "b-move"){ moveStaff(S.b, el.dataset.id, Number(el.dataset.dir)); render("b"); return; }
+  if(act === "b-rename"){
+    const s = S.b.staff.find(x=>x.id===el.dataset.id);
+    const n = window.prompt("Rename " + s.name + " to:", s.name);
+    if(n && n.trim()){ s.name = n.trim(); toast("Renamed to <b>"+esc(s.name)+"</b>. Past shifts follow the new name."); render("b"); }
+    return;
+  }
+  if(act === "b-active"){
+    const s = S.b.staff.find(x=>x.id===el.dataset.id); s.active = !s.active;
+    toast(s.active ? "<b>"+esc(s.name)+"</b> is back in the picker."
+      : "<b>"+esc(s.name)+"</b> is off the picker. Their history is untouched.");
+    render("b"); return;
+  }
+  if(act === "b-del"){
+    const s = S.b.staff.find(x=>x.id===el.dataset.id);
+    S.b.staff = S.b.staff.filter(x=>x.id!==el.dataset.id);
+    toast("<b>"+esc(s.name)+"</b> deleted."); render("b"); return;
+  }
+  if(act === "b-rotate"){ S.b.ui.pending = {rest:el.dataset.rest, kind:el.dataset.kind}; render("b"); return; }
+  if(act === "b-signout"){ S.b.ui.pending = {rest:el.dataset.rest, kind:"signout"}; render("b"); return; }
+  if(act === "b-mclose"){ S.b.ui.pending = null; render("b"); return; }
+  if(act === "b-rotate-go"){ doRotate("b", S.b.ui.pending.rest, S.b.ui.pending.kind); return; }
+  if(act === "b-ackdone"){ S.b.ui.reveal = null; S.b.ui.acked = false; toast("Done. That code cannot be shown again."); render("b"); return; }
+  if(act === "b-copy"){ copyVal(el.dataset.val); return; }
+  if(act === "b-print"){ toast("Sticker sheet sent to the printer."); return; }
+
+  /* ---------- variant C ---------- */
+  if(act === "c-rest"){ S.c.filters.rest = el.dataset.k; render("c"); return; }
+  if(act === "c-person"){ S.c.ui.openPerson = (S.c.ui.openPerson === el.dataset.id) ? null : el.dataset.id; render("c"); return; }
+  if(act === "c-edit"){ startDraft("c", el.dataset.id); render("c"); return; }
+  if(act === "c-close"){ S.c.ui.draft = null; render("c"); return; }
+  if(act === "c-apply"){ commitDraft("c"); render("c"); return; }
+  if(act === "c-add"){ addStaff("c", false); return; }
+  if(act === "c-move"){ moveStaff(S.c, el.dataset.id, Number(el.dataset.dir)); render("c"); return; }
+  if(act === "c-rename"){ S.c.ui.renaming = el.dataset.id; render("c");
+    const i = document.querySelector('[data-act="c-renameinput"]'); if(i){i.focus(); i.select();} return; }
+  if(act === "c-renamesave"){ S.c.ui.renaming = null; render("c"); toast("Name updated."); return; }
+  if(act === "c-active"){
+    const s = S.c.staff.find(x=>x.id===el.dataset.id); s.active = !s.active;
+    toast(s.active ? "<b>"+esc(s.name)+"</b> reactivated." : "<b>"+esc(s.name)+"</b> deactivated — every share they were paid is kept.");
+    render("c"); return;
+  }
+  if(act === "c-del"){
+    const s = S.c.staff.find(x=>x.id===el.dataset.id);
+    S.c.staff = S.c.staff.filter(x=>x.id!==el.dataset.id);
+    toast("<b>"+esc(s.name)+"</b> deleted."); render("c"); return;
+  }
+  if(act === "c-unlock"){ S.c.ui.keysUnlocked = !S.c.ui.keysUnlocked; render("c"); return; }
+  if(act === "c-rotate"){ S.c.ui.pending = {rest:el.dataset.rest, kind:el.dataset.kind}; render("c"); return; }
+  if(act === "c-signout"){ S.c.ui.pending = {rest:el.dataset.rest, kind:"signout"}; render("c"); return; }
+  if(act === "c-mclose"){ S.c.ui.pending = null; render("c"); return; }
+  if(act === "c-rotate-go"){ doRotate("c", S.c.ui.pending.rest, S.c.ui.pending.kind); return; }
+  if(act === "c-ackdone"){ S.c.ui.reveal = null; S.c.ui.checks = {}; S.c.ui.keysUnlocked = false;
+    toast("Rotated. Controls re-locked."); render("c"); return; }
+  if(act === "c-copy"){ copyVal(el.dataset.val); return; }
+  if(act === "c-print"){ toast("Sticker sheet sent to the printer."); return; }
+});
+
+/* live inputs — targeted updates so focus and caret survive */
+document.addEventListener("input", e => {
+  const el = e.target.closest("[data-act]");
+  if(!el) return;
+  const act = el.dataset.act;
+
+  /* A */
+  if(act === "a-date"){ S.a.filters[el.dataset.which] = el.value; S.a.filters.preset = null; render("a"); return; }
+  if(act === "a-rest"){ S.a.filters.rest = el.value; render("a"); return; }
+  if(act === "a-cash" || act === "a-card"){
+    S.a.ui.draft[act === "a-cash" ? "cash" : "card"] = el.value;
+    const p = document.getElementById("a-preview"); if(p) p.innerHTML = previewA();
+    const btn = document.querySelector('[data-act="a-apply"]'); if(btn) btn.disabled = !draftNums("a").valid;
+    return;
+  }
+  if(act === "a-person"){
+    const d = S.a.ui.draft, id = el.dataset.id;
+    if(el.checked){ if(!d.people.includes(id)) d.people.push(id); }
+    else d.people = d.people.filter(x=>x!==id);
+    el.closest("label").classList.toggle("on", el.checked);
+    const p = document.getElementById("a-preview"); if(p) p.innerHTML = previewA();
+    const btn = document.querySelector('[data-act="a-apply"]'); if(btn) btn.disabled = !draftNums("a").valid;
+    return;
+  }
+  if(act === "a-newname"){ S.a.ui.newStaff = Object.assign({at:"sushi"}, S.a.ui.newStaff, {name:el.value}); return; }
+  if(act === "a-newat"){ S.a.ui.newStaff = Object.assign({name:""}, S.a.ui.newStaff, {at:el.value}); return; }
+  if(act === "a-renameinput"){ S.a.staff.find(s=>s.id===el.dataset.id).name = el.value; return; }
+  if(act === "a-at"){ S.a.staff.find(s=>s.id===el.dataset.id).at = el.value; render("a"); return; }
+  if(act === "a-ackchk"){ S.a.ui.acked = el.checked;
+    const b = document.querySelector('[data-act="a-ackdone"]'); if(b) b.disabled = !el.checked; return; }
+
+  /* B */
+  if(act === "b-date"){ S.b.filters[el.dataset.which] = el.value; render("b"); return; }
+  if(act === "b-cash" || act === "b-card"){
+    S.b.ui.draft[act === "b-cash" ? "cash" : "card"] = el.value;
+    updateBResult(); return;
+  }
+  if(act === "b-person"){
+    const d = S.b.ui.draft, id = el.dataset.id;
+    if(el.checked){ if(!d.people.includes(id)) d.people.push(id); }
+    else d.people = d.people.filter(x=>x!==id);
+    el.closest("label").classList.toggle("on", el.checked);
+    updateBResult(); return;
+  }
+  if(act === "b-newname"){ S.b.ui.newStaff = Object.assign({at:"sushi",pos:"end"}, S.b.ui.newStaff, {name:el.value}); return; }
+  if(act === "b-newat"){ S.b.ui.newStaff = Object.assign({name:"",pos:"end"}, S.b.ui.newStaff, {at:el.value}); return; }
+  if(act === "b-newpos"){ S.b.ui.newStaff = Object.assign({name:"",at:"sushi"}, S.b.ui.newStaff, {pos:el.value}); return; }
+  if(act === "b-at"){ S.b.staff.find(s=>s.id===el.dataset.id).at = el.value; render("b"); return; }
+  if(act === "b-ackchk"){ S.b.ui.acked = el.checked;
+    const btn = document.querySelector('[data-act="b-ackdone"]'); if(btn) btn.disabled = !el.checked; return; }
+
+  /* C */
+  if(act === "c-date"){ S.c.filters[el.dataset.which] = el.value; render("c"); return; }
+  if(act === "c-cash" || act === "c-card"){
+    S.c.ui.draft[act === "c-cash" ? "cash" : "card"] = el.value;
+    rerenderCModal(); return;
+  }
+  if(act === "c-person"){
+    const d = S.c.ui.draft, id = el.dataset.id;
+    if(el.checked){ if(!d.people.includes(id)) d.people.push(id); }
+    else d.people = d.people.filter(x=>x!==id);
+    rerenderCModal(); return;
+  }
+  if(act === "c-newname"){ S.c.ui.newStaff = Object.assign({at:"sushi"}, S.c.ui.newStaff, {name:el.value}); return; }
+  if(act === "c-newat"){ S.c.ui.newStaff = Object.assign({name:""}, S.c.ui.newStaff, {at:el.value}); return; }
+  if(act === "c-renameinput"){ S.c.staff.find(s=>s.id===el.dataset.id).name = el.value; return; }
+  if(act === "c-at"){ S.c.staff.find(s=>s.id===el.dataset.id).at = el.value; render("c"); return; }
+  if(act === "c-check"){
+    /* update the gate in place — re-rendering the takeover would replace the
+       checklist under the user's cursor and drop keyboard focus */
+    S.c.ui.checks = S.c.ui.checks || {};
+    S.c.ui.checks[el.dataset.k] = el.checked;
+    const boxes = [...document.querySelectorAll('[data-act="c-check"]')];
+    const done = boxes.length > 0 && boxes.every(b => b.checked);
+    const btn = document.querySelector('[data-act="c-ackdone"]');
+    if(btn){
+      btn.disabled = !done;
+      btn.textContent = done ? "Done — hide this forever" : "Check every box to continue";
+    }
+    return;
+  }
+});
+
+/* keep caret/focus while the B result block and C diff recompute */
+function updateBResult(){
+  const nm = draftNums("b");
+  const blk = document.querySelectorAll("#b-drawer .blk");
+  const last = blk[blk.length-1];
+  if(last && last.querySelector("h4") && last.querySelector("h4").textContent === "Result"){
+    last.innerHTML = '<h4>Result</h4>' + (nm.valid
+      ? '<div style="font-size:30px;font-weight:700;letter-spacing:-.02em">'+money(nm.per)+'</div>' +
+        '<p class="meta">each · '+money(nm.cash)+' ÷ '+nm.n+'</p>'
+      : '<p style="color:var(--accent-deep);font-weight:600">'+(nm.n===0?"Pick at least one person.":"Enter a valid cash amount.")+'</p>');
+  }
+  const hdr = document.querySelectorAll("#b-drawer .blk h4");
+  hdr.forEach(x => { if(x.textContent.indexOf("On the split") === 0)
+    x.textContent = "On the split — " + nm.n + " " + (nm.n===1?"person":"people"); });
+  const btn = document.querySelector('[data-act="b-step2"]');
+  if(btn) btn.disabled = !nm.valid;
+}
+function rerenderCModal(){
+  const focusId = document.activeElement && document.activeElement.id;
+  const selStart = document.activeElement && document.activeElement.selectionStart;
+  renderOverlay();
+  if(focusId){
+    const el = document.getElementById(focusId);
+    if(el){ el.focus(); if(selStart != null && el.setSelectionRange){ try{ el.setSelectionRange(selStart, selStart); }catch(_){} } }
+  }
+}
+
+/* change events for selects that need a full re-render */
+document.addEventListener("change", e => {
+  const el = e.target.closest("[data-act]");
+  if(!el) return;
+  if(el.dataset.act === "a-rest"){ S.a.filters.rest = el.value; render("a"); }
+});
+
+/* Esc closes any overlay */
+document.addEventListener("keydown", e => {
+  if(e.key !== "Escape") return;
+  const st = S[current];
+  if(st.ui.reveal) return;            /* the one-time reveal is not Esc-dismissible */
+  if(st.ui.draft || st.ui.pending){ st.ui.draft = null; st.ui.pending = null; render(current); }
+});
+/* Enter in the add-staff name field adds */
+document.addEventListener("keydown", e => {
+  if(e.key !== "Enter") return;
+  const el = e.target.closest("[data-act]");
+  if(!el) return;
+  if(el.dataset.act === "a-newname"){ e.preventDefault(); addStaff("a", false); }
+  if(el.dataset.act === "b-newname"){ e.preventDefault(); addStaff("b", (S.b.ui.newStaff||{}).pos === "start"); }
+  if(el.dataset.act === "c-newname"){ e.preventDefault(); addStaff("c", false); }
+  if(el.dataset.act === "a-renameinput"){ e.preventDefault(); S.a.ui.renaming = null; render("a"); }
+  if(el.dataset.act === "c-renameinput"){ e.preventDefault(); S.c.ui.renaming = null; render("c"); }
+});
+/* remember whether the B access section was left open */
+document.addEventListener("toggle", e => {
+  if(e.target.matches('details.access')) S.b.ui.accOpen = e.target.open;
+}, true);
+
+/* boot */
+render("a"); render("b"); render("c");
+</script>
+</body>
+</html>

--- a/docs/mockups/tips-dashboard/core/tips-core.js
+++ b/docs/mockups/tips-dashboard/core/tips-core.js
@@ -1,0 +1,187 @@
+/**
+ * TipsCore is the dependency-free data and calculation API for the tips ledger.
+ *
+ * API:
+ * - money(cents): format integer cents as US currency.
+ * - parseMoney(str): parse a non-negative currency value into integer cents.
+ * - perShare(cashCents, nPeople): calculate a rounded per-person cash share.
+ * - seeded(seed): create the ledger's deterministic LCG.
+ * - mkSched(spec): create a weekly lunch/dinner schedule.
+ * - STAFF_SEED: the seven reference staff records and their schedules.
+ * - REAL_RECORDS: the ten reference records from August 6–9, 2026.
+ * - generateHistory(staff): generate deterministic history from May 1–August 5.
+ * - buildRecords(staff): combine and sort generated and reference records.
+ * - filterRecords(records, options): select an inclusive date range and restaurant.
+ * - grouping(spanDays): select day, week, or month grouping behavior.
+ * - groupRecords(records, spanDays): return grouped records and payment totals.
+ * - totals(records): total cash, card, record count, and flagged count.
+ * - toCSV(records): serialize records using the ledger CSV format.
+ */
+(function(global){
+'use strict';
+
+var DATA_START=new Date(2026,4,1);
+var RESTS={sushi:'Sushi', poki:'Poki & Pho'};
+var DAYKEYS=['sun','mon','tue','wed','thu','fri','sat'];
+var WEEKORDER=['mon','tue','wed','thu','fri','sat','sun'];
+var MONS=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+var MONSFULL=['January','February','March','April','May','June','July','August','September','October','November','December'];
+var DOWS=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+function money(c){return '$'+(c/100).toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2});}
+function parseMoney(v){var n=parseFloat(String(v).replace(/[$,\s]/g,''));return (isFinite(n)&&n>=0)?Math.round(n*100):null;}
+function perShare(cashCents,nPeople){return Math.round(cashCents/nPeople);}
+function sum(a,f){return a.reduce(function(t,x){return t+f(x);},0);}
+function dstamp(d){return new Date(d.getFullYear(),d.getMonth(),d.getDate()).getTime();}
+function fmtDay(t){var d=new Date(t);return DOWS[d.getDay()]+' '+MONS[d.getMonth()]+' '+d.getDate();}
+function addDays(d,n){return new Date(d.getFullYear(),d.getMonth(),d.getDate()+n);}
+function mondayOf(d){return addDays(d,-((d.getDay()+6)%7));}
+function seeded(seed){var s=seed>>>0;return function(){s=(Math.imul(s,1664525)+1013904223)>>>0;return s/4294967296;};}
+function q25(c){return Math.round(c/25)*25;}
+
+function mkSched(spec){
+  var s={}; WEEKORDER.forEach(function(d){s[d]={L:false,D:false};});
+  spec.split(' ').forEach(function(tok){
+    if(!tok)return; var d=tok.slice(0,3), ms=tok.slice(3);
+    if(ms.indexOf('L')>=0)s[d].L=true; if(ms.indexOf('D')>=0)s[d].D=true;
+  });
+  return s;
+}
+
+var STAFF_SEED=[
+ {id:'maria', name:'Maria', works:'sushi', active:true,  sched:mkSched('monL tueL thuLD friLD sunLD')},
+ {id:'jose',  name:'Jose',  works:'sushi', active:true,  sched:mkSched('tueD wedD thuD friD satD sunD')},
+ {id:'ken',   name:'Ken',   works:'both',  active:true,  sched:mkSched('monD wedLD thuD satD sunLD')},
+ {id:'rey',   name:'Rey',   works:'both',  active:true,  sched:mkSched('monL friD satD')},
+ {id:'lena',  name:'Lena',  works:'poki',  active:true,  sched:mkSched('monL wedL friL satLD sunD')},
+ {id:'tom',   name:'Tom',   works:'poki',  active:true,  sched:mkSched('tueD thuD friD satD sunD')},
+ {id:'aiko',  name:'Aiko',  works:'sushi', active:false, sched:mkSched('')}
+];
+
+function generateHistory(staff){
+  staff=staff||STAFF_SEED;
+  var rnd=seeded(20260810), out=[], id=1;
+  var aikoUntil=new Date(2026,6,1).getTime();  /* Aiko left end of June */
+  for(var d=new Date(DATA_START); d<=new Date(2026,7,5); d=addDays(d,1)){
+    var dow=DAYKEYS[d.getDay()];
+    var wk=(d.getDay()===0||d.getDay()>=5);
+    ['sushi','poki'].forEach(function(rest){
+      ['Lunch','Dinner'].forEach(function(meal){
+        var mk=meal==='Lunch'?'L':'D';
+        var pool=staff.filter(function(s){
+          if(s.id==='aiko') return rest==='sushi'&&d.getTime()<aikoUntil&&mk==='D';
+          return (s.works===rest||s.works==='both')&&s.sched[dow][mk];
+        }).map(function(s){return s.name;});
+        if(!pool.length) return;                       /* nobody scheduled → shift not recorded */
+        if(meal==='Lunch'&&rnd()<0.12) return;         /* occasionally lunch goes unrecorded */
+        var n=1+(rnd()<0.7?1:0)+(rnd()<0.3?1:0); if(n>pool.length)n=pool.length;
+        for(var i=pool.length-1;i>0;i--){var j=Math.floor(rnd()*(i+1));var t=pool[i];pool[i]=pool[j];pool[j]=t;}
+        var people=pool.slice(0,n);
+        var range = rest==='sushi'
+          ? (meal==='Dinner'?(wk?[25000,42000]:[18000,33000]):(wk?[7000,14000]:[6000,11000]))
+          : (meal==='Dinner'?(wk?[15000,26000]:[12000,22000]):[5000,11000]);
+        var cash=q25(range[0]+rnd()*(range[1]-range[0]));
+        var card=q25(cash*(1.35+rnd()*0.75));
+        out.push({id:'g'+(id++), t:dstamp(d), rest:rest, meal:meal, cash:cash, card:card,
+                  people:people, by:people[Math.floor(rnd()*people.length)],
+                  mode:rnd()<0.3?'voice':'typed', flag:false});
+      });
+    });
+  }
+  return out;
+}
+
+var REAL_RECORDS=[
+ {id:'r1', t:dstamp(new Date(2026,7,9)), rest:'sushi', meal:'Dinner', cash:41200,  card:68850, people:['Maria','Jose','Ken'], by:'Maria', mode:'voice', flag:false},
+ {id:'r2', t:dstamp(new Date(2026,7,9)), rest:'sushi', meal:'Lunch',  cash:9625,   card:21000, people:['Maria','Ken'],       by:'Ken',   mode:'typed', flag:false},
+ {id:'r3', t:dstamp(new Date(2026,7,9)), rest:'poki',  meal:'Dinner', cash:18800,  card:40275, people:['Lena','Tom'],        by:'Lena',  mode:'typed', flag:false},
+ {id:'r4', t:dstamp(new Date(2026,7,8)), rest:'sushi', meal:'Dinner', cash:36650,  card:59400, people:['Jose','Ken','Rey'],  by:'Ken',   mode:'typed', flag:false},
+ {id:'r5', t:dstamp(new Date(2026,7,8)), rest:'poki',  meal:'Dinner', cash:20575,  card:38800, people:['Lena','Tom','Rey'],  by:'Rey',   mode:'voice', flag:false},
+ {id:'r6', t:dstamp(new Date(2026,7,8)), rest:'poki',  meal:'Lunch',  cash:7400,   card:16525, people:['Lena'],              by:'Lena',  mode:'typed', flag:false},
+ {id:'r7', t:dstamp(new Date(2026,7,7)), rest:'sushi', meal:'Dinner', cash:310000, card:61000, people:['Maria','Jose'],      by:'Jose',  mode:'voice', flag:true},
+ {id:'r8', t:dstamp(new Date(2026,7,7)), rest:'sushi', meal:'Lunch',  cash:8850,   card:17400, people:['Maria'],             by:'Maria', mode:'typed', flag:false},
+ {id:'r9', t:dstamp(new Date(2026,7,7)), rest:'poki',  meal:'Dinner', cash:19725,  card:35150, people:['Tom','Rey'],         by:'Tom',   mode:'typed', flag:false},
+ {id:'r10',t:dstamp(new Date(2026,7,6)), rest:'sushi', meal:'Dinner', cash:34400,  card:56125, people:['Maria','Jose','Ken'],by:'Maria', mode:'typed', flag:false}
+];
+
+function buildRecords(staff){
+  var records=generateHistory(staff||STAFF_SEED).concat(REAL_RECORDS);
+  records.sort(function(a,b){
+    if(a.t!==b.t)return b.t-a.t;
+    if(a.rest!==b.rest)return a.rest==='sushi'?-1:1;
+    return a.meal==='Dinner'?-1:1;
+  });
+  return records;
+}
+
+function filterRecords(records,options){
+  var startT=options.startT, endT=options.endT, rest=options.rest;
+  return records.filter(function(r){
+    if(r.t<startT||r.t>endT)return false;
+    if(rest!=='all'&&r.rest!==rest)return false;
+    return true;
+  });
+}
+
+function grouping(spanDays){
+  if(spanDays<=16) return {mode:'day', key:function(r){return r.t;}, label:function(k){return fmtDay(k)+' — day total';}};
+  if(spanDays<=100) return {mode:'week', key:function(r){return mondayOf(new Date(r.t)).getTime();},
+    label:function(k){var m=new Date(k),e=addDays(m,6);return 'Week of '+MONS[m.getMonth()]+' '+m.getDate()+' – '+(e.getMonth()===m.getMonth()?'':MONS[e.getMonth()]+' ')+e.getDate()+' — total';}};
+  return {mode:'month', key:function(r){var d=new Date(r.t);return new Date(d.getFullYear(),d.getMonth(),1).getTime();},
+    label:function(k){var d=new Date(k);return MONSFULL[d.getMonth()]+' '+d.getFullYear()+' — total';}};
+}
+
+function groupRecords(records,spanDays){
+  var behavior=grouping(spanDays), groups=[];
+  records.forEach(function(r){
+    var key=behavior.key(r), group=null;
+    for(var i=0;i<groups.length;i++)if(groups[i].key===key){group=groups[i];break;}
+    if(!group){
+      group={key:key,label:behavior.label(key),records:[],cashTotal:0,cardTotal:0};
+      groups.push(group);
+    }
+    group.records.push(r);
+    group.cashTotal+=r.cash;
+    group.cardTotal+=r.card;
+  });
+  return groups;
+}
+
+function totals(records){
+  return {
+    cash:sum(records,function(r){return r.cash;}),
+    card:sum(records,function(r){return r.card;}),
+    count:records.length,
+    flagged:records.filter(function(r){return r.flag;}).length
+  };
+}
+
+function csvField(v){v=String(v);return /[",\n]/.test(v)?'"'+v.replace(/"/g,'""')+'"':v;}
+function toCSV(records){
+  var rows=['Business date,Restaurant,Meal,Cash (split pool),Card (logged only),People on split,Names,Per-person share,Flagged,Entered by,Entry method'];
+  records.forEach(function(r){
+    rows.push([fmtDay(r.t)+' '+new Date(r.t).getFullYear(),RESTS[r.rest],r.meal,(r.cash/100).toFixed(2),(r.card/100).toFixed(2),r.people.length,'"'+r.people.join('; ').replace(/"/g,'""')+'"',(perShare(r.cash,r.people.length)/100).toFixed(2),r.flag?'yes':'no',csvField(r.by),r.mode].join(','));
+  });
+  return rows.join('\n');
+}
+
+var api={
+  money:money,
+  parseMoney:parseMoney,
+  perShare:perShare,
+  seeded:seeded,
+  mkSched:mkSched,
+  STAFF_SEED:STAFF_SEED,
+  REAL_RECORDS:REAL_RECORDS,
+  generateHistory:generateHistory,
+  buildRecords:buildRecords,
+  filterRecords:filterRecords,
+  grouping:grouping,
+  groupRecords:groupRecords,
+  totals:totals,
+  toCSV:toCSV
+};
+
+global.TipsCore=api;
+if(typeof module!=='undefined')module.exports=api;
+})(globalThis);

--- a/docs/mockups/tips-dashboard/core/tips-core.test.js
+++ b/docs/mockups/tips-dashboard/core/tips-core.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+var assert=require('node:assert/strict');
+var fs=require('node:fs');
+var path=require('node:path');
+var vm=require('node:vm');
+var corePath=path.join(__dirname,'tips-core.js');
+var TipsCore=require(corePath);
+var passCount=0;
+
+function check(actual,expected,message){
+  assert.deepStrictEqual(actual,expected,message);
+  passCount++;
+}
+
+var expectedShares={
+  r1:13733,
+  r2:4813,
+  r3:9400,
+  r4:12217,
+  r5:6858,
+  r6:7400,
+  r7:155000,
+  r8:8850,
+  r9:9863,
+  r10:11467
+};
+
+TipsCore.REAL_RECORDS.forEach(function(record){
+  check(
+    TipsCore.perShare(record.cash,record.people.length),
+    expectedShares[record.id],
+    'per-person share for '+record.id
+  );
+});
+check(TipsCore.perShare(9625,2),4813,'9625 cents split two ways rounds half a cent up');
+check(TipsCore.perShare(19725,2),9863,'19725 cents split two ways rounds half a cent up');
+
+var records=TipsCore.buildRecords();
+var aug3To9=TipsCore.filterRecords(records,{
+  startT:new Date(2026,7,3).getTime(),
+  endT:new Date(2026,7,9).getTime(),
+  rest:'all'
+});
+check(TipsCore.totals(aug3To9),{cash:677325,card:694225,count:20,flagged:1},'August 3–9 pinned totals');
+
+var july=TipsCore.filterRecords(records,{
+  startT:new Date(2026,6,1).getTime(),
+  endT:new Date(2026,6,31).getTime(),
+  rest:'all'
+});
+check(TipsCore.totals(july),{cash:1887925,card:3199775,count:108,flagged:0},'July pinned totals');
+
+check(TipsCore.buildRecords(),TipsCore.buildRecords(),'independent builds are deterministic');
+
+check(TipsCore.grouping(16).mode,'day','16 days groups by day');
+check(TipsCore.grouping(17).mode,'week','17 days groups by week');
+check(TipsCore.grouping(100).mode,'week','100 days groups by week');
+check(TipsCore.grouping(101).mode,'month','101 days groups by month');
+
+var dayGroups=TipsCore.groupRecords([TipsCore.REAL_RECORDS[0]],16);
+check(dayGroups[0].label,'Sun Aug 9 — day total','day group label');
+check(
+  TipsCore.groupRecords([{t:new Date(2026,6,22).getTime(),cash:100,card:200}],17)[0].label,
+  'Week of Jul 20 – 26 — total',
+  'week group label'
+);
+var monthGroup=TipsCore.groupRecords([{t:new Date(2026,6,22).getTime(),cash:100,card:200}],101)[0];
+check(monthGroup.label,'July 2026 — total','month group label');
+check(
+  {cashTotal:monthGroup.cashTotal,cardTotal:monthGroup.cardTotal,records:monthGroup.records.length},
+  {cashTotal:100,cardTotal:200,records:1},
+  'group objects carry records and totals'
+);
+
+var csv=TipsCore.toCSV(TipsCore.REAL_RECORDS);
+var csvLines=csv.split('\n');
+check(
+  csvLines[0],
+  'Business date,Restaurant,Meal,Cash (split pool),Card (logged only),People on split,Names,Per-person share,Flagged,Entered by,Entry method',
+  'CSV header'
+);
+check(csvLines.length,TipsCore.REAL_RECORDS.length+1,'CSV row count');
+check(
+  csvLines[1],
+  'Sun Aug 9 2026,Sushi,Dinner,412.00,688.50,3,"Maria; Jose; Ken",137.33,no,Maria,voice',
+  'known real CSV row'
+);
+
+check(TipsCore.money(123456),'$1,234.56','format money with thousands separator');
+check(TipsCore.money(7400),'$74.00','format money pads cents');
+check(
+  TipsCore.toCSV([{t:new Date(2025,0,15).getTime(),rest:'sushi',meal:'Lunch',cash:200,card:0,people:['O"Brien'],by:'Smith, John',mode:'typed',flag:false}]).split('\n')[1],
+  'Wed Jan 15 2025,Sushi,Lunch,2.00,0.00,1,"O""Brien",2.00,no,"Smith, John",typed',
+  'CSV derives year from record and escapes quotes/commas'
+);
+
+check(TipsCore.parseMoney('$1,234.56'),123456,'parse formatted money');
+check(TipsCore.parseMoney('12'),1200,'parse whole dollars');
+check(TipsCore.parseMoney('-5'),null,'reject negative money');
+check(TipsCore.parseMoney('abc'),null,'reject non-numeric money');
+
+var source=fs.readFileSync(corePath,'utf8');
+['document','window.','import ','export ','Date.now','Math.random'].forEach(function(forbidden){
+  check(source.includes(forbidden),false,'source excludes '+forbidden);
+});
+
+var browserContext={};
+vm.runInNewContext(source,browserContext,{filename:'tips-core.js'});
+check(typeof browserContext.TipsCore,'object','source runs as an inline browser script');
+check(typeof TipsCore.buildRecords,'function','source loads through require');
+
+console.log('PASS '+passCount+' checks');


### PR DESCRIPTION
## What this is

Design exploration for the **manager side of the tips app** — the page the owner opens on a laptop to review recorded tips, fix mistakes, manage staff, and rotate device access. Everything is static, self-contained HTML that opens from `file://` by double-click: no server, no build, no network.

## Contents

| File | What it is |
|---|---|
| `PROMPT.md` | The design brief (domain rules, sample data, functional requirements) |
| `claude-fable.html` | Three-variant design comparison built to the brief: **Ledger** (dense console), **Daybook** (warm card-per-shift), **Morning Check** (triage-first) |
| `claude-opus.html` | Competition entry from Claude Opus for the same brief |
| `claude-fable-ledger.html` | **The finalized interface** — single-page ledger with 7 switchable styles (Classic, Modern A glass, Modern B rail, Warm, Dark, Dense, White), a calendar range picker (days/weeks/months/years + presets), per-day + lunch/dinner staff schedules that drive the phone picker's defaults, device-access rotation with one-time secret reveal, and deterministic generated history May 1 – Aug 9, 2026 |
| `core/tips-core.js` | The data/logic layer extracted as a pure, dependency-free module (per-person share math, seeded history generator, filter/group/totals, CSV export) — inlined into the ledger page and `require()`-able in Node |
| `core/tips-core.test.js` | 41 pinned assertions — run `node docs/mockups/tips-dashboard/core/tips-core.test.js` |

## Key domain rules encoded

- Per-person share = **cash ÷ people**, nearest cent, exact half-cents round **up** ($96.25 ÷ 2 = $48.13). Card tips are logged for payroll and **never** enter the split — the tables make this distinction structural (tinted split-pool column group vs. dashed-off "logged only" column).
- Business dates roll at 4 am; the flagged $3,100 Friday entry is prominent in every design.

## Provenance & review

- `tips-core.js` was implemented by **Codex `gpt-5.6-sol`** in an isolated worktree; the UI/integration work is Claude's.
- Both halves got **independent cross-vendor review**: a Claude subagent reviewed Sol's module (grade A — verified all acceptance criteria empirically, incl. a vm double-load probe), and Sol read-only-reviewed Claude's diff (grade B). All findings — CSV year hardcode, incomplete CSV escaping, a duplicated rounding rule in the editor — were fixed, with regression tests added (38 → 41 checks).

## How to review

1. Open `docs/mockups/tips-dashboard/claude-fable-ledger.html` in a browser; flip through the 7 style tabs (state persists across switches).
2. Try the range button (calendar with week/month/year modes), fix the flagged Friday record (two-step confirm shows the payout delta), toggle an L/D schedule cell, rotate a PIN (type-to-confirm → one-time reveal).
3. `node docs/mockups/tips-dashboard/core/tips-core.test.js` → expect `PASS 41 checks`.

**Note:** `roadmap/integration` carries an earlier snapshot of some of these files (swept in by 1468f33); this branch has the newer versions, so whichever merges second will need the trivial take-theirs resolution in `docs/mockups/tips-dashboard/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)