### PR TITLE
Marketing: www→apex redirect (and trigger the first production build)

### DIFF
--- a/marketing/next.config.ts
+++ b/marketing/next.config.ts
@@ -4,6 +4,13 @@ const nextConfig: NextConfig = {
   redirects() {
     return Promise.resolve([
       {
+        // The apex is canonical, so www normalizes to it before anything else.
+        source: "/:path*",
+        has: [{ type: "host", value: "www.smelterpos.com" }],
+        destination: "https://smelterpos.com/:path*",
+        permanent: true,
+      },
+      {
         // The mobile app's About screen links to /contact; support covers it.
         source: "/contact",
         destination: "/support",


### PR DESCRIPTION
One commit, and it does two jobs.

**It's the missing redirect.** PR #13 merged at `56c2d74`, one commit before this landed on the branch, so `main` has the marketing site but not the www→apex normalization. Without it `www.smelterpos.com` serves the site directly instead of redirecting, which is duplicate content on the non-canonical host.

**It also makes the site go live.** The `smelter-marketing` Vercel project was created *after* #13 merged, so no push to `main` has happened during its lifetime and it has never produced a production deployment — only a preview. That's why `smelterpos.com` currently returns 404 over HTTP with no certificate: DNS and the domain binding are correct, but there is no production build behind them.

Merging this pushes `main`, which triggers that first production build and brings the apex up.

Verified before opening this:

- DNS resolves for all three hosts; Cloudflare records are correct and all grey-cloud.
- `tips.smelterpos.com` already returns 200 — it's on `inventory-system`, which does have a production build.
- `tips.babytunasystems.com` still returns 200, so the printed QR stickers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)