### PR TITLE
Serve the Tip Dashboard at dashboard.smelterpos.com

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,28 @@
 import type { NextConfig } from "next";
 
+/** Manager dashboard host. The tips app owns "/" on its own host as the staff
+ *  scan screen, so the dashboard gets a host rather than a path. */
+const DASHBOARD_HOST = "dashboard.smelterpos.com";
+
 const nextConfig: NextConfig = {
+  rewrites() {
+    return Promise.resolve({
+      // beforeFiles, not a bare array: "/" is a prerendered page, and an
+      // afterFiles rewrite never fires because the static file wins first.
+      beforeFiles: [
+        {
+          // Rewrite, not redirect: the address bar stays on the dashboard host
+          // instead of bouncing visitors to /manager. Every other path is
+          // untouched, so /manager and /manager/qr keep working everywhere.
+          source: "/",
+          has: [{ type: "host", value: DASHBOARD_HOST }],
+          destination: "/manager",
+        },
+      ],
+      afterFiles: [],
+      fallback: [],
+    });
+  },
   headers() {
     return Promise.resolve([
       {


### PR DESCRIPTION
Moves the Tip Dashboard from `tips.smelterpos.com/manager` to its own host, `dashboard.smelterpos.com`.

The tips app owns `/` on its host as the staff scan screen, so the dashboard couldn't simply take a shorter path there. It gets a host instead: on `dashboard.smelterpos.com`, `/` rewrites to `/manager`.

A **rewrite, not a redirect** — the address bar stays on the dashboard host rather than bouncing visitors to `/manager`.

## What doesn't change

`/manager` and `/manager/qr` keep working on every host, so no bookmark breaks and the in-app "Tips" nav link stays relative (and therefore still correct on localhost). `tips.smelterpos.com/` is untouched and still serves the scan screen, as is the legacy `tips.babytunasystems.com` that the printed QR stickers point at.

## The non-obvious bit

The rewrite has to be in the **`beforeFiles`** phase. Returning a bare array from `rewrites()` puts rules in `afterFiles`, which runs *after* filesystem routes — and `/` is a prerendered page, so the static file wins and the rewrite silently never fires. The first version of this did exactly that and looked fine until it was actually exercised.

Verified against a production build with a spoofed `Host` header:

- `dashboard.smelterpos.com/` returns byte-identical output to `/manager`
- `tips.smelterpos.com/` still returns the scan screen (different bytes)
- `tips.babytunasystems.com/` likewise unchanged
- `/manager`, `/manager/qr`, `/entry`, `/terms`, `/privacy` all 200 on the dashboard host
- 194 web tests pass

## Before this helps anyone

`dashboard.smelterpos.com` is already attached to the `inventory-system` Vercel project, but it needs a Cloudflare record — `CNAME dashboard → cname.vercel-dns.com`, **DNS only / grey cloud**.

Worth knowing: the manager session lives in `localStorage`, which is per-origin, so managers will sign in once more on the new host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)