### PR TITLE
Tighten onboarding and scan copy; animate tutorial icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,69 @@ on:
     branches: [main, master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  quality:
+  changes:
+    name: Detect affected projects
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: filter
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base_sha="$PR_BASE_SHA"
+          else
+            base_sha="$PUSH_BASE_SHA"
+          fi
+
+          mobile=false
+          web=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              web/*)
+                web=true
+                ;;
+              app/*|assets/*|scripts/*|src/*|supabase/*|.env.example|.env.local.example|app.json|babel.config.js|dump.sql|eas.json|eslint.config.js|global.css|jest.config.js|metro.config.js|nativewind-env.d.ts|package.json|package-lock.json|tailwind.config.js|tsconfig.json)
+                mobile=true
+                ;;
+              .github/actions/*)
+                mobile=true
+                web=true
+                ;;
+            esac
+          done < <(
+            if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
+              git ls-tree -r --name-only "$HEAD_SHA"
+            else
+              git diff --name-only "$base_sha" "$HEAD_SHA"
+            fi
+          )
+
+          echo "mobile=$mobile" >> "$GITHUB_OUTPUT"
+          echo "web=$web" >> "$GITHUB_OUTPUT"
+
+  mobile-quality:
+    name: Mobile quality
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,3 +94,41 @@ jobs:
 
       - name: Production dependency audit
         run: npm run audit:prod
+
+  web-quality:
+    name: Web quality
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Production build
+        run: npx next build --webpack
+
+      - name: Production dependency audit
+        run: npm audit --omit=dev --audit-level=critical
+
+      # The Playwright suite intentionally writes to the live tips database,
+      # so it remains an explicit, opt-in verification rather than a CI step.

--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -18,11 +18,18 @@ test.describe("scan landing", () => {
   }) => {
     await page.goto("/");
     // Variant A carousel: three slides, dots, Next → Next → done.
+    const currentSlide = () =>
+      page.getByLabel("Tutorial slides").evaluate((track) =>
+        Math.round(track.scrollLeft / track.clientWidth),
+      );
+
     await expect(page.getByText("Scan to start")).toBeVisible();
-    await page.getByRole("button", { name: "Next" }).click();
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await expect.poll(currentSlide).toBe(1);
     await expect(page.getByText("Speak it in")).toBeVisible();
-    await page.getByRole("button", { name: "Next" }).click();
-    await page.getByRole("button", { name: /let.s go/i }).click();
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await expect.poll(currentSlide).toBe(2);
+    await page.getByRole("button", { name: "Got it", exact: true }).click();
 
     await expect(
       page.getByRole("heading", { name: "Scan to enter" }),

--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -42,6 +42,10 @@ test.describe("scan landing", () => {
     await expect(
       page.getByRole("button", { name: "Scan the sticker" }),
     ).toBeVisible();
+    await expect(
+      page.getByText("Use your camera app or scan it here."),
+    ).toBeVisible();
+    await expect(page.getByText(/One scan per entry/)).toHaveCount(0);
     // PIN entry is gone from the product.
     await expect(page.getByText(/PIN/)).toHaveCount(0);
 

--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -24,6 +24,11 @@ test.describe("scan landing", () => {
       );
 
     await expect(page.getByText("Scan to start")).toBeVisible();
+    await expect(page.locator("[data-onboarding-icon]")).toHaveCount(3);
+    await expect(
+      page.locator(".onboarding-kinetic-tile").first(),
+    ).toHaveCSS("animation-iteration-count", "infinite");
+    await expect(page.locator(".onboarding-kinetic-eq > span")).toHaveCount(5);
     await page.getByRole("button", { name: "Next", exact: true }).click();
     await expect.poll(currentSlide).toBe(1);
     await expect(page.getByText("Speak it in")).toBeVisible();

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "next typegen && tsc --noEmit",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -41,6 +41,191 @@ body {
   color: var(--color-ink3);
 }
 
+/* Always-on kinetic tutorial icons. The loops include quiet pauses so the
+   onboarding stays lively without turning into constant visual noise. */
+.onboarding-kinetic-stage {
+  position: relative;
+  isolation: isolate;
+}
+
+.onboarding-kinetic-tile {
+  position: absolute;
+  inset: 8px;
+  z-index: 0;
+  border-radius: 24px;
+  background: var(--color-tint);
+  animation: onboarding-tile-loop 4.8s ease-in-out infinite;
+}
+
+.onboarding-kinetic-stage[data-onboarding-variant="story"]
+  .onboarding-kinetic-tile {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.onboarding-kinetic-graphic {
+  position: relative;
+  z-index: 1;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.onboarding-kinetic-scan-beam {
+  opacity: 0;
+  animation: onboarding-scan-loop 3.2s cubic-bezier(0.45, 0, 0.2, 1)
+    infinite;
+}
+
+.onboarding-kinetic-eq {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  height: 38px;
+  align-items: center;
+  gap: 4px;
+}
+
+.onboarding-kinetic-eq > span {
+  width: 4px;
+  height: 26px;
+  border-radius: 999px;
+  background: currentColor;
+  transform-origin: center;
+  animation: onboarding-eq-loop 1.4s ease-in-out infinite alternate;
+}
+
+.onboarding-kinetic-eq > span:nth-child(2),
+.onboarding-kinetic-eq > span:nth-child(4) {
+  height: 30px;
+  animation-delay: -0.72s;
+}
+
+.onboarding-kinetic-eq > span:nth-child(3) {
+  height: 34px;
+  animation-delay: -1.08s;
+}
+
+.onboarding-kinetic-check {
+  animation: onboarding-check-loop 3.6s cubic-bezier(0.2, 0.8, 0.2, 1)
+    infinite;
+}
+
+.onboarding-kinetic-glint {
+  position: absolute;
+  top: 19px;
+  right: 20px;
+  z-index: 2;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 5px color-mix(in srgb, currentColor 18%, transparent);
+  animation: onboarding-glint-loop 3.6s ease-in-out infinite;
+}
+
+.onboarding-kinetic-stage[data-onboarding-variant="story"]
+  .onboarding-kinetic-glint {
+  top: 27px;
+  right: 28px;
+}
+
+@keyframes onboarding-tile-loop {
+  0%,
+  30%,
+  100% {
+    transform: scale(1);
+  }
+  38% {
+    transform: scale(1.035);
+  }
+  48% {
+    transform: scale(0.992);
+  }
+}
+
+@keyframes onboarding-scan-loop {
+  0%,
+  12% {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  20% {
+    opacity: 0.9;
+  }
+  52% {
+    opacity: 0.9;
+    transform: translateY(4px);
+  }
+  60%,
+  100% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+}
+
+@keyframes onboarding-eq-loop {
+  0% {
+    opacity: 0.65;
+    transform: scaleY(0.38);
+  }
+  45% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  100% {
+    opacity: 0.82;
+    transform: scaleY(0.58);
+  }
+}
+
+@keyframes onboarding-check-loop {
+  0%,
+  22%,
+  100% {
+    transform: scale(1);
+  }
+  32% {
+    transform: scale(1.08);
+  }
+  42% {
+    transform: scale(0.98);
+  }
+}
+
+@keyframes onboarding-glint-loop {
+  0%,
+  20%,
+  55%,
+  100% {
+    opacity: 0;
+    transform: scale(0.35);
+  }
+  30% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  42% {
+    opacity: 0;
+    transform: translate(5px, -5px) scale(0.5);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-kinetic-tile,
+  .onboarding-kinetic-scan-beam,
+  .onboarding-kinetic-eq > span,
+  .onboarding-kinetic-check,
+  .onboarding-kinetic-glint {
+    animation: none;
+  }
+
+  .onboarding-kinetic-scan-beam,
+  .onboarding-kinetic-glint {
+    display: none;
+  }
+}
+
 @media print {
   .no-print {
     display: none !important;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -144,8 +144,7 @@ function ScanLanding() {
           <div className="pt-1">
             <p className="font-bold text-ink">Two ways to scan</p>
             <p className="mt-1 text-sm text-ink2">
-              Point your camera app at the sticker, or use the scanner right
-              here — same sticker either way
+              Use your camera app or scan it here.
             </p>
           </div>
         </div>
@@ -161,9 +160,6 @@ function ScanLanding() {
         <CameraIcon />
         Scan the sticker
       </button>
-      <p className="mt-4 text-center text-sm text-ink3">
-        One scan per entry — you&rsquo;re signed out automatically after saving
-      </p>
 
       {showScanner && (
         <QrScanner

--- a/web/src/components/entry-flow/Onboarding.tsx
+++ b/web/src/components/entry-flow/Onboarding.tsx
@@ -21,17 +21,17 @@ interface Slide {
 const SLIDES: Slide[] = [
   {
     title: "Scan to start",
-    body: "The sticker by the register is your sign-in. Scan it with your camera — or tap Scan here — and you're in. No PIN, nothing to remember.",
+    body: "Scan the sticker by the register with your camera, or tap Scan here. No PIN needed.",
     icon: "scan",
   },
   {
     title: "Speak it in",
-    body: "Say the shift, the cash, the card, and who's splitting — any order, any accent. Tap any row to type it instead.",
+    body: "Say the shift, cash, card, and who's splitting. Any order or accent works. You can also tap a row to type.",
     icon: "mic",
   },
   {
     title: "Save and go",
-    body: "Check the numbers, hit Save. You'll see a quick confirmation and the app resets for the next shift.",
+    body: "Check the numbers and tap Save. You'll see a quick confirmation, then the app resets for the next shift.",
     icon: "check",
   },
 ];
@@ -132,6 +132,7 @@ function CardsOnboarding({ onDone }: { onDone: () => void }) {
         <div
           ref={trackRef}
           onScroll={handleScroll}
+          aria-label="Tutorial slides"
           className="mt-6 flex flex-1 snap-x snap-mandatory overflow-x-auto"
           style={{ scrollbarWidth: "none" }}
         >
@@ -170,7 +171,7 @@ function CardsOnboarding({ onDone }: { onDone: () => void }) {
             onClick={() => (index === last ? onDone() : goTo(index + 1))}
             className="w-full rounded-full bg-accent py-4 font-semibold text-white active:opacity-90"
           >
-            {index === last ? "Got it — let's go" : "Next"}
+            {index === last ? "Got it" : "Next"}
           </button>
         </div>
       </div>
@@ -246,7 +247,7 @@ function StoryOnboarding({ onDone }: { onDone: () => void }) {
             onClick={advance}
             className="rounded-full bg-white px-8 py-3.5 font-semibold text-accent active:opacity-90"
           >
-            {index === last ? "Let's go" : "Next"}
+            {index === last ? "Got it" : "Next"}
           </button>
         </div>
       </div>

--- a/web/src/components/entry-flow/Onboarding.tsx
+++ b/web/src/components/entry-flow/Onboarding.tsx
@@ -36,7 +36,14 @@ const SLIDES: Slide[] = [
   },
 ];
 
-function SlideIcon({ icon, size = 44 }: { icon: Slide["icon"]; size?: number }) {
+function SlideIcon({
+  icon,
+  variant,
+}: {
+  icon: Slide["icon"];
+  variant: OnboardingVariant;
+}) {
+  const size = variant === "story" ? 52 : 44;
   const common = {
     width: size,
     height: size,
@@ -46,29 +53,55 @@ function SlideIcon({ icon, size = 44 }: { icon: Slide["icon"]; size?: number }) 
     strokeWidth: 1.8,
     strokeLinecap: "round" as const,
     strokeLinejoin: "round" as const,
-    "aria-hidden": true,
+    className: "onboarding-kinetic-graphic",
   };
-  if (icon === "scan") {
+
+  const graphic = (() => {
+    if (icon === "scan") {
+      return (
+        <svg {...common}>
+          <path d="M3 7V5a2 2 0 0 1 2-2h2M17 3h2a2 2 0 0 1 2 2v2M21 17v2a2 2 0 0 1-2 2h-2M7 21H5a2 2 0 0 1-2-2v-2" />
+          <rect x="8" y="8" width="8" height="8" rx="1.5" />
+          <path className="onboarding-kinetic-scan-beam" d="M5 12h14" />
+        </svg>
+      );
+    }
+
+    if (icon === "mic") {
+      return (
+        <span className="onboarding-kinetic-eq">
+          <span />
+          <span />
+          <span />
+          <span />
+          <span />
+        </span>
+      );
+    }
+
     return (
-      <svg {...common}>
-        <path d="M3 7V5a2 2 0 0 1 2-2h2M17 3h2a2 2 0 0 1 2 2v2M21 17v2a2 2 0 0 1-2 2h-2M7 21H5a2 2 0 0 1-2-2v-2" />
-        <rect x="8" y="8" width="8" height="8" rx="1.5" />
-      </svg>
+      <>
+        <span className="onboarding-kinetic-glint" />
+        <svg {...common} className="onboarding-kinetic-graphic onboarding-kinetic-check">
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+      </>
     );
-  }
-  if (icon === "mic") {
-    return (
-      <svg {...common}>
-        <rect x="9" y="2" width="6" height="12" rx="3" />
-        <path d="M5 10v1a7 7 0 0 0 14 0v-1" />
-        <path d="M12 18v4" />
-      </svg>
-    );
-  }
+  })();
+
+  const sizeClasses = variant === "story" ? "h-28 w-28" : "h-24 w-24";
+  const colorClass = variant === "story" ? "text-white" : "text-accent";
+
   return (
-    <svg {...common}>
-      <path d="M20 6L9 17l-5-5" />
-    </svg>
+    <span
+      aria-hidden="true"
+      data-onboarding-icon={icon}
+      data-onboarding-variant={variant}
+      className={`onboarding-kinetic-stage flex items-center justify-center ${sizeClasses} ${colorClass}`}
+    >
+      <span className="onboarding-kinetic-tile" />
+      {graphic}
+    </span>
   );
 }
 
@@ -142,9 +175,7 @@ function CardsOnboarding({ onDone }: { onDone: () => void }) {
               className="flex w-full shrink-0 snap-center flex-col px-5"
             >
               <div className="flex flex-1 flex-col items-center justify-center rounded-card bg-card p-8 text-center">
-                <span className="flex h-24 w-24 items-center justify-center rounded-full bg-tint text-accent">
-                  <SlideIcon icon={slide.icon} />
-                </span>
+                <SlideIcon icon={slide.icon} variant="cards" />
                 <h2 className="mt-6 text-2xl font-bold text-ink">
                   {slide.title}
                 </h2>
@@ -219,9 +250,7 @@ function StoryOnboarding({ onDone }: { onDone: () => void }) {
           onClick={advance}
           className="flex flex-1 flex-col items-center justify-center text-center"
         >
-          <span className="flex h-28 w-28 items-center justify-center rounded-full bg-white/15">
-            <SlideIcon icon={slide.icon} size={52} />
-          </span>
+          <SlideIcon icon={slide.icon} variant="story" />
           <h2 className="mt-8 text-3xl font-bold">{slide.title}</h2>
           <p className="mt-4 max-w-xs text-white/85">{slide.body}</p>
         </button>


### PR DESCRIPTION
## Summary
- shorten all three onboarding descriptions and remove user-facing em dashes
- change both final tutorial actions to "Got it"
- replace the static scan, voice, and check artwork with the selected always-on kinetic tile set
- use compositor-friendly loops with quiet pauses and a reduced-motion fallback
- simplify the scan-method explanation and remove the helper text beneath the scan button
- make the onboarding E2E wait for the carousel to settle, assert that the kinetic loop is active, and cover the cleaned-up scan copy
- split GitHub CI into path-aware mobile and web quality jobs
- generate Next.js route types before web TypeScript checks on fresh runners

## Verification
- focused ESLint pass
- TypeScript pass
- onboarding-to-scan Playwright test pass
- production build pass with Next.js Webpack mode
- visual verification of both onboarding variants and the scan landing page
- Vercel preview deployment passed and the deployed scan copy was verified
- GitHub Web quality passed; Mobile quality correctly skipped this web-only PR

## CI behavior
- web changes run web typecheck, unit tests, lint, production build, and dependency audit
- mobile changes run the existing mobile typecheck, tests, lint, Expo Doctor, and dependency audit
- mixed changes run both jobs; unrelated jobs are skipped
- Playwright remains an explicit opt-in because the suite writes to the live tips database
