### PR TITLE
Fix native production build configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'com.babytuna.systems'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11
-        versionName "2.0"
+        versionCode 20
+        versionName "2.2"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,5 +2,5 @@
   <string name="app_name">Babytuna Systems</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
-  <string name="expo_runtime_version">2.0</string>
+  <string name="expo_runtime_version">2.2</string>
 </resources>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 #Sat Mar 14 14:40:01 PDT 2026
 networkTimeout=10000
 distributionBase=GRADLE_USER_HOME
- distributionPath=wrapper/dists
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 validateDistributionUrl=true
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/ios/Babytuna.xcodeproj/project.pbxproj
+++ b/ios/Babytuna.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Babytuna/Babytuna.entitlements;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 20;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -360,7 +360,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -384,14 +384,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Babytuna/Babytuna.entitlements;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 20;
 				INFOPLIST_FILE = Babytuna/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
## Summary
- restore the missing Gradle wrapper distribution URL
- align native Android and iOS versions with app version 2.2
- align the embedded Android OTA runtime with runtime 2.2
- raise Gradle heap/metaspace limits for the production native bundle

## Verification
- `./gradlew --version` (Gradle 8.14.3)
- `./gradlew --no-daemon :app:bundleRelease` (BUILD SUCCESSFUL)
- `npm run doctor` (17/17 checks passed)