### PR TITLE
Tip Dashboard v2: honest trend series, recoverable Fix flow, N+1 collapse

### DIFF
--- a/docs/flood-test-2026-08-27.md
+++ b/docs/flood-test-2026-08-27.md
@@ -1,0 +1,114 @@
+# Flood Test & Security Review — 2026-08-27
+
+Scope: the web surfaces only — the tips entry app and the manager dashboard —
+plus the four tip edge functions and their SQL RPCs. The Expo mobile app was
+out of scope.
+
+**Targets tested live:** `tips.babytunasystems.com` (production web app) and
+`https://whrohvitvmcrmedepurd.supabase.co/functions/v1/{tip-entry-auth,
+tip-entries, tip-voice-parse, tip-voice-stream}`.
+
+## Method
+
+1. **Static review** of `web/src/**`, `supabase/functions/{tip-entry-auth,
+   tip-entries, tip-voice-parse, tip-voice-stream}`, `_shared/tips.ts`,
+   `_shared/cors.ts`, and the tip migrations.
+2. **Live flood harness** (`flood-test/harness.mjs`, 81 checks): route
+   availability, method fuzzing, malformed JSON, 19 garbage-token shapes
+   (SQLi, XSS, path traversal, unicode, oversized, wrong types),
+   session-gate bypass attempts, rate-limit burn-down (20-try window),
+   XFF-spoof bypass attempt, 30-way concurrent bad-token burst, 60-way
+   concurrent site GET burst, 25-way concurrent voice-parse burst, WebSocket
+   ticket auth (no/short/garbage/oversized tickets), oversized upload (5–6MB).
+3. **Fix + verify**: all fixes on branch `fix/web-flood-hardening`, quality
+   gates green, browser verification on the Vercel preview.
+
+## Result: 73/81 checks passed on the unpatched deployment. 8 findings.
+
+---
+
+## Findings fixed in PR #17
+
+### Security
+
+| # | Severity | Finding | Status |
+|---|----------|---------|--------|
+| S1 | High | **No CSP / X-Frame-Options / Referrer-Policy / X-Content-Type-Options** on any page (confirmed live). Clickjacking + script-injection surface with session tokens in localStorage. | Fixed — full header set in `next.config.ts` |
+| S2 | High | **Rate-limit bypass via `x-forwarded-for` spoofing** (confirmed live): after burning the 20-try token limit, a request with a spoofed XFF was allowed again immediately. `clientIdentifier` trusted the first (client-controlled) XFF entry. | Fixed — uses the last (proxy-appended) entry |
+| S3 | High | **QR token leak via Referer**: `/e?t=<token>` validated before stripping the URL, and fetches used the default referrer policy. | Fixed — token stripped before any network call; `referrerPolicy: "no-referrer"` on all edge fetches; site-wide `Referrer-Policy: no-referrer` |
+| S4 | Medium | **CSV formula injection**: a roster name like `=HYPERLINK(...)` exported unescaped; Excel/Sheets would execute it when a manager opens the CSV. | Fixed — `= + - @` prefixes neutralized; regression test added |
+| S5 | Medium | **`/manager/qr` gated by any session**, not manager role — any signed-in account with a `#t=` link could print entry QR codes. | Fixed — requires `current_user_is_manager()` |
+| S6 | Low | QR entry URL built without `encodeURIComponent`. | Fixed |
+
+### Reliability
+
+| # | Severity | Finding | Status |
+|---|----------|---------|--------|
+| R1 | Medium | **`tip-voice-parse` returned HTTP 500 on a non-multipart body** (confirmed live). | Fixed — clean 400 |
+| R2 | High | **Meal-switch race**: tapping Save mid Lunch↔Dinner switch sent the new meal with the old meal's crew (and possibly stale amounts). | Fixed — Save blocked while slot loads |
+| R3 | Medium | **Double-submit race**: two fast taps both passed the `saving` state guard. | Fixed — synchronous in-flight ref |
+| R4 | Medium | **Voice recorder played the live mic through the device speaker** (`processor.connect(destination)`) — feedback + privacy leak in the dining room. | Fixed — zero-gain node |
+| R5 | Medium | **Unsafe response casts**: malformed edge-function responses crashed the render (`.map` of undefined). | Fixed — shape validation → retryable error |
+| R6 | Medium | **Manager "Fix" was non-atomic** (3 PostgREST calls; mid-failure = mixed roster). | Fixed — single transactional `tip_manager_fix_entry` RPC (new migration, needs `supabase db push`) |
+| R7 | Low | Saved-screen per-person used float division — could disagree with the split strip by a cent. | Fixed — shared `perPersonShare` |
+| R8 | Low | `$NaN` in dashboard on malformed numeric; `localStorage` without try/catch; no `error.tsx`/`not-found.tsx`. | Fixed |
+
+### Verified NOT vulnerable (tested, no action needed)
+
+- Gateway rejects missing/garbage API keys (401) on all verify_jwt functions.
+- All session-gated actions return 401 `session_invalid` for bad/missing sessions — no path past the gate found.
+- Rate limit engages exactly at attempt #21 (20/10min) and holds under a 30-way concurrent burst (advisory locks work).
+- WebSocket stream rejects missing/short/garbage/oversized tickets (connection never opens); tickets are single-use, 60s.
+- 60 concurrent GETs on the site: 60×200, 0×5xx, ~0.4s.
+- 25 concurrent bad-session voice-parse posts: 25×401, no 5xx.
+- Malformed JSON → 400; wrong methods → 405; unknown actions → 400/401. No 5xx from any fuzzed input except R1.
+- `end_session` is idempotent and safe with garbage/missing tokens.
+- RLS: anon/authenticated roles have zero direct access to `tip_*` tables (manager-only policies); service-role key is nowhere in the client bundle.
+- Split math is integer-cent based; division-by-zero guarded.
+
+---
+
+## Findings NOT fixed (need David / infra decisions)
+
+| # | Severity | Finding | Recommended action |
+|---|----------|---------|--------------------|
+| O1 | **Critical ops** | **`tips.smelter.com` serves a parked-domain lander page** over plain HTTP; HTTPS has no certificate (TLS SNI error). `dashboard.smelter.com` likewise dead. The real app is `tips.babytunasystems.com`; dashboard host per config is `dashboard.smelterpos.com`. Anyone controlling that parked domain could later serve a phishing clone of the QR landing page. | Point the DNS at Vercel (or let the registration lapse); until then do not print/ship anything referencing smelter.com |
+| O2 | Medium | **`ALLOWED_ORIGINS` is unset** — edge functions answer browser CORS from any origin (`*`). Already on the launch checklist. | `supabase secrets set ALLOWED_ORIGINS=https://tips.babytunasystems.com,https://dashboard.smelterpos.com` |
+| O3 | Medium | **`entry_token_plain` stores the live QR token in plaintext**, re-fetched by the dashboard on every load. Accepted tradeoff (per David, 2026-08-20) so stickers can be reprinted — but any manager-session XSS/extensions can lift live entry credentials. | Keep as-is consciously, or null the column after first print and require rotation for reprints |
+| O4 | Medium | **Oversized voice uploads (5–6MB) hang until gateway timeout (504)** instead of the intended fast 413 — the Supabase gateway buffers the body before the function's content-length guard runs. Ties up workers for the full timeout. | Client-side: stop recording/chunk before ~4MB. Server-side guard stays as defense-in-depth. No function-side fix possible |
+| O5 | Medium | **Auth gates are client-only** (no Next middleware); `/manager`, `/dashboard`, `/manager/qr` render their shells to anyone and rely on RLS/RPC for data. Data is safe (verified), but defense-in-depth says add a server-side gate. | Add `middleware.ts` with Supabase SSR session check for `/manager*` and `/dashboard*` |
+| O6 | Low | **Invite tokens ride in the URL path** (`/join/<token>`) — persisted in history/proxy logs, unlike the scrubbed `#t=` fragment pattern. | Move to fragment or one-time exchange code |
+| O7 | Low | **Unlimited session minting with a valid QR token**: successful validations aren't rate-limited (only failures are), so a photo of the sticker can mint unbounded 12h sessions (table bloat). Voice quota (40/5min/session) caps the expensive path. | Optional: cap concurrent active sessions per location |
+| O8 | Low | **No client `maxLength` on roster/invite names** (server allows 60 chars for tip_employees; other inputs unbounded). | Add maxLength attributes |
+| O9 | Info | `$0 + $0` saves are allowed — **intentional** per SETUP.md ("$0 must be accepted"). | No action |
+| O10 | Info | Path-traversal-shaped tokens (`../../etc/passwd`) are rejected at the Supabase edge with 403 before reaching the function — safe, just a different code than the app's 401. | No action |
+
+## Test-data note
+
+The rate-limit burn-down wrote ~55 intentionally-failed rows to
+`tip_auth_attempts` keyed to random throwaway identifier hashes (no real
+device IPs). The ledger auto-deletes rows older than 2 days
+(`tip_auth_attempt_allowed` cleanup), so no manual cleanup is needed. No
+`tip_entries`, sessions, or roster rows were created — no valid entry token
+was available to the harness, and none was needed.
+
+## Validation that the fixes broke nothing
+
+- `npm run typecheck` — green
+- `npx eslint src --max-warnings=0` — green
+- `npm run test` — 195/195 (17 files), including a new CSV-injection
+  regression test
+- `npm run build` — green (15 routes)
+- `deno check` on the four tip functions — only the 3 pre-existing
+  strict-mode errors that exist identically on `main`
+- Browser verification of the preview deployment by an independent agent:
+  entry landing, malformed-token handling, scan screen, dashboard login
+  gate, 404/error pages, and the new security headers.
+
+## Deploy checklist (after merge)
+
+1. `supabase db push` (applies `20260827120000_tip_manager_fix_entry.sql`)
+2. `supabase functions deploy tip-entry-auth tip-entries tip-voice-parse tip-voice-stream`
+3. Vercel: merge deploys `web/` automatically
+4. Set `ALLOWED_ORIGINS` (O2)
+5. Resolve the smelter.com domain situation (O1)

--- a/supabase/functions/_shared/tips.test.ts
+++ b/supabase/functions/_shared/tips.test.ts
@@ -1,0 +1,29 @@
+import { clientIdentifier } from "./tips.ts";
+
+Deno.test("clientIdentifier uses the trusted proxy-appended XFF value", () => {
+  const request = new Request("https://example.test", {
+    headers: {
+      "x-forwarded-for": "203.0.113.10, 198.51.100.24",
+      "user-agent": "flood-test",
+    },
+  });
+
+  const actual = clientIdentifier(request);
+  if (actual !== "198.51.100.24:flood-test") {
+    throw new Error(`Unexpected identifier: ${actual}`);
+  }
+});
+
+Deno.test("clientIdentifier falls back without a forwarded chain", () => {
+  const realIpRequest = new Request("https://example.test", {
+    headers: { "x-real-ip": "192.0.2.42" },
+  });
+  if (clientIdentifier(realIpRequest) !== "192.0.2.42:") {
+    throw new Error("Expected x-real-ip fallback");
+  }
+
+  const unknownRequest = new Request("https://example.test");
+  if (clientIdentifier(unknownRequest) !== "unknown:") {
+    throw new Error("Expected unknown fallback");
+  }
+});

--- a/supabase/functions/_shared/tips.ts
+++ b/supabase/functions/_shared/tips.ts
@@ -33,8 +33,12 @@ export function randomToken(bytes = 32): string {
 }
 
 export function clientIdentifier(req: Request): string {
+  // The LAST x-forwarded-for entry is the one appended by the hosting edge
+  // proxy; earlier entries are client-supplied and trivially spoofable, which
+  // would let an attacker rotate IPs to dodge the validation rate limit.
   const forwarded = req.headers.get('x-forwarded-for');
-  const ip = forwarded?.split(',')[0]?.trim() || req.headers.get('x-real-ip')?.trim() || 'unknown';
+  const chain = forwarded?.split(',').map((part) => part.trim()).filter(Boolean) ?? [];
+  const ip = chain[chain.length - 1] || req.headers.get('x-real-ip')?.trim() || 'unknown';
   return `${ip}:${req.headers.get('user-agent') ?? ''}`;
 }
 

--- a/supabase/functions/tip-voice-parse/index.ts
+++ b/supabase/functions/tip-voice-parse/index.ts
@@ -237,7 +237,14 @@ Deno.serve(async (req) => {
       return json(req, { ok: false, code: 'too_large', error: 'That recording is too long.' }, 413);
     }
 
-    const form = await req.formData();
+    // Non-multipart bodies (e.g. a JSON post) make formData() throw — that
+    // is a client error, not a server fault.
+    let form: FormData;
+    try {
+      form = await req.formData();
+    } catch {
+      return json(req, { ok: false, code: 'invalid_audio', error: 'Expected a voice recording upload.' }, 400);
+    }
     const session = await validateTipSession(supabaseAdmin, asString(form.get('session_token')));
     if (!session) {
       return json(req, { ok: false, code: 'session_invalid', error: 'Session expired. Scan the sticker again.' }, 401);

--- a/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
+++ b/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
@@ -1,0 +1,63 @@
+-- Atomic manager "Fix" for a recorded tip entry.
+--
+-- The dashboard's Fix dialog previously did insert-people → update-amounts →
+-- delete-people as three separate PostgREST calls. A failure mid-sequence
+-- left the entry with a mixed roster / wrong split_count. This RPC performs
+-- the whole edit in one transaction, guarded by the same manager check the
+-- RLS policies use.
+
+create or replace function public.tip_manager_fix_entry(
+  p_entry_id uuid,
+  p_cash numeric,
+  p_card numeric,
+  p_people uuid[]
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.current_user_is_manager() then
+    raise exception 'Only managers can fix tip entries';
+  end if;
+
+  if p_cash is null or p_card is null
+     or p_cash < 0 or p_card < 0
+     or p_cash >= 100000 or p_card >= 100000 then
+    raise exception 'Amounts must be between 0 and 99,999.99';
+  end if;
+
+  if array_length(p_people, 1) is null or array_length(p_people, 1) < 1 then
+    raise exception 'At least one person must split the entry';
+  end if;
+
+  -- Every person must be on the roster (active or not — history may include
+  -- deactivated staff who were on the original split).
+  if exists (
+    select 1
+    from unnest(p_people) as person(id)
+    left join public.tip_employees e on e.id = person.id
+    where e.id is null
+  ) then
+    raise exception 'Someone selected is not on the roster';
+  end if;
+
+  update public.tip_entries
+  set cash_amount = p_cash,
+      card_amount = p_card,
+      split_count = array_length(p_people, 1)
+  where id = p_entry_id;
+
+  if not found then
+    raise exception 'Unknown entry';
+  end if;
+
+  delete from public.tip_entry_people where tip_entry_id = p_entry_id;
+  insert into public.tip_entry_people (tip_entry_id, tip_employee_id)
+  select p_entry_id, unnest(p_people);
+end;
+$$;
+
+revoke all on function public.tip_manager_fix_entry(uuid, numeric, numeric, uuid[]) from public, anon;
+grant execute on function public.tip_manager_fix_entry(uuid, numeric, numeric, uuid[]) to authenticated, service_role;

--- a/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
+++ b/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
@@ -15,8 +15,10 @@ create or replace function public.tip_manager_fix_entry(
 returns void
 language plpgsql
 security definer
-set search_path = public
+set search_path = ''
 as $$
+declare
+  v_people uuid[];
 begin
   if not public.current_user_is_manager() then
     raise exception 'Only managers can fix tip entries';
@@ -28,15 +30,24 @@ begin
     raise exception 'Amounts must be between 0 and 99,999.99';
   end if;
 
-  if array_length(p_people, 1) is null or array_length(p_people, 1) < 1 then
+  -- Match the entry API's 30-person cap and collapse duplicate ids so the
+  -- stored split_count can never disagree with the join table.
+  select array_agg(person.id order by person.id)
+  into v_people
+  from (select distinct unnest(p_people) as id) as person;
+
+  if cardinality(v_people) is null or cardinality(v_people) < 1 then
     raise exception 'At least one person must split the entry';
+  end if;
+  if cardinality(v_people) > 30 then
+    raise exception 'No more than 30 people can split an entry';
   end if;
 
   -- Every person must be on the roster (active or not — history may include
   -- deactivated staff who were on the original split).
   if exists (
     select 1
-    from unnest(p_people) as person(id)
+    from unnest(v_people) as person(id)
     left join public.tip_employees e on e.id = person.id
     where e.id is null
   ) then
@@ -46,7 +57,7 @@ begin
   update public.tip_entries
   set cash_amount = p_cash,
       card_amount = p_card,
-      split_count = array_length(p_people, 1)
+      split_count = cardinality(v_people)
   where id = p_entry_id;
 
   if not found then
@@ -55,7 +66,7 @@ begin
 
   delete from public.tip_entry_people where tip_entry_id = p_entry_id;
   insert into public.tip_entry_people (tip_entry_id, tip_employee_id)
-  select p_entry_id, unnest(p_people);
+  select p_entry_id, unnest(v_people);
 end;
 $$;
 

--- a/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
+++ b/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
@@ -14,7 +14,7 @@ create or replace function public.tip_manager_fix_entry(
 )
 returns void
 language plpgsql
-security definer
+security invoker
 set search_path = ''
 as $$
 declare

--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -40,7 +40,7 @@ test.describe("scan landing", () => {
       page.getByRole("heading", { name: "Scan to enter" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Scan the sticker" }),
+      page.getByRole("button", { name: "Scan the QR code" }),
     ).toBeVisible();
     await expect(
       page.getByText("Use your camera app or scan it here."),

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,6 +4,25 @@ import type { NextConfig } from "next";
  *  scan screen, so the dashboard gets a host rather than a path. */
 const DASHBOARD_HOST = "dashboard.smelterpos.com";
 
+// Keep the CSP pinned to the configured project. A wildcard here would let a
+// script-injection bug exfiltrate browser-stored sessions to an attacker-owned
+// Supabase project while still satisfying connect-src.
+const DEFAULT_SUPABASE_ORIGIN = "https://whrohvitvmcrmedepurd.supabase.co";
+
+function supabaseConnectSources(): string {
+  const configured = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, "");
+  let origin = DEFAULT_SUPABASE_ORIGIN;
+  if (configured) {
+    try {
+      origin = new URL(configured).origin;
+    } catch {
+      // The app itself will report the invalid URL when it creates the client;
+      // keep the security header valid and fail closed to the production host.
+    }
+  }
+  return `${origin} ${origin.replace(/^http/, "ws")}`;
+}
+
 const nextConfig: NextConfig = {
   rewrites() {
     return Promise.resolve({
@@ -35,7 +54,7 @@ const nextConfig: NextConfig = {
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob:",
       "media-src 'self' blob:",
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      `connect-src 'self' ${supabaseConnectSources()}`,
       "font-src 'self' data:",
       "object-src 'none'",
       "base-uri 'self'",

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -24,12 +24,50 @@ const nextConfig: NextConfig = {
     });
   },
   headers() {
+    // Entry sessions and manager auth live in browser storage, and QR tokens
+    // ride in URLs — so lock down what a page can do and where URLs leak.
+    // script-src keeps 'unsafe-inline' because Next/Turbopack ship inline
+    // runtime scripts without nonces; connect-src is the real perimeter
+    // (only our Supabase project can be talked to).
+    const contentSecurityPolicy = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob:",
+      "media-src 'self' blob:",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      "font-src 'self' data:",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+      "upgrade-insecure-requests",
+    ].join("; ");
     return Promise.resolve([
       {
         // Apple fetches this to enable iCloud Keychain autofill for the app
         // (webcredentials associated domain). It must be served as JSON.
         source: "/.well-known/apple-app-site-association",
         headers: [{ key: "Content-Type", value: "application/json" }],
+      },
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Content-Security-Policy", value: contentSecurityPolicy },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          // QR entry tokens ride in the ?t= query param — never let the URL
+          // leave this origin via Referer.
+          { key: "Referrer-Policy", value: "no-referrer" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(self), microphone=(self), geolocation=()",
+          },
+        ],
       },
     ]);
   },

--- a/web/src/app/e/page.tsx
+++ b/web/src/app/e/page.tsx
@@ -28,10 +28,21 @@ function TokenLanding() {
 
   const [attempt, setAttempt] = useState(0);
 
+  // Same shape check the in-page scanner applies: obviously-wrong tokens
+  // fail locally instead of burning a rate-limited server attempt. Derived
+  // (not effect state) so it renders without a setState-in-effect.
+  const tokenMalformed = token !== null && !/^[A-Za-z0-9_-]{16,128}$/.test(token);
+
   useEffect(() => {
     if (!token) {
       router.replace(loadSession() ? "/entry" : "/");
       return;
+    }
+    if (tokenMalformed) return;
+    // Strip ?t=<token> from the address bar/history BEFORE any network call
+    // so the QR secret can't leak via Referer or a crash mid-validation.
+    if (typeof window !== "undefined" && window.location.search.includes("t=")) {
+      window.history.replaceState(null, "", "/e");
     }
     let cancelled = false;
     const signIn = async (): Promise<"entry" | "closer"> => {
@@ -76,7 +87,7 @@ function TokenLanding() {
     return () => {
       cancelled = true;
     };
-  }, [token, router, attempt]);
+  }, [token, tokenMalformed, router, attempt]);
 
   // Both possible destinations are known the moment this page mounts —
   // prefetch them so the post-validation navigation is instant.
@@ -91,7 +102,7 @@ function TokenLanding() {
     setAttempt((n) => n + 1);
   };
 
-  if (phase === "checking") {
+  if (phase === "checking" && !tokenMalformed) {
     return <Splash>Checking the QR code&hellip;</Splash>;
   }
 
@@ -99,7 +110,11 @@ function TokenLanding() {
     <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col justify-center px-5 pb-10">
       <div className="rounded-card bg-card p-5 text-center">
         <p className="font-bold text-ink">Couldn&rsquo;t sign you in</p>
-        <p className="mt-2 text-ink2">{errorMessage}</p>
+        <p className="mt-2 text-ink2">
+          {tokenMalformed
+            ? "This QR code is no longer active. Ask a manager for the new one."
+            : errorMessage}
+        </p>
       </div>
       <button
         type="button"
@@ -108,13 +123,15 @@ function TokenLanding() {
       >
         Back to scan
       </button>
-      <button
-        type="button"
-        onClick={retry}
-        className="mt-4 text-center text-ink2 underline"
-      >
-        Try again
-      </button>
+      {!tokenMalformed && (
+        <button
+          type="button"
+          onClick={retry}
+          className="mt-4 text-center text-ink2 underline"
+        >
+          Try again
+        </button>
+      )}
     </main>
   );
 }

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+// Last-resort render-error boundary: a phone mid-entry must never land on a
+// bare framework error. Reset re-renders the segment; home is the scan gate.
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[smelter-tips] unhandled render error", error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col justify-center px-5 pb-10">
+      <div className="rounded-card bg-card p-5 text-center">
+        <p className="font-bold text-ink">Something went wrong</p>
+        <p className="mt-2 text-ink2">
+          Your entry is still on this screen. Try again — if it keeps
+          happening, scan the QR code again.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 w-full rounded-full bg-accent py-4 font-semibold text-white"
+      >
+        Try again
+      </button>
+      <Link
+        href="/"
+        className="mt-4 text-center text-ink2 underline"
+      >
+        Back to scan
+      </Link>
+    </main>
+  );
+}

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -22,8 +22,8 @@ export default function GlobalError({
       <div className="rounded-card bg-card p-5 text-center">
         <p className="font-bold text-ink">Something went wrong</p>
         <p className="mt-2 text-ink2">
-          Your entry is still on this screen. Try again — if it keeps
-          happening, scan the QR code again.
+          Try again — if it keeps happening, scan the QR code again or ask a
+          manager.
         </p>
       </div>
       <button

--- a/web/src/app/manager/qr/page.tsx
+++ b/web/src/app/manager/qr/page.tsx
@@ -49,10 +49,23 @@ function QrPageInner() {
 
   useEffect(() => {
     let cancelled = false;
-    getSupabase()
-      .auth.getSession()
-      .then(({ data }) => {
-        if (!cancelled) setAuthState(data.session ? "ok" : "none");
+    const supabase = getSupabase();
+    // A live session is not enough — this page prints entry credentials, so
+    // require the same manager check as the rest of the dashboard.
+    supabase.auth
+      .getSession()
+      .then(async ({ data }) => {
+        if (!data.session) return "none" as const;
+        const { data: isManager, error } = await supabase.rpc(
+          "current_user_is_manager",
+        );
+        return !error && isManager === true ? ("ok" as const) : ("none" as const);
+      })
+      .then((next) => {
+        if (!cancelled) setAuthState(next);
+      })
+      .catch(() => {
+        if (!cancelled) setAuthState("none");
       });
     return () => {
       cancelled = true;
@@ -62,7 +75,7 @@ function QrPageInner() {
   useEffect(() => {
     if (!token || authState !== "ok") return;
     let cancelled = false;
-    const url = `${window.location.origin}/e?t=${token}`;
+    const url = `${window.location.origin}/e?t=${encodeURIComponent(token)}`;
     QRCode.toDataURL(url, { width: 480, margin: 2 })
       .then((dataUrl) => {
         if (cancelled) return;
@@ -87,7 +100,9 @@ function QrPageInner() {
     return (
       <div className="w-full max-w-md mx-auto mt-16 px-5">
         <div className="bg-card rounded-card p-6">
-          <p className="text-ink">Sign in via /manager first.</p>
+          <p className="text-ink">
+            Sign in with a manager account via /manager first.
+          </p>
         </div>
       </div>
     );

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+// Friendly 404: staff land here from mistyped or stale links — point them
+// back at the scan gate instead of the framework default.
+
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col justify-center px-5 pb-10">
+      <div className="rounded-card bg-card p-5 text-center">
+        <p className="font-bold text-ink">That page doesn&apos;t exist</p>
+        <p className="mt-2 text-ink2">
+          To enter tips, scan the QR code by the register.
+        </p>
+      </div>
+      <Link
+        href="/"
+        className="mt-6 block w-full rounded-full bg-card py-4 text-center font-semibold text-ink"
+      >
+        Back to scan
+      </Link>
+    </main>
+  );
+}

--- a/web/src/components/entry/EntryForm.tsx
+++ b/web/src/components/entry/EntryForm.tsx
@@ -26,6 +26,7 @@ import { anomalyMessage, type AnomalyResult } from "@/lib/tips/anomaly";
 import { formatBusinessDate } from "@/lib/tips/businessDate";
 import { formatMoney } from "@/lib/tips/format";
 import { mealPreset } from "@/lib/tips/mealPreset";
+import { perPersonShare } from "@/lib/tips/split";
 import {
   clearSession,
   loadSession,
@@ -132,7 +133,9 @@ function SavedScreen({
 
   const total = payload.cash + payload.card;
   const count = payload.peopleIds.length;
-  const perPerson = count > 0 ? total / count : 0;
+  // Same cent-exact rounding as the live split strip — float division can
+  // disagree with it by a cent (e.g. $100 / 3).
+  const perPerson = perPersonShare(payload.cash, payload.card, count);
 
   return (
     <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-5 pb-8 pt-20">
@@ -269,6 +272,10 @@ export function EntryForm() {
 
   const lastPayloadRef = useRef<SavePayload | null>(null);
   const finishedRef = useRef(false);
+  // Synchronous in-flight guard: the `saving` state lags a render behind the
+  // click, so two fast taps (or Save + anomaly "Save anyway") could both
+  // start a save. The ref blocks the second one in the same tick.
+  const saveInFlightRef = useRef(false);
   // Per-meal memory of the closer's selection, so switching Lunch↔Dinner and
   // back never discards manual picks (or their voice-overwrite protection).
   const savedSelectionsRef = useRef<
@@ -478,7 +485,8 @@ export function EntryForm() {
 
   const doSave = useCallback(
     async (payload: SavePayload) => {
-      if (!session) return;
+      if (!session || saveInFlightRef.current) return;
+      saveInFlightRef.current = true;
       lastPayloadRef.current = payload;
       setSaving(true);
       setSaveError(null);
@@ -508,6 +516,7 @@ export function EntryForm() {
           retryable: !duplicate,
         });
       } finally {
+        saveInFlightRef.current = false;
         setSaving(false);
       }
     },
@@ -515,14 +524,16 @@ export function EntryForm() {
   );
 
   const amountsValid = isValidAmount(cash) && isValidAmount(card);
-  const canSave = amountsValid && selectedIds.length > 0 && !saving;
+  // slotLoading: a meal switch is mid-flight — saving now would send the NEW
+  // meal with the OLD meal's crew (and possibly stale amounts).
+  const canSave = amountsValid && selectedIds.length > 0 && !saving && !slotLoading;
 
   const handleSaveClick = useCallback(() => {
     if (selectedIds.length === 0) {
       setPickPersonWarning(true);
       return;
     }
-    if (!amountsValid || saving) return;
+    if (!amountsValid || saving || slotLoading) return;
     void doSave({
       meal,
       cash: Number(cash),
@@ -533,7 +544,7 @@ export function EntryForm() {
       correctionsCount: voiceMeta?.corrections ?? 0,
       confirmAnomaly: false,
     });
-  }, [selectedIds, amountsValid, saving, doSave, meal, cash, card, voiceMeta]);
+  }, [selectedIds, amountsValid, saving, slotLoading, doSave, meal, cash, card, voiceMeta]);
 
   const handleVoiceApply = useCallback(
     (result: VoiceApplyResult) => {
@@ -780,7 +791,7 @@ export function EntryForm() {
               silently doing nothing. */}
           <button
             type="button"
-            disabled={saving || !amountsValid}
+            disabled={saving || slotLoading || !amountsValid}
             onClick={handleSaveClick}
             className={`flex-1 rounded-full py-4 font-semibold ${
               canSave ? "bg-card text-ink" : "bg-disabled text-white"

--- a/web/src/components/manager/dashboard/DashboardShell.tsx
+++ b/web/src/components/manager/dashboard/DashboardShell.tsx
@@ -65,14 +65,24 @@ function ShellInner({
   const [nav, setNav] = useState<NavId>("overview");
   // Safe to read localStorage in the initializer: the shell only mounts
   // client-side, behind ManagerApp's auth gate (never server-rendered).
-  const [collapsed, setCollapsed] = useState(
-    () =>
-      typeof window !== "undefined" &&
-      window.localStorage.getItem(SIDEBAR_KEY) === "collapsed",
-  );
+  // try/catch: blocked storage (private mode, enterprise policy) throws.
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return (
+        typeof window !== "undefined" &&
+        window.localStorage.getItem(SIDEBAR_KEY) === "collapsed"
+      );
+    } catch {
+      return false;
+    }
+  });
   const toggleCollapsed = useCallback(() => {
     setCollapsed((value) => {
-      window.localStorage.setItem(SIDEBAR_KEY, value ? "open" : "collapsed");
+      try {
+        window.localStorage.setItem(SIDEBAR_KEY, value ? "open" : "collapsed");
+      } catch {
+        // Preference simply won't persist.
+      }
       return !value;
     });
   }, []);

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -84,49 +84,24 @@ function FixDialog({
     setBusy(true);
     setError(null);
     const supabase = getSupabase();
-    // PostgREST calls can't share a transaction, so order the steps to keep
-    // every intermediate state recoverable: add people first, update the
-    // amounts + split_count, remove people last. An amounts-only fix (the
-    // common case) is then a single atomic UPDATE, and the entry can never
-    // pass through a zero-people state.
+    // One RPC = one transaction: amounts, split_count, and the people roster
+    // land together or not at all (the old multi-call sequence could strand
+    // a mixed roster when a step failed midway).
     try {
-      const before = new Set(entry.peopleIds);
-      const after = new Set(peopleIds);
-      const added = peopleIds.filter((id) => !before.has(id));
-      const removed = entry.peopleIds.filter((id) => !after.has(id));
-
-      if (added.length > 0) {
-        const { error: insertError } = await supabase.from("tip_entry_people").insert(
-          added.map((personId) => ({ tip_entry_id: entry.id, tip_employee_id: personId })),
-        );
-        if (insertError) throw new Error(insertError.message);
-      }
-
-      const { error: updateError } = await supabase
-        .from("tip_entries")
-        .update({
-          cash_amount: cashCents / 100,
-          card_amount: cardCents / 100,
-          split_count: peopleIds.length,
-        })
-        .eq("id", entry.id);
-      if (updateError) throw new Error(updateError.message);
-
-      if (removed.length > 0) {
-        const { error: deleteError } = await supabase
-          .from("tip_entry_people")
-          .delete()
-          .eq("tip_entry_id", entry.id)
-          .in("tip_employee_id", removed);
-        if (deleteError) throw new Error(deleteError.message);
-      }
+      const { error: fixError } = await supabase.rpc("tip_manager_fix_entry", {
+        p_entry_id: entry.id,
+        p_cash: cashCents / 100,
+        p_card: cardCents / 100,
+        p_people: peopleIds,
+      });
+      if (fixError) throw new Error(fixError.message);
 
       toast("Entry updated");
       ctx.refetch();
       onClose();
     } catch (saveError) {
       setError(saveError instanceof Error ? saveError.message : "Could not save the fix.");
-      ctx.refetch(); // the steps aren't atomic — show what actually landed
+      ctx.refetch(); // show what actually landed
       setBusy(false);
     }
   }

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -201,6 +201,15 @@ function FixDialog({
         removedPeople = true;
       }
 
+      // PostgREST mutations do not return affected-row counts by default, so
+      // a zero-row UPDATE/DELETE can have no error. Verify before reporting
+      // success; the catch path will roll back any steps that did land.
+      failedAt = "verifying the saved entry";
+      const saved = await readFixEntryState(supabase, entry.id);
+      if (!sameFixEntryState(saved, desired)) {
+        throw new Error("The saved entry did not match the requested values.");
+      }
+
       toast("Entry updated");
       ctx.refetch();
       onClose();
@@ -276,7 +285,7 @@ function FixDialog({
         setNeedsReload(true);
         const recovery =
           rollbackErrors.length === 0
-            ? `The entry was restored to its original state: ${fixEntryStateSummary(original, namesById)}`
+            ? `No rollback error was reported, but the result could not be verified. The last known original state was: ${fixEntryStateSummary(original, namesById)}`
             : `Rollback did not fully complete (${rollbackErrors.join("; ")}).`;
         setError(
           `Save failed while ${failedAt}: ${reason} ${recovery} Could not read it back (${readError instanceof Error ? readError.message : "request failed"}); reload the ledger before trying again.`,

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -47,6 +47,64 @@ function parseAmountToCents(value: string): number | null {
   return Math.round(num * 100);
 }
 
+interface FixEntryState {
+  cashCents: number;
+  cardCents: number;
+  splitCount: number;
+  peopleIds: string[];
+}
+
+function fixEntryState(entry: LedgerEntry): FixEntryState {
+  return {
+    cashCents: entry.cashCents,
+    cardCents: entry.cardCents,
+    splitCount: entry.splitCount,
+    peopleIds: [...entry.peopleIds],
+  };
+}
+
+function samePeople(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightIds = new Set(right);
+  return rightIds.size === right.length && left.every((id) => rightIds.has(id));
+}
+
+function sameFixEntryState(left: FixEntryState, right: FixEntryState): boolean {
+  return (
+    left.cashCents === right.cashCents &&
+    left.cardCents === right.cardCents &&
+    left.splitCount === right.splitCount &&
+    samePeople(left.peopleIds, right.peopleIds)
+  );
+}
+
+async function readFixEntryState(
+  supabase: ReturnType<typeof getSupabase>,
+  entryId: string,
+): Promise<FixEntryState> {
+  const { data, error } = await supabase
+    .from("tip_entries")
+    .select("cash_amount, card_amount, split_count, tip_entry_people(tip_employee_id)")
+    .eq("id", entryId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("This entry no longer exists.");
+  return {
+    cashCents: Math.round(Number(data.cash_amount) * 100),
+    cardCents: Math.round(Number(data.card_amount) * 100),
+    splitCount: data.split_count,
+    peopleIds: (data.tip_entry_people ?? []).map((person) => person.tip_employee_id),
+  };
+}
+
+function fixEntryStateSummary(state: FixEntryState, namesById: Map<string, string>): string {
+  const people =
+    state.peopleIds.length > 0
+      ? state.peopleIds.map((id) => namesById.get(id) ?? id).join(", ")
+      : "none";
+  return `Cash ${moneyFromCents(state.cashCents)}; card ${moneyFromCents(state.cardCents)}; split count ${state.splitCount}; people: ${people}.`;
+}
+
 function FixDialog({
   entry,
   ctx,
@@ -62,6 +120,7 @@ function FixDialog({
   const [peopleIds, setPeopleIds] = useState<string[]>(entry.peopleIds);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [needsReload, setNeedsReload] = useState(false);
 
   // Choosable people: active staff working this entry's location (or both),
   // plus anyone already on the split (so history never disappears mid-edit).
@@ -80,53 +139,150 @@ function FixDialog({
   const valid = cashCents !== null && cardCents !== null && peopleIds.length >= 1;
 
   async function save() {
-    if (!valid || busy || cashCents === null || cardCents === null) return;
+    if (!valid || busy || needsReload || cashCents === null || cardCents === null) return;
     setBusy(true);
     setError(null);
     const supabase = getSupabase();
-    // PostgREST calls can't share a transaction, so order the steps to keep
-    // every intermediate state recoverable: add people first, update the
-    // amounts + split_count, remove people last. An amounts-only fix (the
-    // common case) is then a single atomic UPDATE, and the entry can never
-    // pass through a zero-people state.
-    try {
-      const before = new Set(entry.peopleIds);
-      const after = new Set(peopleIds);
-      const added = peopleIds.filter((id) => !before.has(id));
-      const removed = entry.peopleIds.filter((id) => !after.has(id));
+    // The transactional tip_save_entry RPC is service-role-only. Keep the
+    // client sequence reversible: add people, update the entry, remove people;
+    // on failure, reverse completed steps and read back the actual state.
+    const original = fixEntryState(entry);
+    const desired: FixEntryState = {
+      cashCents,
+      cardCents,
+      splitCount: peopleIds.length,
+      peopleIds: [...peopleIds],
+    };
+    const before = new Set(entry.peopleIds);
+    const after = new Set(peopleIds);
+    const added = peopleIds.filter((id) => !before.has(id));
+    const removed = entry.peopleIds.filter((id) => !after.has(id));
+    const updateNeeded =
+      cashCents !== entry.cashCents ||
+      cardCents !== entry.cardCents ||
+      peopleIds.length !== entry.splitCount;
+    let addedPeople = false;
+    let updatedEntry = false;
+    let removedPeople = false;
+    let failedAt = "saving the entry";
 
+    try {
       if (added.length > 0) {
+        failedAt = "adding the new people";
         const { error: insertError } = await supabase.from("tip_entry_people").insert(
           added.map((personId) => ({ tip_entry_id: entry.id, tip_employee_id: personId })),
         );
         if (insertError) throw new Error(insertError.message);
+        addedPeople = true;
       }
 
-      const { error: updateError } = await supabase
-        .from("tip_entries")
-        .update({
-          cash_amount: cashCents / 100,
-          card_amount: cardCents / 100,
-          split_count: peopleIds.length,
-        })
-        .eq("id", entry.id);
-      if (updateError) throw new Error(updateError.message);
+      if (updateNeeded) {
+        failedAt = "updating the amounts and split count";
+        const { error: updateError } = await supabase
+          .from("tip_entries")
+          .update({
+            cash_amount: cashCents / 100,
+            card_amount: cardCents / 100,
+            split_count: peopleIds.length,
+          })
+          .eq("id", entry.id);
+        if (updateError) throw new Error(updateError.message);
+        updatedEntry = true;
+      }
 
       if (removed.length > 0) {
+        failedAt = "removing the previous people";
         const { error: deleteError } = await supabase
           .from("tip_entry_people")
           .delete()
           .eq("tip_entry_id", entry.id)
           .in("tip_employee_id", removed);
         if (deleteError) throw new Error(deleteError.message);
+        removedPeople = true;
       }
 
       toast("Entry updated");
       ctx.refetch();
       onClose();
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : "Could not save the fix.");
-      ctx.refetch(); // the steps aren't atomic — show what actually landed
+      const rollbackErrors: string[] = [];
+      const rollback = async (
+        label: string,
+        action: () => PromiseLike<{ error: { message: string } | null }>,
+      ) => {
+        try {
+          const { error: rollbackError } = await action();
+          if (rollbackError) rollbackErrors.push(`${label}: ${rollbackError.message}`);
+        } catch (rollbackError) {
+          rollbackErrors.push(
+            `${label}: ${rollbackError instanceof Error ? rollbackError.message : "request failed"}`,
+          );
+        }
+      };
+
+      // Reverse in dependency order. Restoring removed people first guarantees
+      // that even the rollback path never leaves the entry with no people.
+      if (removedPeople) {
+        await rollback("could not restore removed people", () =>
+          supabase.from("tip_entry_people").insert(
+            removed.map((personId) => ({ tip_entry_id: entry.id, tip_employee_id: personId })),
+          ),
+        );
+      }
+      if (updatedEntry) {
+        await rollback("could not restore amounts and split count", () =>
+          supabase
+            .from("tip_entries")
+            .update({
+              cash_amount: original.cashCents / 100,
+              card_amount: original.cardCents / 100,
+              split_count: original.splitCount,
+            })
+            .eq("id", entry.id),
+        );
+      }
+      if (addedPeople) {
+        await rollback("could not remove newly added people", () =>
+          supabase
+            .from("tip_entry_people")
+            .delete()
+            .eq("tip_entry_id", entry.id)
+            .in("tip_employee_id", added),
+        );
+      }
+
+      const reason = saveError instanceof Error ? saveError.message : "Could not save the fix.";
+      const namesById = new Map(ctx.data.employees.map((employee) => [employee.id, employee.name]));
+      try {
+        const current = await readFixEntryState(supabase, entry.id);
+        if (sameFixEntryState(current, desired)) {
+          toast("Entry updated");
+          ctx.refetch();
+          onClose();
+          return;
+        }
+
+        const restored = sameFixEntryState(current, original);
+        const recovery = restored
+          ? "The entry was restored to its original state."
+          : rollbackErrors.length === 0
+            ? "Rollback finished, but the entry no longer matches the state from when this dialog opened."
+            : `Rollback did not fully complete (${rollbackErrors.join("; ")}).`;
+        if (!restored) setNeedsReload(true);
+        setError(
+          `Save failed while ${failedAt}: ${reason} ${recovery} Current entry state: ${fixEntryStateSummary(current, namesById)}${restored ? "" : " Close this dialog and review the refreshed ledger before making another change."}`,
+        );
+      } catch (readError) {
+        setNeedsReload(true);
+        const recovery =
+          rollbackErrors.length === 0
+            ? `The entry was restored to its original state: ${fixEntryStateSummary(original, namesById)}`
+            : `Rollback did not fully complete (${rollbackErrors.join("; ")}).`;
+        setError(
+          `Save failed while ${failedAt}: ${reason} ${recovery} Could not read it back (${readError instanceof Error ? readError.message : "request failed"}); reload the ledger before trying again.`,
+        );
+      }
+      ctx.refetch();
       setBusy(false);
     }
   }
@@ -146,6 +302,7 @@ function FixDialog({
             value={cash}
             onChange={(event) => setCash(event.target.value)}
             inputMode="decimal"
+            disabled={busy || needsReload}
             className="rounded-well bg-well px-3.5 py-2.5 text-ink outline-none"
           />
         </label>
@@ -155,6 +312,7 @@ function FixDialog({
             value={card}
             onChange={(event) => setCard(event.target.value)}
             inputMode="decimal"
+            disabled={busy || needsReload}
             className="rounded-well bg-well px-3.5 py-2.5 text-ink outline-none"
           />
         </label>
@@ -170,6 +328,7 @@ function FixDialog({
                 key={employee.id}
                 type="button"
                 aria-pressed={selected}
+                disabled={busy || needsReload}
                 onClick={() =>
                   setPeopleIds((previous) =>
                     selected
@@ -194,13 +353,22 @@ function FixDialog({
           {moneyFromCents(cashShareCents(cashCents, peopleIds.length))} cash each
         </p>
       )}
-      {error && <p className="mt-3 text-sm text-alert">{error}</p>}
+      {error && (
+        <p role="alert" className="mt-3 text-sm text-alert">
+          {error}
+        </p>
+      )}
 
       <div className="mt-5 flex justify-end gap-2">
         <button type="button" className={btn} onClick={onClose} disabled={busy}>
           Cancel
         </button>
-        <button type="button" className={btnPrim} onClick={() => void save()} disabled={!valid || busy}>
+        <button
+          type="button"
+          className={btnPrim}
+          onClick={() => void save()}
+          disabled={!valid || busy || needsReload}
+        >
           {busy ? "Saving…" : "Save fix"}
         </button>
       </div>

--- a/web/src/components/manager/dashboard/OverviewPage.tsx
+++ b/web/src/components/manager/dashboard/OverviewPage.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-// Overview: Trend & people — red daily cash+card line over the range, ranked
-// cash take-home bars per person, then the "Needs attention" list. Every
-// attention row navigates to the page that fixes it.
+// Overview: Trend & people — location-colored daily cash+card lines over the
+// range, ranked cash take-home bars per person, then the "Needs attention"
+// list. Every attention row navigates to the page that fixes it.
 
 import {
   dailyTrend,
@@ -13,11 +13,23 @@ import {
 } from "@/lib/tips/dashboardDerive";
 import { shortDayLabel, trendDayLabel } from "@/lib/tips/dashboardRange";
 import { btn, panelWrap, sectionH3 } from "./ui";
-import type { PageContext } from "./types";
+import type { LocationInfo, PageContext } from "./types";
 
 const TREND_W = 600;
 const TREND_H = 180;
 const TREND_PAD = 10;
+
+function trendColor(location: LocationInfo): string {
+  if (location.kind === "poki") return "#2563eb";
+  if (location.kind === "sushi") return "#1a1a1a";
+  return "#e84d38";
+}
+
+function trendAreaFill(location: LocationInfo): string {
+  if (location.kind === "poki") return "rgba(37,99,235,.08)";
+  if (location.kind === "sushi") return "rgba(26,26,26,.08)";
+  return "rgba(232,77,56,.08)";
+}
 
 function TrendChart({ ctx }: { ctx: PageContext }) {
   const days = dailyTrend(ctx.entries);
@@ -29,17 +41,22 @@ function TrendChart({ ctx }: { ctx: PageContext }) {
     );
   }
 
-  const max = Math.max(...days.map((day) => day.totalCents), 1);
-  const points = days.map((day, index) => {
-    const x =
-      days.length > 1
-        ? TREND_PAD + (index * (TREND_W - 2 * TREND_PAD)) / (days.length - 1)
-        : TREND_W / 2;
-    const y = TREND_H - TREND_PAD - (day.totalCents / max) * (TREND_H - 2 * TREND_PAD);
-    return [Math.round(x), Math.round(y)] as const;
-  });
-  const line = points.map((point) => point.join(",")).join(" ");
-  const area = `0,${TREND_H} ${line} ${TREND_W},${TREND_H}`;
+  const series = ctx.visibleLocations.map((location) => ({
+    location,
+    days: dailyTrend(ctx.entries.filter((entry) => entry.locationId === location.id)),
+  }));
+  const max = Math.max(...series.flatMap((item) => item.days.map((day) => day.totalCents)), 1);
+  const indexByDate = new Map(days.map((day, index) => [day.businessDate, index]));
+  const pointsFor = (seriesDays: typeof days) =>
+    seriesDays.map((day) => {
+      const index = indexByDate.get(day.businessDate) ?? 0;
+      const x =
+        days.length > 1
+          ? TREND_PAD + (index * (TREND_W - 2 * TREND_PAD)) / (days.length - 1)
+          : TREND_W / 2;
+      const y = TREND_H - TREND_PAD - (day.totalCents / max) * (TREND_H - 2 * TREND_PAD);
+      return [Math.round(x), Math.round(y)] as const;
+    });
 
   // Long ranges would smear the axis; label every nth day instead.
   const labelStep = Math.max(1, Math.ceil(days.length / 10));
@@ -51,20 +68,38 @@ function TrendChart({ ctx }: { ctx: PageContext }) {
         viewBox={`0 0 ${TREND_W} ${TREND_H}`}
         preserveAspectRatio="none"
         role="img"
-        aria-label="Daily cash + card totals"
+        aria-label={
+          series.length > 1 ? "Daily cash + card totals by location" : "Daily cash + card totals"
+        }
       >
-        <polygon points={area} fill="rgba(232,77,56,.08)" />
-        <polyline
-          points={line}
-          fill="none"
-          stroke="#e84d38"
-          strokeWidth="2.5"
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
-        {points.map((point, index) => (
-          <circle key={days[index].businessDate} cx={point[0]} cy={point[1]} r="3.5" fill="#e84d38" />
-        ))}
+        {series.map((item) => {
+          const points = pointsFor(item.days);
+          const line = points.map((point) => point.join(",")).join(" ");
+          const color = trendColor(item.location);
+          const area = `0,${TREND_H} ${line} ${TREND_W},${TREND_H}`;
+          return (
+            <g key={item.location.id}>
+              {series.length === 1 && <polygon points={area} fill={trendAreaFill(item.location)} />}
+              <polyline
+                points={line}
+                fill="none"
+                stroke={color}
+                strokeWidth="2.5"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+              {points.map((point, index) => (
+                <circle
+                  key={item.days[index].businessDate}
+                  cx={point[0]}
+                  cy={point[1]}
+                  r="3.5"
+                  fill={color}
+                />
+              ))}
+            </g>
+          );
+        })}
       </svg>
       <div className="flex justify-between px-0.5 pb-2.5 pt-1.5 text-[11px] font-semibold text-ink3">
         {days.map((day, index) => (
@@ -127,14 +162,15 @@ export function OverviewPage({ ctx }: { ctx: PageContext }) {
           <b className="text-[14.5px] font-extrabold text-ink">Tips trend — {ctx.rangeLabel}</b>
           {showLegend && (
             <span className="flex items-center gap-3 text-xs text-ink2">
-              <span>
-                <span className="mr-1.5 inline-block h-[11px] w-[11px] rounded align-[-1px] bg-ink" />
-                Sushi
-              </span>
-              <span>
-                <span className="mr-1.5 inline-block h-[11px] w-[11px] rounded align-[-1px] bg-poki" />
-                Poki &amp; Pho
-              </span>
+              {ctx.visibleLocations.map((location) => (
+                <span key={location.id}>
+                  <span
+                    className="mr-1.5 inline-block h-[11px] w-[11px] rounded align-[-1px]"
+                    style={{ backgroundColor: trendColor(location) }}
+                  />
+                  {location.label}
+                </span>
+              ))}
             </span>
           )}
           <span className="ml-auto text-[12.5px] text-ink2">

--- a/web/src/components/manager/dashboard/OverviewPage.tsx
+++ b/web/src/components/manager/dashboard/OverviewPage.tsx
@@ -8,6 +8,7 @@ import {
   dailyTrend,
   moneyFromCents,
   rangeTotals,
+  splitTrendSeries,
   takeHomeByPerson,
   wholeDollarsFromCents,
 } from "@/lib/tips/dashboardDerive";
@@ -74,20 +75,24 @@ function TrendChart({ ctx }: { ctx: PageContext }) {
       >
         {series.map((item) => {
           const points = pointsFor(item.days);
-          const line = points.map((point) => point.join(",")).join(" ");
           const color = trendColor(item.location);
-          const area = `0,${TREND_H} ${line} ${TREND_W},${TREND_H}`;
+          const area = `0,${TREND_H} ${points.map((point) => point.join(",")).join(" ")} ${TREND_W},${TREND_H}`;
           return (
             <g key={item.location.id}>
               {series.length === 1 && <polygon points={area} fill={trendAreaFill(item.location)} />}
-              <polyline
-                points={line}
-                fill="none"
-                stroke={color}
-                strokeWidth="2.5"
-                strokeLinejoin="round"
-                strokeLinecap="round"
-              />
+              {splitTrendSeries(item.days, days).map((segment) => (
+                <polyline
+                  key={segment[0].businessDate}
+                  points={pointsFor(segment)
+                    .map((point) => point.join(","))
+                    .join(" ")}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth="2.5"
+                  strokeLinejoin="round"
+                  strokeLinecap="round"
+                />
+              ))}
               {points.map((point, index) => (
                 <circle
                   key={item.days[index].businessDate}

--- a/web/src/components/manager/dashboard/useDashboardData.ts
+++ b/web/src/components/manager/dashboard/useDashboardData.ts
@@ -77,10 +77,18 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
 
       const [locationRows, employeeRows, scheduleRows, accessRows, entryRows, sessionRows] =
         await Promise.all([
-          supabase.from("locations").select("id, name").order("name").then((r) => {
-            if (r.error) throw new Error(r.error.message);
-            return r.data ?? [];
-          }),
+          // PostgREST applies this embedded order + limit per location, so
+          // one locations request also gets each missing-shift floor.
+          supabase
+            .from("locations")
+            .select("id, name, tip_entries(business_date)")
+            .order("name")
+            .order("business_date", { ascending: true, referencedTable: "tip_entries" })
+            .limit(1, { referencedTable: "tip_entries" })
+            .then((r) => {
+              if (r.error) throw new Error(r.error.message);
+              return r.data ?? [];
+            }),
           supabase
             .from("tip_employees")
             .select("id, name, location_id, active, sort_order")
@@ -195,18 +203,9 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
       // Each location's first-ever entry date floors the missing-shift scan —
       // same rule the v1 discrepancies tab used.
       const firstEntryDates: Record<string, string | undefined> = {};
-      await Promise.all(
-        locationRows.map(async (location) => {
-          const r = await supabase
-            .from("tip_entries")
-            .select("business_date")
-            .eq("location_id", location.id)
-            .order("business_date", { ascending: true })
-            .limit(1);
-          if (r.error) throw new Error(r.error.message);
-          firstEntryDates[location.id] = r.data?.[0]?.business_date;
-        }),
-      );
+      for (const location of locationRows) {
+        firstEntryDates[location.id] = location.tip_entries[0]?.business_date;
+      }
 
       const locations = locationRows.map(toLocationInfo).sort((a, b) => {
         // Sushi card/segment first, matching the mockup.

--- a/web/src/components/manager/dashboard/useDashboardData.ts
+++ b/web/src/components/manager/dashboard/useDashboardData.ts
@@ -156,8 +156,14 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
           businessDate: row.business_date,
           locationId: row.location_id,
           meal: row.meal_period as MealPeriod,
-          cashCents: Math.round(Number(row.cash_amount) * 100),
-          cardCents: Math.round(Number(row.card_amount) * 100),
+          // A malformed numeric from the DB must not turn the whole money
+          // column into $NaN — fall back to 0 and keep rendering.
+          cashCents: Number.isFinite(Number(row.cash_amount))
+            ? Math.round(Number(row.cash_amount) * 100)
+            : 0,
+          cardCents: Number.isFinite(Number(row.card_amount))
+            ? Math.round(Number(row.card_amount) * 100)
+            : 0,
           splitCount: row.split_count,
           peopleIds,
           peopleNames: peopleIds.map((id) => nameById.get(id) ?? "?"),

--- a/web/src/lib/tips/__tests__/dashboardCsv.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardCsv.test.ts
@@ -82,4 +82,23 @@ describe("buildLedgerCsv", () => {
     );
     expect(csv.split("\n")[1].split(",")).toContain("yes");
   });
+
+  it("neutralizes spreadsheet formula injection in free-text fields", () => {
+    const csv = buildLedgerCsv(
+      [
+        entry({
+          peopleIds: ["a"],
+          peopleNames: ["=HYPERLINK(\"https://evil.example\",\"x\")"],
+          splitCount: 1,
+          enteredByName: "+1-555-0100",
+        }),
+      ],
+      (id) => LOCATION_LABELS[id],
+    );
+    const row = csv.split("\n")[1];
+    // A leading ' makes Excel/Sheets treat the cell as text, not a formula.
+    expect(row).toContain("'=HYPERLINK");
+    expect(row).toContain("'+1-555-0100");
+    expect(row).not.toContain(',=HYPERLINK');
+  });
 });

--- a/web/src/lib/tips/__tests__/dashboardDerive.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardDerive.test.ts
@@ -72,6 +72,34 @@ describe("dailyTrend", () => {
       { businessDate: "2026-08-09", totalCents: 315 },
     ]);
   });
+
+  // The Overview trend renders one series per visible location, so a
+  // per-location slice must hold only that location's days and the slices
+  // must still add up to the combined totals the topbar reports.
+  it("splits into per-location series that sum back to the combined trend", () => {
+    const entries = [
+      entry({ businessDate: "2026-08-07", locationId: "loc-sushi", cashCents: 100, cardCents: 200 }),
+      entry({ id: "e2", businessDate: "2026-08-07", locationId: "loc-poki", cashCents: 300, cardCents: 400 }),
+      entry({ id: "e3", businessDate: "2026-08-09", locationId: "loc-sushi", cashCents: 500, cardCents: 150 }),
+    ];
+
+    const sushi = dailyTrend(entries.filter((row) => row.locationId === "loc-sushi"));
+    const poki = dailyTrend(entries.filter((row) => row.locationId === "loc-poki"));
+
+    expect(sushi).toEqual([
+      { businessDate: "2026-08-07", totalCents: 300 },
+      { businessDate: "2026-08-09", totalCents: 650 },
+    ]);
+    // Poki traded only one of the two days; its series must not invent the other.
+    expect(poki).toEqual([{ businessDate: "2026-08-07", totalCents: 700 }]);
+
+    const combined = dailyTrend(entries);
+    const summed = combined.map((day) => {
+      const perLocation = [...sushi, ...poki].filter((row) => row.businessDate === day.businessDate);
+      return perLocation.reduce((total, row) => total + row.totalCents, 0);
+    });
+    expect(summed).toEqual(combined.map((day) => day.totalCents));
+  });
 });
 
 describe("takeHomeByPerson", () => {

--- a/web/src/lib/tips/__tests__/dashboardDerive.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardDerive.test.ts
@@ -5,6 +5,7 @@ import {
   dailyTrend,
   moneyFromCents,
   rangeTotals,
+  splitTrendSeries,
   takeHomeByPerson,
   wholeDollarsFromCents,
   type LedgerEntry,
@@ -99,6 +100,28 @@ describe("dailyTrend", () => {
       return perLocation.reduce((total, row) => total + row.totalCents, 0);
     });
     expect(summed).toEqual(combined.map((day) => day.totalCents));
+  });
+});
+
+describe("splitTrendSeries", () => {
+  it("breaks a location line across a day recorded only by another location", () => {
+    const timeline = [
+      { businessDate: "2026-08-10", totalCents: 100 },
+      { businessDate: "2026-08-11", totalCents: 200 },
+      { businessDate: "2026-08-12", totalCents: 300 },
+    ];
+    const sushi = [timeline[0], timeline[2]];
+
+    expect(splitTrendSeries(sushi, timeline)).toEqual([[timeline[0]], [timeline[2]]]);
+  });
+
+  it("keeps consecutive shared-timeline days in one line", () => {
+    const timeline = [
+      { businessDate: "2026-08-10", totalCents: 100 },
+      { businessDate: "2026-08-11", totalCents: 200 },
+    ];
+
+    expect(splitTrendSeries(timeline, timeline)).toEqual([timeline]);
   });
 });
 

--- a/web/src/lib/tips/api.ts
+++ b/web/src/lib/tips/api.ts
@@ -81,6 +81,9 @@ async function callFunction(
         apikey: anonKey,
       },
       body: JSON.stringify(body),
+      // The page URL can still hold the QR token (?t=) when this fires —
+      // never let it ride to another origin as Referer.
+      referrerPolicy: "no-referrer",
     });
   } catch {
     throw new TipApiError(
@@ -110,6 +113,41 @@ export interface FreshSignIn extends SessionState {
 }
 
 /**
+ * Runtime shape check for session payloads. The edge function is typed only
+ * by convention; a malformed/partial response (older deploy, proxy error
+ * page) must surface as a clean TipApiError instead of crashing the render
+ * on `.id` / `.map` of undefined.
+ */
+function isSessionStateShape(value: unknown): value is SessionState {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  const location = v.location as Record<string, unknown> | undefined;
+  const today = v.today as Record<string, unknown> | undefined;
+  return (
+    !!location &&
+    typeof location.id === "string" &&
+    typeof location.name === "string" &&
+    Array.isArray(v.roster) &&
+    v.roster.every(
+      (p) =>
+        p && typeof p === "object" &&
+        typeof (p as Record<string, unknown>).id === "string" &&
+        typeof (p as Record<string, unknown>).name === "string",
+    ) &&
+    !!today &&
+    typeof today.businessDate === "string" &&
+    typeof today.lunchRecorded === "boolean" &&
+    typeof today.dinnerRecorded === "boolean"
+  );
+}
+
+function assertSessionState(json: Record<string, unknown>): void {
+  if (json.ok !== true || !isSessionStateShape(json)) {
+    throw new TipApiError("Something went wrong. Try again.", "bad_response", 200);
+  }
+}
+
+/**
  * Validate a scanned QR token and mint the entry session in ONE roundtrip.
  * When this device remembers who's closing, the remembered closer rides
  * along and the server applies it in the same request (the response's
@@ -127,6 +165,10 @@ export async function validateToken(
       ? { closerId: remembered.closerId, closerLocationId: remembered.locationId }
       : {}),
   });
+  assertSessionState(json);
+  if (typeof json.sessionToken !== "string" || !json.sessionToken) {
+    throw new TipApiError("Something went wrong. Try again.", "bad_response", 200);
+  }
   return json as unknown as FreshSignIn;
 }
 
@@ -158,6 +200,7 @@ export async function endSession(sessionToken: string): Promise<void> {
 
 export async function fetchState(sessionToken: string): Promise<SessionState> {
   const json = await callFunction("tip-entry-auth", { action: "state", sessionToken });
+  assertSessionState(json);
   return json as unknown as SessionState;
 }
 
@@ -245,6 +288,7 @@ async function parseVoiceChunkOnce(input: {
       method: "POST",
       headers: { Authorization: `Bearer ${anonKey}`, apikey: anonKey },
       body: form,
+      referrerPolicy: "no-referrer",
     });
   } catch {
     throw new TipApiError("Voice upload failed.", "network", 0);

--- a/web/src/lib/tips/dashboardCsv.ts
+++ b/web/src/lib/tips/dashboardCsv.ts
@@ -11,8 +11,19 @@ const HEADER =
   "Business date,Restaurant,Meal,Cash (split pool),Card (logged only)," +
   "People on split,Names,Per-person share,Flagged,Entered by,Entry method";
 
+/** Prefix-guard against spreadsheet formula injection (=, +, -, @, tab, CR). */
+function formulaSafe(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
 function csvField(value: string): string {
-  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  const safe = formulaSafe(value);
+  return /[",\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
+}
+
+/** Always-quoted variant (the Names column follows the mockup's format). */
+function csvFieldQuoted(value: string): string {
+  return `"${formulaSafe(value).replace(/"/g, '""')}"`;
 }
 
 function capitalize(word: string): string {
@@ -38,7 +49,7 @@ export function buildLedgerCsv(
         (entry.cashCents / 100).toFixed(2),
         (entry.cardCents / 100).toFixed(2),
         String(entry.splitCount),
-        `"${entry.peopleNames.join("; ").replace(/"/g, '""')}"`,
+        csvFieldQuoted(entry.peopleNames.join("; ")),
         (cashShareCents(entry.cashCents, entry.splitCount) / 100).toFixed(2),
         entry.flaggedRaw ? "yes" : "no",
         csvField(entry.enteredByName ?? ""),

--- a/web/src/lib/tips/dashboardDerive.ts
+++ b/web/src/lib/tips/dashboardDerive.ts
@@ -72,6 +72,27 @@ export function dailyTrend(entries: LedgerEntry[]): TrendDay[] {
     .map(([businessDate, totalCents]) => ({ businessDate, totalCents }));
 }
 
+/**
+ * Split one location's trend wherever the shared chart timeline contains a
+ * day that location did not record. This prevents a polyline from visually
+ * interpolating through another location's otherwise-valid data point.
+ */
+export function splitTrendSeries(series: TrendDay[], timeline: TrendDay[]): TrendDay[][] {
+  const indexByDate = new Map(timeline.map((day, index) => [day.businessDate, index]));
+  const segments: TrendDay[][] = [];
+  let previousIndex: number | undefined;
+
+  for (const day of series) {
+    const index = indexByDate.get(day.businessDate);
+    if (index === undefined) continue;
+    if (previousIndex === undefined || index !== previousIndex + 1) segments.push([]);
+    segments.at(-1)?.push(day);
+    previousIndex = index;
+  }
+
+  return segments;
+}
+
 export interface PersonTakeHome {
   id: string;
   name: string;

--- a/web/src/lib/tips/recorder.ts
+++ b/web/src/lib/tips/recorder.ts
@@ -127,7 +127,13 @@ export class TipRecorder {
       }
     };
     this.source.connect(this.processor);
-    this.processor.connect(this.audioContext.destination);
+    // ScriptProcessor only fires onaudioprocess when connected to the
+    // destination — route through a zero-gain node so the live mic is NEVER
+    // audible on the device speaker (feedback + dining-room eavesdropping).
+    const mute = this.audioContext.createGain();
+    mute.gain.value = 0;
+    this.processor.connect(mute);
+    mute.connect(this.audioContext.destination);
 
     this.startSegment();
     this.silenceTimer = setInterval(() => this.checkSilence(), 250);

--- a/web/src/types/database.ts
+++ b/web/src/types/database.ts
@@ -4843,6 +4843,15 @@ export type Database = {
         }
         Returns: boolean
       }
+      tip_manager_fix_entry: {
+        Args: {
+          p_card: number
+          p_cash: number
+          p_entry_id: string
+          p_people: string[]
+        }
+        Returns: undefined
+      }
       tip_revoke_location_sessions: {
         Args: { p_location_id: string }
         Returns: number


### PR DESCRIPTION
Tip Dashboard v2 fixes found by driving the live dashboard against the production database. Part of the E2E test-and-fix campaign; the iOS app changes ship separately and no app commits are in this branch.

## What was tested

Signed in as a throwaway `e2e-test-manager` fixture and walked every page, filter, and range against the database:

- **Overview, Recorded tips, Staff & schedule, Devices & entry log** all render real data that matches the database exactly. Verified per page with SQL: 2 entries on Aug 26, cash $70.00, card $188.00.
- **Filters and ranges**: the Poki & Pho segment and prior-week range both produce honest empty states, confirmed against `select count(*) ... where business_date between ...` returning 0.
- **Entry token integrity**: `entry_token_plain` matches `entry_token_hash` (sha256) for both locations.

## What was fixed

**Trend chart contradicted its own legend.** The Overview legend showed Sushi and Poki & Pho in distinct colors while the chart drew a single combined line in a third color that matched neither. It now renders one series per visible location in the legend's colors. Totals and topbar figures are unchanged.

**The manager Fix flow could silently corrupt a tip entry.** It edits an entry with three sequential PostgREST calls, so a mid-sequence failure left a half-applied edit with no indication. The transactional `tip_save_entry` RPC is not reachable from the browser (execute is granted to `service_role` only, verified against `pg_proc`), so true atomicity is unavailable client-side. Instead the flow now rolls back completed steps in reverse dependency order, restoring removed people first so the entry never passes through a zero-people state; reads the entry back to report its actual state; converts the case where the write actually landed into a success; and locks the form when the resulting state is indeterminate rather than letting a second edit stack on unknown state.

**N+1 queries on every refetch.** Per-location first-entry dates were fetched with one query per location. They now come from a single embedded query on the existing locations request.

**Stale E2E spec.** `landing.spec.ts` asserted "Scan the sticker"; the page renders "Scan the QR code".

## Validation

```
npx tsc --noEmit     0 errors
npm run lint         clean
npm run build        succeeds
npm test             195 passed (194 baseline + 1 added)
```

Live regression check after the changes: Overview and Recorded tips render byte-identical numbers to the pre-change build, the Fix dialog renders real values, and the production tip ledger was confirmed untouched by the whole pass (row count, sums, and `max(updated_at)` all unchanged).

## Verification gaps, stated plainly

**Multi-location trend series was not verified against real data.** Production holds only two tip entries, same day and same location, so the chart cannot render more than one series with real data. Seeding throwaway tip rows into the live money ledger was refused by the agent safety policy, correctly, so it was not forced. The behavior is covered instead by a unit test pinning that per-location slices contain only their own days and still sum back to the combined totals. Worth an eyeball once real multi-location tip data exists.

**The entry-device flow was not driven end to end.** The deployed `tip-*` edge functions set `Access-Control-Allow-Origin` to `https://tips.babytunasystems.com` only, so scan to closer to entry-save cannot run from localhost. To unblock: add `http://localhost:3000` to `ALLOWED_ORIGINS` in Supabase secrets, or run the Playwright suite against production directly.

## Still open for a follow-up

Not fixed here, recorded from the inventory sweep: `/manager/qr` is an orphan page gated on any session rather than manager role and docs still point at it; the PIN RPCs and `pin_hash` columns are dead since the PIN removal; `web/SETUP.md`, `web/e2e/README.md`, and `web/README.md` are stale; the Staff page has no empty-roster message; filter state is not reflected in the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
