### PR TITLE
Fix tip QR routing and authentication reliability

### DIFF
--- a/docs/deploy/NEEDS-DAVID.md
+++ b/docs/deploy/NEEDS-DAVID.md
@@ -5,10 +5,10 @@ Each phase also gets a deploy checklist in `docs/deploy/phase-N.md` (staged — 
 is pushed to production by agents).
 
 ## Carry-over from tips launch (production, do whenever)
-- [ ] Set Supabase secret `ALLOWED_ORIGINS=https://tips.babytunasystems.com`
+- [ ] Keep the Supabase secret aligned with the web domains: `ALLOWED_ORIGINS=https://tips.smelterpos.com,https://dashboard.smelterpos.com,https://tips.babytunasystems.com` (the last host is the temporary legacy fallback).
 - [ ] Rotate seeded entry tokens + PINs from `/manager` (Sushi 4271, Poki 8356 are seeded fixtures)
 - [ ] Rename placeholder roster (Maria/Jose/Lena/Tom/Ken)
-- [ ] Print QR stickers — ONLY from `tips.babytunasystems.com/manager/qr` (vercel.app URL bakes wrong host)
+- [ ] Reprint QR stickers from the dashboard after this fix ships. QR/NFC links now always use `https://tips.smelterpos.com/e`, regardless of which manager or preview host generated them.
 
 ## Real-world verification (build is done with fixtures; these prove it)
 - [ ] Phase 1: send a real order-day Send All run from a physical iPhone

--- a/docs/flood-test-2026-08-27.md
+++ b/docs/flood-test-2026-08-27.md
@@ -1,0 +1,114 @@
+# Flood Test & Security Review — 2026-08-27
+
+Scope: the web surfaces only — the tips entry app and the manager dashboard —
+plus the four tip edge functions and their SQL RPCs. The Expo mobile app was
+out of scope.
+
+**Targets tested live:** `tips.babytunasystems.com` (production web app) and
+`https://whrohvitvmcrmedepurd.supabase.co/functions/v1/{tip-entry-auth,
+tip-entries, tip-voice-parse, tip-voice-stream}`.
+
+## Method
+
+1. **Static review** of `web/src/**`, `supabase/functions/{tip-entry-auth,
+   tip-entries, tip-voice-parse, tip-voice-stream}`, `_shared/tips.ts`,
+   `_shared/cors.ts`, and the tip migrations.
+2. **Live flood harness** (`flood-test/harness.mjs`, 81 checks): route
+   availability, method fuzzing, malformed JSON, 19 garbage-token shapes
+   (SQLi, XSS, path traversal, unicode, oversized, wrong types),
+   session-gate bypass attempts, rate-limit burn-down (20-try window),
+   XFF-spoof bypass attempt, 30-way concurrent bad-token burst, 60-way
+   concurrent site GET burst, 25-way concurrent voice-parse burst, WebSocket
+   ticket auth (no/short/garbage/oversized tickets), oversized upload (5–6MB).
+3. **Fix + verify**: all fixes on branch `fix/web-flood-hardening`, quality
+   gates green, browser verification on the Vercel preview.
+
+## Result: 73/81 checks passed on the unpatched deployment. 8 findings.
+
+---
+
+## Findings fixed in PR #17
+
+### Security
+
+| # | Severity | Finding | Status |
+|---|----------|---------|--------|
+| S1 | High | **No CSP / X-Frame-Options / Referrer-Policy / X-Content-Type-Options** on any page (confirmed live). Clickjacking + script-injection surface with session tokens in localStorage. | Fixed — full header set in `next.config.ts` |
+| S2 | High | **Rate-limit bypass via `x-forwarded-for` spoofing** (confirmed live): after burning the 20-try token limit, a request with a spoofed XFF was allowed again immediately. `clientIdentifier` trusted the first (client-controlled) XFF entry. | Fixed — uses the last (proxy-appended) entry |
+| S3 | High | **QR token leak via Referer**: `/e?t=<token>` validated before stripping the URL, and fetches used the default referrer policy. | Fixed — token stripped before any network call; `referrerPolicy: "no-referrer"` on all edge fetches; site-wide `Referrer-Policy: no-referrer` |
+| S4 | Medium | **CSV formula injection**: a roster name like `=HYPERLINK(...)` exported unescaped; Excel/Sheets would execute it when a manager opens the CSV. | Fixed — `= + - @` prefixes neutralized; regression test added |
+| S5 | Medium | **`/manager/qr` gated by any session**, not manager role — any signed-in account with a `#t=` link could print entry QR codes. | Fixed — requires `current_user_is_manager()` |
+| S6 | Low | QR entry URL built without `encodeURIComponent`. | Fixed |
+
+### Reliability
+
+| # | Severity | Finding | Status |
+|---|----------|---------|--------|
+| R1 | Medium | **`tip-voice-parse` returned HTTP 500 on a non-multipart body** (confirmed live). | Fixed — clean 400 |
+| R2 | High | **Meal-switch race**: tapping Save mid Lunch↔Dinner switch sent the new meal with the old meal's crew (and possibly stale amounts). | Fixed — Save blocked while slot loads |
+| R3 | Medium | **Double-submit race**: two fast taps both passed the `saving` state guard. | Fixed — synchronous in-flight ref |
+| R4 | Medium | **Voice recorder played the live mic through the device speaker** (`processor.connect(destination)`) — feedback + privacy leak in the dining room. | Fixed — zero-gain node |
+| R5 | Medium | **Unsafe response casts**: malformed edge-function responses crashed the render (`.map` of undefined). | Fixed — shape validation → retryable error |
+| R6 | Medium | **Manager "Fix" was non-atomic** (3 PostgREST calls; mid-failure = mixed roster). | Fixed — single transactional `tip_manager_fix_entry` RPC (new migration, needs `supabase db push`) |
+| R7 | Low | Saved-screen per-person used float division — could disagree with the split strip by a cent. | Fixed — shared `perPersonShare` |
+| R8 | Low | `$NaN` in dashboard on malformed numeric; `localStorage` without try/catch; no `error.tsx`/`not-found.tsx`. | Fixed |
+
+### Verified NOT vulnerable (tested, no action needed)
+
+- Gateway rejects missing/garbage API keys (401) on all verify_jwt functions.
+- All session-gated actions return 401 `session_invalid` for bad/missing sessions — no path past the gate found.
+- Rate limit engages exactly at attempt #21 (20/10min) and holds under a 30-way concurrent burst (advisory locks work).
+- WebSocket stream rejects missing/short/garbage/oversized tickets (connection never opens); tickets are single-use, 60s.
+- 60 concurrent GETs on the site: 60×200, 0×5xx, ~0.4s.
+- 25 concurrent bad-session voice-parse posts: 25×401, no 5xx.
+- Malformed JSON → 400; wrong methods → 405; unknown actions → 400/401. No 5xx from any fuzzed input except R1.
+- `end_session` is idempotent and safe with garbage/missing tokens.
+- RLS: anon/authenticated roles have zero direct access to `tip_*` tables (manager-only policies); service-role key is nowhere in the client bundle.
+- Split math is integer-cent based; division-by-zero guarded.
+
+---
+
+## Findings NOT fixed (need David / infra decisions)
+
+| # | Severity | Finding | Recommended action |
+|---|----------|---------|--------------------|
+| O1 | **Critical ops** | **`tips.smelter.com` serves a parked-domain lander page** over plain HTTP; HTTPS has no certificate (TLS SNI error). `dashboard.smelter.com` likewise dead. The real app is `tips.babytunasystems.com`; dashboard host per config is `dashboard.smelterpos.com`. Anyone controlling that parked domain could later serve a phishing clone of the QR landing page. | Point the DNS at Vercel (or let the registration lapse); until then do not print/ship anything referencing smelter.com |
+| O2 | Medium | **`ALLOWED_ORIGINS` is unset** — edge functions answer browser CORS from any origin (`*`). Already on the launch checklist. | `supabase secrets set ALLOWED_ORIGINS=https://tips.babytunasystems.com,https://dashboard.smelterpos.com` |
+| O3 | Medium | **`entry_token_plain` stores the live QR token in plaintext**, re-fetched by the dashboard on every load. Accepted tradeoff (per David, 2026-08-20) so stickers can be reprinted — but any manager-session XSS/extensions can lift live entry credentials. | Keep as-is consciously, or null the column after first print and require rotation for reprints |
+| O4 | Medium | **Oversized voice uploads (5–6MB) hang until gateway timeout (504)** instead of the intended fast 413 — the Supabase gateway buffers the body before the function's content-length guard runs. Ties up workers for the full timeout. | Client-side: stop recording/chunk before ~4MB. Server-side guard stays as defense-in-depth. No function-side fix possible |
+| O5 | Medium | **Auth gates are client-only** (no Next middleware); `/manager`, `/dashboard`, `/manager/qr` render their shells to anyone and rely on RLS/RPC for data. Data is safe (verified), but defense-in-depth says add a server-side gate. | Add `middleware.ts` with Supabase SSR session check for `/manager*` and `/dashboard*` |
+| O6 | Low | **Invite tokens ride in the URL path** (`/join/<token>`) — persisted in history/proxy logs, unlike the scrubbed `#t=` fragment pattern. | Move to fragment or one-time exchange code |
+| O7 | Low | **Unlimited session minting with a valid QR token**: successful validations aren't rate-limited (only failures are), so a photo of the sticker can mint unbounded 12h sessions (table bloat). Voice quota (40/5min/session) caps the expensive path. | Optional: cap concurrent active sessions per location |
+| O8 | Low | **No client `maxLength` on roster/invite names** (server allows 60 chars for tip_employees; other inputs unbounded). | Add maxLength attributes |
+| O9 | Info | `$0 + $0` saves are allowed — **intentional** per SETUP.md ("$0 must be accepted"). | No action |
+| O10 | Info | Path-traversal-shaped tokens (`../../etc/passwd`) are rejected at the Supabase edge with 403 before reaching the function — safe, just a different code than the app's 401. | No action |
+
+## Test-data note
+
+The rate-limit burn-down wrote ~55 intentionally-failed rows to
+`tip_auth_attempts` keyed to random throwaway identifier hashes (no real
+device IPs). The ledger auto-deletes rows older than 2 days
+(`tip_auth_attempt_allowed` cleanup), so no manual cleanup is needed. No
+`tip_entries`, sessions, or roster rows were created — no valid entry token
+was available to the harness, and none was needed.
+
+## Validation that the fixes broke nothing
+
+- `npm run typecheck` — green
+- `npx eslint src --max-warnings=0` — green
+- `npm run test` — 195/195 (17 files), including a new CSV-injection
+  regression test
+- `npm run build` — green (15 routes)
+- `deno check` on the four tip functions — only the 3 pre-existing
+  strict-mode errors that exist identically on `main`
+- Browser verification of the preview deployment by an independent agent:
+  entry landing, malformed-token handling, scan screen, dashboard login
+  gate, 404/error pages, and the new security headers.
+
+## Deploy checklist (after merge)
+
+1. `supabase db push` (applies `20260827120000_tip_manager_fix_entry.sql`)
+2. `supabase functions deploy tip-entry-auth tip-entries tip-voice-parse tip-voice-stream`
+3. Vercel: merge deploys `web/` automatically
+4. Set `ALLOWED_ORIGINS` (O2)
+5. Resolve the smelter.com domain situation (O1)

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,25 +1,60 @@
 // Wildcard origin keeps React Native / Expo clients working (no fixed web origin).
 // Set ALLOWED_ORIGINS to a comma-separated list to restrict browser callers; mobile is unchanged.
-const allowedOrigins = (Deno.env.get('ALLOWED_ORIGINS') ?? '')
-  .split(',')
+const allowedOrigins = (Deno.env.get("ALLOWED_ORIGINS") ?? "")
+  .split(",")
   .map((origin) => origin.trim())
   .filter(Boolean);
 
-function resolveAllowOrigin(req?: Request): string {
-  if (allowedOrigins.length === 0) return '*';
-  const requestOrigin = req?.headers.get('Origin')?.trim();
-  if (requestOrigin && allowedOrigins.includes(requestOrigin)) {
-    return requestOrigin;
+/** Browser origins used by the public tip-entry flow during the domain migration. */
+export const TIP_WEB_ORIGINS = [
+  "https://tips.smelterpos.com",
+  "https://dashboard.smelterpos.com",
+  "https://tips.babytunasystems.com",
+] as const;
+
+export function resolveAllowOrigin(
+  requestOrigin: string | null,
+  configuredOrigins: readonly string[],
+  additionalOrigins: readonly string[] = [],
+): string {
+  // No configured allowlist means local/mobile-compatible wildcard mode.
+  // Product-specific additions only extend an explicit production allowlist.
+  if (configuredOrigins.length === 0) return "*";
+  const effectiveOrigins = [
+    ...new Set([...configuredOrigins, ...additionalOrigins]),
+  ];
+  const normalizedOrigin = requestOrigin?.trim();
+  if (normalizedOrigin && effectiveOrigins.includes(normalizedOrigin)) {
+    return normalizedOrigin;
   }
-  return allowedOrigins[0];
+  // Deliberately return a non-matching allow-origin for unknown browser
+  // callers; their browser blocks the response without reflecting the origin.
+  return effectiveOrigins[0];
 }
 
-export function corsHeadersForRequest(req?: Request): Record<string, string> {
+export function corsHeadersForRequest(
+  req?: Request,
+  additionalOrigins: readonly string[] = [],
+): Record<string, string> {
   return {
-    'Access-Control-Allow-Origin': resolveAllowOrigin(req),
-    'Access-Control-Allow-Headers':
-      'authorization, x-client-info, apikey, content-type',
+    "Access-Control-Allow-Origin": resolveAllowOrigin(
+      req?.headers.get("Origin") ?? null,
+      allowedOrigins,
+      additionalOrigins,
+    ),
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers":
+      "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
   };
+}
+
+/** CORS policy for the staff tip-entry browser endpoints. */
+export function tipCorsHeadersForRequest(
+  req?: Request,
+): Record<string, string> {
+  return corsHeadersForRequest(req, TIP_WEB_ORIGINS);
 }
 
 /** Default headers; use corsHeadersForRequest when the incoming Request is available. */

--- a/supabase/functions/_shared/cors_test.ts
+++ b/supabase/functions/_shared/cors_test.ts
@@ -1,0 +1,76 @@
+import {
+  corsHeadersForRequest,
+  resolveAllowOrigin,
+  TIP_WEB_ORIGINS,
+  tipCorsHeadersForRequest,
+} from "./cors.ts";
+
+function requestFrom(origin: string): Request {
+  return new Request(
+    "https://example.supabase.co/functions/v1/tip-entry-auth",
+    {
+      headers: { Origin: origin },
+    },
+  );
+}
+
+function assertEqual(actual: unknown, expected: unknown): void {
+  if (actual !== expected) {
+    throw new Error(
+      `Expected ${JSON.stringify(expected)}, received ${
+        JSON.stringify(actual)
+      }`,
+    );
+  }
+}
+
+Deno.test("generic functions keep wildcard CORS when ALLOWED_ORIGINS is unset", () => {
+  assertEqual(
+    corsHeadersForRequest(
+      requestFrom("http://localhost:3000"),
+    )["Access-Control-Allow-Origin"],
+    "*",
+  );
+});
+
+Deno.test("tip endpoints keep wildcard CORS for local development", () => {
+  assertEqual(
+    tipCorsHeadersForRequest(
+      requestFrom("http://localhost:3000"),
+    )["Access-Control-Allow-Origin"],
+    "*",
+  );
+});
+
+for (const origin of TIP_WEB_ORIGINS) {
+  Deno.test(`an explicit production allowlist includes ${origin}`, () => {
+    assertEqual(
+      resolveAllowOrigin(
+        origin,
+        ["https://tips.babytunasystems.com"],
+        TIP_WEB_ORIGINS,
+      ),
+      origin,
+    );
+  });
+}
+
+Deno.test("tip endpoints do not reflect an unknown browser origin", () => {
+  assertEqual(
+    resolveAllowOrigin(
+      "https://attacker.example",
+      ["https://tips.babytunasystems.com"],
+      TIP_WEB_ORIGINS,
+    ),
+    "https://tips.babytunasystems.com",
+  );
+});
+
+Deno.test("preflight headers allow the entry POST and vary by origin", () => {
+  const headers = tipCorsHeadersForRequest(
+    requestFrom("https://tips.smelterpos.com"),
+  );
+  assertEqual(headers["Access-Control-Allow-Methods"], "POST, OPTIONS");
+  assertEqual(headers["Access-Control-Max-Age"], "86400");
+  assertEqual(headers.Vary, "Origin");
+});

--- a/supabase/functions/_shared/tips.test.ts
+++ b/supabase/functions/_shared/tips.test.ts
@@ -1,0 +1,29 @@
+import { clientIdentifier } from "./tips.ts";
+
+Deno.test("clientIdentifier uses the trusted proxy-appended XFF value", () => {
+  const request = new Request("https://example.test", {
+    headers: {
+      "x-forwarded-for": "203.0.113.10, 198.51.100.24",
+      "user-agent": "flood-test",
+    },
+  });
+
+  const actual = clientIdentifier(request);
+  if (actual !== "198.51.100.24:flood-test") {
+    throw new Error(`Unexpected identifier: ${actual}`);
+  }
+});
+
+Deno.test("clientIdentifier falls back without a forwarded chain", () => {
+  const realIpRequest = new Request("https://example.test", {
+    headers: { "x-real-ip": "192.0.2.42" },
+  });
+  if (clientIdentifier(realIpRequest) !== "192.0.2.42:") {
+    throw new Error("Expected x-real-ip fallback");
+  }
+
+  const unknownRequest = new Request("https://example.test");
+  if (clientIdentifier(unknownRequest) !== "unknown:") {
+    throw new Error("Expected unknown fallback");
+  }
+});

--- a/supabase/functions/_shared/tips.ts
+++ b/supabase/functions/_shared/tips.ts
@@ -33,8 +33,12 @@ export function randomToken(bytes = 32): string {
 }
 
 export function clientIdentifier(req: Request): string {
+  // The LAST x-forwarded-for entry is the one appended by the hosting edge
+  // proxy; earlier entries are client-supplied and trivially spoofable, which
+  // would let an attacker rotate IPs to dodge the validation rate limit.
   const forwarded = req.headers.get('x-forwarded-for');
-  const ip = forwarded?.split(',')[0]?.trim() || req.headers.get('x-real-ip')?.trim() || 'unknown';
+  const chain = forwarded?.split(',').map((part) => part.trim()).filter(Boolean) ?? [];
+  const ip = chain[chain.length - 1] || req.headers.get('x-real-ip')?.trim() || 'unknown';
   return `${ip}:${req.headers.get('user-agent') ?? ''}`;
 }
 

--- a/supabase/functions/tip-entries/index.ts
+++ b/supabase/functions/tip-entries/index.ts
@@ -5,7 +5,7 @@
 
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
-import { corsHeadersForRequest } from '../_shared/cors.ts';
+import { tipCorsHeadersForRequest } from '../_shared/cors.ts';
 import {
   businessDateFor,
   checkAnomaly,
@@ -35,7 +35,7 @@ const ANOMALY_HISTORY_LIMIT = 60;
 function json(req: Request, body: Record<string, unknown>, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeadersForRequest(req), 'Content-Type': 'application/json' },
+    headers: { ...tipCorsHeadersForRequest(req), 'Content-Type': 'application/json' },
   });
 }
 
@@ -95,7 +95,7 @@ async function scheduledRosterIds(locationId: string, businessDate: string, meal
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeadersForRequest(req) });
+    return new Response('ok', { headers: tipCorsHeadersForRequest(req) });
   }
   if (req.method !== 'POST') {
     return json(req, { error: 'Method not allowed' }, 405);
@@ -114,7 +114,10 @@ Deno.serve(async (req) => {
     return json(req, { ok: true });
   }
 
-  const session = await validateTipSession(supabaseAdmin, body.sessionToken);
+  const session = await validateTipSession(
+    supabaseAdmin,
+    typeof body.sessionToken === 'string' ? body.sessionToken : null,
+  );
   if (!session) {
     return json(req, { ok: false, code: 'session_invalid', error: 'Session expired. Scan the QR code again.' }, 401);
   }

--- a/supabase/functions/tip-entry-auth/index.ts
+++ b/supabase/functions/tip-entry-auth/index.ts
@@ -9,7 +9,7 @@
 
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
-import { corsHeadersForRequest } from '../_shared/cors.ts';
+import { tipCorsHeadersForRequest } from '../_shared/cors.ts';
 import {
   businessDateFor,
   clientIdentifier,
@@ -41,7 +41,7 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3
 function json(req: Request, body: Record<string, unknown>, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeadersForRequest(req), 'Content-Type': 'application/json' },
+    headers: { ...tipCorsHeadersForRequest(req), 'Content-Type': 'application/json' },
   });
 }
 
@@ -121,7 +121,7 @@ async function sessionPayload(locationId: string, locationName: string, closerId
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeadersForRequest(req) });
+    return new Response('ok', { headers: tipCorsHeadersForRequest(req) });
   }
   if (req.method !== 'POST') {
     return json(req, { error: 'Method not allowed' }, 405);
@@ -197,7 +197,10 @@ Deno.serve(async (req) => {
     }
 
     if (action === 'end_session') {
-      const session = await validateTipSession(supabaseAdmin, body.sessionToken);
+      const session = await validateTipSession(
+        supabaseAdmin,
+        typeof body.sessionToken === 'string' ? body.sessionToken : null,
+      );
       if (session) {
         const { error } = await supabaseAdmin
           .from('tip_entry_sessions')
@@ -209,7 +212,10 @@ Deno.serve(async (req) => {
     }
 
     // Everything below requires a valid entry session.
-    const session = await validateTipSession(supabaseAdmin, body.sessionToken);
+    const session = await validateTipSession(
+      supabaseAdmin,
+      typeof body.sessionToken === 'string' ? body.sessionToken : null,
+    );
     if (!session) {
       return json(req, { ok: false, code: 'session_invalid', error: 'Session expired. Scan the QR code again.' }, 401);
     }

--- a/supabase/functions/tip-voice-parse/index.ts
+++ b/supabase/functions/tip-voice-parse/index.ts
@@ -237,7 +237,14 @@ Deno.serve(async (req) => {
       return json(req, { ok: false, code: 'too_large', error: 'That recording is too long.' }, 413);
     }
 
-    const form = await req.formData();
+    // Non-multipart bodies (e.g. a JSON post) make formData() throw — that
+    // is a client error, not a server fault.
+    let form: FormData;
+    try {
+      form = await req.formData();
+    } catch {
+      return json(req, { ok: false, code: 'invalid_audio', error: 'Expected a voice recording upload.' }, 400);
+    }
     const session = await validateTipSession(supabaseAdmin, asString(form.get('session_token')));
     if (!session) {
       return json(req, { ok: false, code: 'session_invalid', error: 'Session expired. Scan the sticker again.' }, 401);

--- a/supabase/functions/tip-voice-parse/index.ts
+++ b/supabase/functions/tip-voice-parse/index.ts
@@ -12,7 +12,7 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
 import { z } from 'https://esm.sh/zod@3.25.76';
-import { corsHeadersForRequest } from '../_shared/cors.ts';
+import { tipCorsHeadersForRequest } from '../_shared/cors.ts';
 import { normalizeAmount, validateTipSession } from '../_shared/tips.ts';
 
 declare const Deno: {
@@ -74,7 +74,7 @@ const GEMINI_RESPONSE_SCHEMA = {
 function json(req: Request, body: Record<string, unknown>, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeadersForRequest(req), 'Content-Type': 'application/json' },
+    headers: { ...tipCorsHeadersForRequest(req), 'Content-Type': 'application/json' },
   });
 }
 
@@ -224,7 +224,7 @@ function matchPeople(
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeadersForRequest(req) });
+    return new Response('ok', { headers: tipCorsHeadersForRequest(req) });
   }
   if (req.method !== 'POST') {
     return json(req, { ok: false, error: 'Method not allowed' }, 405);

--- a/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
+++ b/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
@@ -1,0 +1,63 @@
+-- Atomic manager "Fix" for a recorded tip entry.
+--
+-- The dashboard's Fix dialog previously did insert-people → update-amounts →
+-- delete-people as three separate PostgREST calls. A failure mid-sequence
+-- left the entry with a mixed roster / wrong split_count. This RPC performs
+-- the whole edit in one transaction, guarded by the same manager check the
+-- RLS policies use.
+
+create or replace function public.tip_manager_fix_entry(
+  p_entry_id uuid,
+  p_cash numeric,
+  p_card numeric,
+  p_people uuid[]
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not public.current_user_is_manager() then
+    raise exception 'Only managers can fix tip entries';
+  end if;
+
+  if p_cash is null or p_card is null
+     or p_cash < 0 or p_card < 0
+     or p_cash >= 100000 or p_card >= 100000 then
+    raise exception 'Amounts must be between 0 and 99,999.99';
+  end if;
+
+  if array_length(p_people, 1) is null or array_length(p_people, 1) < 1 then
+    raise exception 'At least one person must split the entry';
+  end if;
+
+  -- Every person must be on the roster (active or not — history may include
+  -- deactivated staff who were on the original split).
+  if exists (
+    select 1
+    from unnest(p_people) as person(id)
+    left join public.tip_employees e on e.id = person.id
+    where e.id is null
+  ) then
+    raise exception 'Someone selected is not on the roster';
+  end if;
+
+  update public.tip_entries
+  set cash_amount = p_cash,
+      card_amount = p_card,
+      split_count = array_length(p_people, 1)
+  where id = p_entry_id;
+
+  if not found then
+    raise exception 'Unknown entry';
+  end if;
+
+  delete from public.tip_entry_people where tip_entry_id = p_entry_id;
+  insert into public.tip_entry_people (tip_entry_id, tip_employee_id)
+  select p_entry_id, unnest(p_people);
+end;
+$$;
+
+revoke all on function public.tip_manager_fix_entry(uuid, numeric, numeric, uuid[]) from public, anon;
+grant execute on function public.tip_manager_fix_entry(uuid, numeric, numeric, uuid[]) to authenticated, service_role;

--- a/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
+++ b/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
@@ -15,8 +15,10 @@ create or replace function public.tip_manager_fix_entry(
 returns void
 language plpgsql
 security definer
-set search_path = public
+set search_path = ''
 as $$
+declare
+  v_people uuid[];
 begin
   if not public.current_user_is_manager() then
     raise exception 'Only managers can fix tip entries';
@@ -28,15 +30,24 @@ begin
     raise exception 'Amounts must be between 0 and 99,999.99';
   end if;
 
-  if array_length(p_people, 1) is null or array_length(p_people, 1) < 1 then
+  -- Match the entry API's 30-person cap and collapse duplicate ids so the
+  -- stored split_count can never disagree with the join table.
+  select array_agg(person.id order by person.id)
+  into v_people
+  from (select distinct unnest(p_people) as id) as person;
+
+  if cardinality(v_people) is null or cardinality(v_people) < 1 then
     raise exception 'At least one person must split the entry';
+  end if;
+  if cardinality(v_people) > 30 then
+    raise exception 'No more than 30 people can split an entry';
   end if;
 
   -- Every person must be on the roster (active or not — history may include
   -- deactivated staff who were on the original split).
   if exists (
     select 1
-    from unnest(p_people) as person(id)
+    from unnest(v_people) as person(id)
     left join public.tip_employees e on e.id = person.id
     where e.id is null
   ) then
@@ -46,7 +57,7 @@ begin
   update public.tip_entries
   set cash_amount = p_cash,
       card_amount = p_card,
-      split_count = array_length(p_people, 1)
+      split_count = cardinality(v_people)
   where id = p_entry_id;
 
   if not found then
@@ -55,7 +66,7 @@ begin
 
   delete from public.tip_entry_people where tip_entry_id = p_entry_id;
   insert into public.tip_entry_people (tip_entry_id, tip_employee_id)
-  select p_entry_id, unnest(p_people);
+  select p_entry_id, unnest(v_people);
 end;
 $$;
 

--- a/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
+++ b/supabase/migrations/20260827120000_tip_manager_fix_entry.sql
@@ -14,7 +14,7 @@ create or replace function public.tip_manager_fix_entry(
 )
 returns void
 language plpgsql
-security definer
+security invoker
 set search_path = ''
 as $$
 declare

--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -3,7 +3,7 @@
 // that skips it on the next scan.
 
 import { expect, test } from "@playwright/test";
-import { fixtures } from "./helpers";
+import { fixtures, mintSession } from "./helpers";
 
 /** Skip the first-run carousel for specs that aren't about it. */
 async function markOnboarded(page: import("@playwright/test").Page) {
@@ -13,6 +13,16 @@ async function markOnboarded(page: import("@playwright/test").Page) {
 }
 
 test.describe("scan landing", () => {
+  test("Sushi and Poki QR tokens resolve to separate locations", async () => {
+    const { sushiToken, pokiToken } = fixtures();
+    const sushi = await mintSession(sushiToken);
+    const poki = await mintSession(pokiToken);
+
+    expect(sushi.locationName).toBe("Babytuna Sushi");
+    expect(poki.locationName).toBe("Babytuna Poki & Pho");
+    expect(sushi.locationId).not.toBe(poki.locationId);
+  });
+
   test("first visit shows onboarding once, then the scan screen", async ({
     page,
   }) => {

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,6 +4,25 @@ import type { NextConfig } from "next";
  *  scan screen, so the dashboard gets a host rather than a path. */
 const DASHBOARD_HOST = "dashboard.smelterpos.com";
 
+// Keep the CSP pinned to the configured project. A wildcard here would let a
+// script-injection bug exfiltrate browser-stored sessions to an attacker-owned
+// Supabase project while still satisfying connect-src.
+const DEFAULT_SUPABASE_ORIGIN = "https://whrohvitvmcrmedepurd.supabase.co";
+
+function supabaseConnectSources(): string {
+  const configured = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, "");
+  let origin = DEFAULT_SUPABASE_ORIGIN;
+  if (configured) {
+    try {
+      origin = new URL(configured).origin;
+    } catch {
+      // The app itself will report the invalid URL when it creates the client;
+      // keep the security header valid and fail closed to the production host.
+    }
+  }
+  return `${origin} ${origin.replace(/^http/, "ws")}`;
+}
+
 const nextConfig: NextConfig = {
   rewrites() {
     return Promise.resolve({
@@ -35,7 +54,7 @@ const nextConfig: NextConfig = {
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob:",
       "media-src 'self' blob:",
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      `connect-src 'self' ${supabaseConnectSources()}`,
       "font-src 'self' data:",
       "object-src 'none'",
       "base-uri 'self'",

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -24,12 +24,50 @@ const nextConfig: NextConfig = {
     });
   },
   headers() {
+    // Entry sessions and manager auth live in browser storage, and QR tokens
+    // ride in URLs — so lock down what a page can do and where URLs leak.
+    // script-src keeps 'unsafe-inline' because Next/Turbopack ship inline
+    // runtime scripts without nonces; connect-src is the real perimeter
+    // (only our Supabase project can be talked to).
+    const contentSecurityPolicy = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob:",
+      "media-src 'self' blob:",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      "font-src 'self' data:",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+      "upgrade-insecure-requests",
+    ].join("; ");
     return Promise.resolve([
       {
         // Apple fetches this to enable iCloud Keychain autofill for the app
         // (webcredentials associated domain). It must be served as JSON.
         source: "/.well-known/apple-app-site-association",
         headers: [{ key: "Content-Type", value: "application/json" }],
+      },
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Content-Security-Policy", value: contentSecurityPolicy },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          // QR entry tokens ride in the ?t= query param — never let the URL
+          // leave this origin via Referer.
+          { key: "Referrer-Policy", value: "no-referrer" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(self), microphone=(self), geolocation=()",
+          },
+        ],
       },
     ]);
   },

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -3,8 +3,22 @@ import type { NextConfig } from "next";
 /** Manager dashboard host. The tips app owns "/" on its own host as the staff
  *  scan screen, so the dashboard gets a host rather than a path. */
 const DASHBOARD_HOST = "dashboard.smelterpos.com";
+const TIPS_ENTRY_ORIGIN = "https://tips.smelterpos.com";
 
 const nextConfig: NextConfig = {
+  redirects() {
+    return Promise.resolve([
+      {
+        // QRs printed while the manager dashboard was the current origin
+        // used dashboard.smelterpos.com/e. Keep those stickers working while
+        // moving the token to the canonical staff host (query is preserved).
+        source: "/e",
+        has: [{ type: "host", value: DASHBOARD_HOST }],
+        destination: `${TIPS_ENTRY_ORIGIN}/e`,
+        permanent: false,
+      },
+    ]);
+  },
   rewrites() {
     return Promise.resolve({
       // beforeFiles, not a bare array: "/" is a prerendered page, and an

--- a/web/src/app/e/page.tsx
+++ b/web/src/app/e/page.tsx
@@ -28,10 +28,21 @@ function TokenLanding() {
 
   const [attempt, setAttempt] = useState(0);
 
+  // Same shape check the in-page scanner applies: obviously-wrong tokens
+  // fail locally instead of burning a rate-limited server attempt. Derived
+  // (not effect state) so it renders without a setState-in-effect.
+  const tokenMalformed = token !== null && !/^[A-Za-z0-9_-]{16,128}$/.test(token);
+
   useEffect(() => {
     if (!token) {
       router.replace(loadSession() ? "/entry" : "/");
       return;
+    }
+    if (tokenMalformed) return;
+    // Strip ?t=<token> from the address bar/history BEFORE any network call
+    // so the QR secret can't leak via Referer or a crash mid-validation.
+    if (typeof window !== "undefined" && window.location.search.includes("t=")) {
+      window.history.replaceState(null, "", "/e");
     }
     let cancelled = false;
     const signIn = async (): Promise<"entry" | "closer"> => {
@@ -76,7 +87,7 @@ function TokenLanding() {
     return () => {
       cancelled = true;
     };
-  }, [token, router, attempt]);
+  }, [token, tokenMalformed, router, attempt]);
 
   // Both possible destinations are known the moment this page mounts —
   // prefetch them so the post-validation navigation is instant.
@@ -91,7 +102,7 @@ function TokenLanding() {
     setAttempt((n) => n + 1);
   };
 
-  if (phase === "checking") {
+  if (phase === "checking" && !tokenMalformed) {
     return <Splash>Checking the QR code&hellip;</Splash>;
   }
 
@@ -99,7 +110,11 @@ function TokenLanding() {
     <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col justify-center px-5 pb-10">
       <div className="rounded-card bg-card p-5 text-center">
         <p className="font-bold text-ink">Couldn&rsquo;t sign you in</p>
-        <p className="mt-2 text-ink2">{errorMessage}</p>
+        <p className="mt-2 text-ink2">
+          {tokenMalformed
+            ? "This QR code is no longer active. Ask a manager for the new one."
+            : errorMessage}
+        </p>
       </div>
       <button
         type="button"
@@ -108,13 +123,15 @@ function TokenLanding() {
       >
         Back to scan
       </button>
-      <button
-        type="button"
-        onClick={retry}
-        className="mt-4 text-center text-ink2 underline"
-      >
-        Try again
-      </button>
+      {!tokenMalformed && (
+        <button
+          type="button"
+          onClick={retry}
+          className="mt-4 text-center text-ink2 underline"
+        >
+          Try again
+        </button>
+      )}
     </main>
   );
 }

--- a/web/src/app/e/page.tsx
+++ b/web/src/app/e/page.tsx
@@ -7,7 +7,8 @@
 
 import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { validateToken, TipApiError } from "@/lib/tips/api";
+import { validateToken } from "@/lib/tips/api";
+import { entrySignInErrorMessage } from "@/lib/tips/entryError";
 import {
   loadRememberedCloser,
   loadSession,
@@ -66,11 +67,7 @@ function TokenLanding() {
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setErrorMessage(
-          err instanceof TipApiError && err.code === "rate_limited"
-            ? err.message
-            : "This QR code is no longer active. Ask a manager for the new one.",
-        );
+        setErrorMessage(entrySignInErrorMessage(err));
         setPhase("error");
       });
     return () => {

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+// Last-resort render-error boundary: a phone mid-entry must never land on a
+// bare framework error. Reset re-renders the segment; home is the scan gate.
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[smelter-tips] unhandled render error", error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col justify-center px-5 pb-10">
+      <div className="rounded-card bg-card p-5 text-center">
+        <p className="font-bold text-ink">Something went wrong</p>
+        <p className="mt-2 text-ink2">
+          Your entry is still on this screen. Try again — if it keeps
+          happening, scan the QR code again.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={reset}
+        className="mt-6 w-full rounded-full bg-accent py-4 font-semibold text-white"
+      >
+        Try again
+      </button>
+      <Link
+        href="/"
+        className="mt-4 text-center text-ink2 underline"
+      >
+        Back to scan
+      </Link>
+    </main>
+  );
+}

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -22,8 +22,8 @@ export default function GlobalError({
       <div className="rounded-card bg-card p-5 text-center">
         <p className="font-bold text-ink">Something went wrong</p>
         <p className="mt-2 text-ink2">
-          Your entry is still on this screen. Try again — if it keeps
-          happening, scan the QR code again.
+          Try again — if it keeps happening, scan the QR code again or ask a
+          manager.
         </p>
       </div>
       <button

--- a/web/src/app/manager/qr/page.tsx
+++ b/web/src/app/manager/qr/page.tsx
@@ -49,10 +49,23 @@ function QrPageInner() {
 
   useEffect(() => {
     let cancelled = false;
-    getSupabase()
-      .auth.getSession()
-      .then(({ data }) => {
-        if (!cancelled) setAuthState(data.session ? "ok" : "none");
+    const supabase = getSupabase();
+    // A live session is not enough — this page prints entry credentials, so
+    // require the same manager check as the rest of the dashboard.
+    supabase.auth
+      .getSession()
+      .then(async ({ data }) => {
+        if (!data.session) return "none" as const;
+        const { data: isManager, error } = await supabase.rpc(
+          "current_user_is_manager",
+        );
+        return !error && isManager === true ? ("ok" as const) : ("none" as const);
+      })
+      .then((next) => {
+        if (!cancelled) setAuthState(next);
+      })
+      .catch(() => {
+        if (!cancelled) setAuthState("none");
       });
     return () => {
       cancelled = true;
@@ -62,7 +75,7 @@ function QrPageInner() {
   useEffect(() => {
     if (!token || authState !== "ok") return;
     let cancelled = false;
-    const url = `${window.location.origin}/e?t=${token}`;
+    const url = `${window.location.origin}/e?t=${encodeURIComponent(token)}`;
     QRCode.toDataURL(url, { width: 480, margin: 2 })
       .then((dataUrl) => {
         if (cancelled) return;
@@ -87,7 +100,9 @@ function QrPageInner() {
     return (
       <div className="w-full max-w-md mx-auto mt-16 px-5">
         <div className="bg-card rounded-card p-6">
-          <p className="text-ink">Sign in via /manager first.</p>
+          <p className="text-ink">
+            Sign in with a manager account via /manager first.
+          </p>
         </div>
       </div>
     );

--- a/web/src/app/manager/qr/page.tsx
+++ b/web/src/app/manager/qr/page.tsx
@@ -9,6 +9,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import QRCode from "qrcode";
 import { getSupabase } from "@/lib/supabase";
+import { entryUrlFor } from "@/lib/tips/entryUrl";
 
 /** Parse "#t=<token>" from the current location, browser only. */
 function readTokenFromHash(): string | null {
@@ -62,7 +63,7 @@ function QrPageInner() {
   useEffect(() => {
     if (!token || authState !== "ok") return;
     let cancelled = false;
-    const url = `${window.location.origin}/e?t=${token}`;
+    const url = entryUrlFor(token);
     QRCode.toDataURL(url, { width: 480, margin: 2 })
       .then((dataUrl) => {
         if (cancelled) return;

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+// Friendly 404: staff land here from mistyped or stale links — point them
+// back at the scan gate instead of the framework default.
+
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col justify-center px-5 pb-10">
+      <div className="rounded-card bg-card p-5 text-center">
+        <p className="font-bold text-ink">That page doesn&apos;t exist</p>
+        <p className="mt-2 text-ink2">
+          To enter tips, scan the QR code by the register.
+        </p>
+      </div>
+      <Link
+        href="/"
+        className="mt-6 block w-full rounded-full bg-card py-4 text-center font-semibold text-ink"
+      >
+        Back to scan
+      </Link>
+    </main>
+  );
+}

--- a/web/src/components/entry/EntryForm.tsx
+++ b/web/src/components/entry/EntryForm.tsx
@@ -26,6 +26,7 @@ import { anomalyMessage, type AnomalyResult } from "@/lib/tips/anomaly";
 import { formatBusinessDate } from "@/lib/tips/businessDate";
 import { formatMoney } from "@/lib/tips/format";
 import { mealPreset } from "@/lib/tips/mealPreset";
+import { perPersonShare } from "@/lib/tips/split";
 import {
   clearSession,
   loadSession,
@@ -132,7 +133,9 @@ function SavedScreen({
 
   const total = payload.cash + payload.card;
   const count = payload.peopleIds.length;
-  const perPerson = count > 0 ? total / count : 0;
+  // Same cent-exact rounding as the live split strip — float division can
+  // disagree with it by a cent (e.g. $100 / 3).
+  const perPerson = perPersonShare(payload.cash, payload.card, count);
 
   return (
     <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-5 pb-8 pt-20">
@@ -269,6 +272,10 @@ export function EntryForm() {
 
   const lastPayloadRef = useRef<SavePayload | null>(null);
   const finishedRef = useRef(false);
+  // Synchronous in-flight guard: the `saving` state lags a render behind the
+  // click, so two fast taps (or Save + anomaly "Save anyway") could both
+  // start a save. The ref blocks the second one in the same tick.
+  const saveInFlightRef = useRef(false);
   // Per-meal memory of the closer's selection, so switching Lunch↔Dinner and
   // back never discards manual picks (or their voice-overwrite protection).
   const savedSelectionsRef = useRef<
@@ -478,7 +485,8 @@ export function EntryForm() {
 
   const doSave = useCallback(
     async (payload: SavePayload) => {
-      if (!session) return;
+      if (!session || saveInFlightRef.current) return;
+      saveInFlightRef.current = true;
       lastPayloadRef.current = payload;
       setSaving(true);
       setSaveError(null);
@@ -508,6 +516,7 @@ export function EntryForm() {
           retryable: !duplicate,
         });
       } finally {
+        saveInFlightRef.current = false;
         setSaving(false);
       }
     },
@@ -515,14 +524,16 @@ export function EntryForm() {
   );
 
   const amountsValid = isValidAmount(cash) && isValidAmount(card);
-  const canSave = amountsValid && selectedIds.length > 0 && !saving;
+  // slotLoading: a meal switch is mid-flight — saving now would send the NEW
+  // meal with the OLD meal's crew (and possibly stale amounts).
+  const canSave = amountsValid && selectedIds.length > 0 && !saving && !slotLoading;
 
   const handleSaveClick = useCallback(() => {
     if (selectedIds.length === 0) {
       setPickPersonWarning(true);
       return;
     }
-    if (!amountsValid || saving) return;
+    if (!amountsValid || saving || slotLoading) return;
     void doSave({
       meal,
       cash: Number(cash),
@@ -533,7 +544,7 @@ export function EntryForm() {
       correctionsCount: voiceMeta?.corrections ?? 0,
       confirmAnomaly: false,
     });
-  }, [selectedIds, amountsValid, saving, doSave, meal, cash, card, voiceMeta]);
+  }, [selectedIds, amountsValid, saving, slotLoading, doSave, meal, cash, card, voiceMeta]);
 
   const handleVoiceApply = useCallback(
     (result: VoiceApplyResult) => {
@@ -780,7 +791,7 @@ export function EntryForm() {
               silently doing nothing. */}
           <button
             type="button"
-            disabled={saving || !amountsValid}
+            disabled={saving || slotLoading || !amountsValid}
             onClick={handleSaveClick}
             className={`flex-1 rounded-full py-4 font-semibold ${
               canSave ? "bg-card text-ink" : "bg-disabled text-white"

--- a/web/src/components/manager/dashboard/DashboardShell.tsx
+++ b/web/src/components/manager/dashboard/DashboardShell.tsx
@@ -65,14 +65,24 @@ function ShellInner({
   const [nav, setNav] = useState<NavId>("overview");
   // Safe to read localStorage in the initializer: the shell only mounts
   // client-side, behind ManagerApp's auth gate (never server-rendered).
-  const [collapsed, setCollapsed] = useState(
-    () =>
-      typeof window !== "undefined" &&
-      window.localStorage.getItem(SIDEBAR_KEY) === "collapsed",
-  );
+  // try/catch: blocked storage (private mode, enterprise policy) throws.
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return (
+        typeof window !== "undefined" &&
+        window.localStorage.getItem(SIDEBAR_KEY) === "collapsed"
+      );
+    } catch {
+      return false;
+    }
+  });
   const toggleCollapsed = useCallback(() => {
     setCollapsed((value) => {
-      window.localStorage.setItem(SIDEBAR_KEY, value ? "open" : "collapsed");
+      try {
+        window.localStorage.setItem(SIDEBAR_KEY, value ? "open" : "collapsed");
+      } catch {
+        // Preference simply won't persist.
+      }
       return !value;
     });
   }, []);

--- a/web/src/components/manager/dashboard/DevicesPage.tsx
+++ b/web/src/components/manager/dashboard/DevicesPage.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import QRCode from "qrcode";
 import { getSupabase } from "@/lib/supabase";
 import { TIPS_TIMEZONE } from "@/lib/tips/businessDate";
+import { entryUrlFor } from "@/lib/tips/entryUrl";
 import {
   classifyEntryTiming,
   formatLoggedAt,
@@ -49,11 +50,6 @@ function rotatedLabel(iso: string): string {
     day: "numeric",
     year: "numeric",
   }).format(new Date(iso));
-}
-
-/** Build the phone-facing entry URL a QR code encodes. Browser only. */
-function entryUrlFor(token: string): string {
-  return `${window.location.origin}/e?t=${encodeURIComponent(token)}`;
 }
 
 /** Renders the location's live entry QR as a data URL; null while pending. */

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -84,49 +84,24 @@ function FixDialog({
     setBusy(true);
     setError(null);
     const supabase = getSupabase();
-    // PostgREST calls can't share a transaction, so order the steps to keep
-    // every intermediate state recoverable: add people first, update the
-    // amounts + split_count, remove people last. An amounts-only fix (the
-    // common case) is then a single atomic UPDATE, and the entry can never
-    // pass through a zero-people state.
+    // One RPC = one transaction: amounts, split_count, and the people roster
+    // land together or not at all (the old multi-call sequence could strand
+    // a mixed roster when a step failed midway).
     try {
-      const before = new Set(entry.peopleIds);
-      const after = new Set(peopleIds);
-      const added = peopleIds.filter((id) => !before.has(id));
-      const removed = entry.peopleIds.filter((id) => !after.has(id));
-
-      if (added.length > 0) {
-        const { error: insertError } = await supabase.from("tip_entry_people").insert(
-          added.map((personId) => ({ tip_entry_id: entry.id, tip_employee_id: personId })),
-        );
-        if (insertError) throw new Error(insertError.message);
-      }
-
-      const { error: updateError } = await supabase
-        .from("tip_entries")
-        .update({
-          cash_amount: cashCents / 100,
-          card_amount: cardCents / 100,
-          split_count: peopleIds.length,
-        })
-        .eq("id", entry.id);
-      if (updateError) throw new Error(updateError.message);
-
-      if (removed.length > 0) {
-        const { error: deleteError } = await supabase
-          .from("tip_entry_people")
-          .delete()
-          .eq("tip_entry_id", entry.id)
-          .in("tip_employee_id", removed);
-        if (deleteError) throw new Error(deleteError.message);
-      }
+      const { error: fixError } = await supabase.rpc("tip_manager_fix_entry", {
+        p_entry_id: entry.id,
+        p_cash: cashCents / 100,
+        p_card: cardCents / 100,
+        p_people: peopleIds,
+      });
+      if (fixError) throw new Error(fixError.message);
 
       toast("Entry updated");
       ctx.refetch();
       onClose();
     } catch (saveError) {
       setError(saveError instanceof Error ? saveError.message : "Could not save the fix.");
-      ctx.refetch(); // the steps aren't atomic — show what actually landed
+      ctx.refetch(); // show what actually landed
       setBusy(false);
     }
   }

--- a/web/src/components/manager/dashboard/useDashboardData.ts
+++ b/web/src/components/manager/dashboard/useDashboardData.ts
@@ -156,8 +156,14 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
           businessDate: row.business_date,
           locationId: row.location_id,
           meal: row.meal_period as MealPeriod,
-          cashCents: Math.round(Number(row.cash_amount) * 100),
-          cardCents: Math.round(Number(row.card_amount) * 100),
+          // A malformed numeric from the DB must not turn the whole money
+          // column into $NaN — fall back to 0 and keep rendering.
+          cashCents: Number.isFinite(Number(row.cash_amount))
+            ? Math.round(Number(row.cash_amount) * 100)
+            : 0,
+          cardCents: Number.isFinite(Number(row.card_amount))
+            ? Math.round(Number(row.card_amount) * 100)
+            : 0,
           splitCount: row.split_count,
           peopleIds,
           peopleNames: peopleIds.map((id) => nameById.get(id) ?? "?"),

--- a/web/src/lib/tips/__tests__/dashboardCsv.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardCsv.test.ts
@@ -82,4 +82,23 @@ describe("buildLedgerCsv", () => {
     );
     expect(csv.split("\n")[1].split(",")).toContain("yes");
   });
+
+  it("neutralizes spreadsheet formula injection in free-text fields", () => {
+    const csv = buildLedgerCsv(
+      [
+        entry({
+          peopleIds: ["a"],
+          peopleNames: ["=HYPERLINK(\"https://evil.example\",\"x\")"],
+          splitCount: 1,
+          enteredByName: "+1-555-0100",
+        }),
+      ],
+      (id) => LOCATION_LABELS[id],
+    );
+    const row = csv.split("\n")[1];
+    // A leading ' makes Excel/Sheets treat the cell as text, not a formula.
+    expect(row).toContain("'=HYPERLINK");
+    expect(row).toContain("'+1-555-0100");
+    expect(row).not.toContain(',=HYPERLINK');
+  });
 });

--- a/web/src/lib/tips/__tests__/entryError.test.ts
+++ b/web/src/lib/tips/__tests__/entryError.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { TipApiError } from "../api";
+import { entrySignInErrorMessage } from "../entryError";
+
+describe("entrySignInErrorMessage", () => {
+  it("reserves inactive wording for a token the server rejected", () => {
+    expect(
+      entrySignInErrorMessage(new TipApiError("invalid", "invalid", 401)),
+    ).toContain("no longer active");
+  });
+
+  it("reports browser/CORS failures as connectivity problems", () => {
+    expect(
+      entrySignInErrorMessage(new TipApiError("offline", "network", 0)),
+    ).toBe("Couldn’t reach smelter. Check your connection and try again.");
+  });
+
+  it("preserves the server's rate-limit guidance", () => {
+    const message = "Too many attempts. Wait a few minutes and try again.";
+    expect(
+      entrySignInErrorMessage(new TipApiError(message, "rate_limited", 429)),
+    ).toBe(message);
+  });
+
+  it("uses a retryable message for unexpected server failures", () => {
+    expect(
+      entrySignInErrorMessage(new TipApiError("internal", "error", 500)),
+    ).toBe("Couldn’t verify this QR code. Try again.");
+  });
+});

--- a/web/src/lib/tips/__tests__/entryUrl.test.ts
+++ b/web/src/lib/tips/__tests__/entryUrl.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { entryUrlFor, TIPS_ENTRY_ORIGIN } from "../entryUrl";
+
+describe("entryUrlFor", () => {
+  it("always targets the staff tips host", () => {
+    expect(entryUrlFor("poki_token_123456")).toBe(
+      `${TIPS_ENTRY_ORIGIN}/e?t=poki_token_123456`,
+    );
+  });
+
+  it("keeps each location token distinct and URL-safe", () => {
+    const sushi = new URL(entryUrlFor("sushi_token_123456"));
+    const poki = new URL(entryUrlFor("poki/token+123456"));
+
+    expect(sushi.origin).toBe(TIPS_ENTRY_ORIGIN);
+    expect(poki.origin).toBe(TIPS_ENTRY_ORIGIN);
+    expect(sushi.searchParams.get("t")).toBe("sushi_token_123456");
+    expect(poki.searchParams.get("t")).toBe("poki/token+123456");
+    expect(sushi.href).not.toBe(poki.href);
+  });
+});

--- a/web/src/lib/tips/api.ts
+++ b/web/src/lib/tips/api.ts
@@ -81,6 +81,9 @@ async function callFunction(
         apikey: anonKey,
       },
       body: JSON.stringify(body),
+      // The page URL can still hold the QR token (?t=) when this fires —
+      // never let it ride to another origin as Referer.
+      referrerPolicy: "no-referrer",
     });
   } catch {
     throw new TipApiError(
@@ -110,6 +113,41 @@ export interface FreshSignIn extends SessionState {
 }
 
 /**
+ * Runtime shape check for session payloads. The edge function is typed only
+ * by convention; a malformed/partial response (older deploy, proxy error
+ * page) must surface as a clean TipApiError instead of crashing the render
+ * on `.id` / `.map` of undefined.
+ */
+function isSessionStateShape(value: unknown): value is SessionState {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  const location = v.location as Record<string, unknown> | undefined;
+  const today = v.today as Record<string, unknown> | undefined;
+  return (
+    !!location &&
+    typeof location.id === "string" &&
+    typeof location.name === "string" &&
+    Array.isArray(v.roster) &&
+    v.roster.every(
+      (p) =>
+        p && typeof p === "object" &&
+        typeof (p as Record<string, unknown>).id === "string" &&
+        typeof (p as Record<string, unknown>).name === "string",
+    ) &&
+    !!today &&
+    typeof today.businessDate === "string" &&
+    typeof today.lunchRecorded === "boolean" &&
+    typeof today.dinnerRecorded === "boolean"
+  );
+}
+
+function assertSessionState(json: Record<string, unknown>): void {
+  if (json.ok !== true || !isSessionStateShape(json)) {
+    throw new TipApiError("Something went wrong. Try again.", "bad_response", 200);
+  }
+}
+
+/**
  * Validate a scanned QR token and mint the entry session in ONE roundtrip.
  * When this device remembers who's closing, the remembered closer rides
  * along and the server applies it in the same request (the response's
@@ -127,6 +165,10 @@ export async function validateToken(
       ? { closerId: remembered.closerId, closerLocationId: remembered.locationId }
       : {}),
   });
+  assertSessionState(json);
+  if (typeof json.sessionToken !== "string" || !json.sessionToken) {
+    throw new TipApiError("Something went wrong. Try again.", "bad_response", 200);
+  }
   return json as unknown as FreshSignIn;
 }
 
@@ -158,6 +200,7 @@ export async function endSession(sessionToken: string): Promise<void> {
 
 export async function fetchState(sessionToken: string): Promise<SessionState> {
   const json = await callFunction("tip-entry-auth", { action: "state", sessionToken });
+  assertSessionState(json);
   return json as unknown as SessionState;
 }
 
@@ -245,6 +288,7 @@ async function parseVoiceChunkOnce(input: {
       method: "POST",
       headers: { Authorization: `Bearer ${anonKey}`, apikey: anonKey },
       body: form,
+      referrerPolicy: "no-referrer",
     });
   } catch {
     throw new TipApiError("Voice upload failed.", "network", 0);

--- a/web/src/lib/tips/dashboardCsv.ts
+++ b/web/src/lib/tips/dashboardCsv.ts
@@ -11,8 +11,19 @@ const HEADER =
   "Business date,Restaurant,Meal,Cash (split pool),Card (logged only)," +
   "People on split,Names,Per-person share,Flagged,Entered by,Entry method";
 
+/** Prefix-guard against spreadsheet formula injection (=, +, -, @, tab, CR). */
+function formulaSafe(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
 function csvField(value: string): string {
-  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  const safe = formulaSafe(value);
+  return /[",\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
+}
+
+/** Always-quoted variant (the Names column follows the mockup's format). */
+function csvFieldQuoted(value: string): string {
+  return `"${formulaSafe(value).replace(/"/g, '""')}"`;
 }
 
 function capitalize(word: string): string {
@@ -38,7 +49,7 @@ export function buildLedgerCsv(
         (entry.cashCents / 100).toFixed(2),
         (entry.cardCents / 100).toFixed(2),
         String(entry.splitCount),
-        `"${entry.peopleNames.join("; ").replace(/"/g, '""')}"`,
+        csvFieldQuoted(entry.peopleNames.join("; ")),
         (cashShareCents(entry.cashCents, entry.splitCount) / 100).toFixed(2),
         entry.flaggedRaw ? "yes" : "no",
         csvField(entry.enteredByName ?? ""),

--- a/web/src/lib/tips/entryError.ts
+++ b/web/src/lib/tips/entryError.ts
@@ -1,0 +1,16 @@
+import { TipApiError } from "./api";
+
+/** Keep connectivity/server failures from being misreported as revoked QR codes. */
+export function entrySignInErrorMessage(error: unknown): string {
+  if (!(error instanceof TipApiError)) {
+    return "Couldn’t verify this QR code. Try again.";
+  }
+  if (error.code === "rate_limited") return error.message;
+  if (error.code === "invalid") {
+    return "This QR code is no longer active. Ask a manager for the new one.";
+  }
+  if (error.code === "network") {
+    return "Couldn’t reach smelter. Check your connection and try again.";
+  }
+  return "Couldn’t verify this QR code. Try again.";
+}

--- a/web/src/lib/tips/entryUrl.ts
+++ b/web/src/lib/tips/entryUrl.ts
@@ -1,0 +1,9 @@
+/** Canonical phone-facing host. Manager and preview origins must never leak into printed QRs. */
+export const TIPS_ENTRY_ORIGIN = "https://tips.smelterpos.com";
+
+/** Build the location-token URL encoded into QR codes and NFC tags. */
+export function entryUrlFor(token: string): string {
+  const url = new URL("/e", TIPS_ENTRY_ORIGIN);
+  url.searchParams.set("t", token);
+  return url.toString();
+}

--- a/web/src/lib/tips/recorder.ts
+++ b/web/src/lib/tips/recorder.ts
@@ -127,7 +127,13 @@ export class TipRecorder {
       }
     };
     this.source.connect(this.processor);
-    this.processor.connect(this.audioContext.destination);
+    // ScriptProcessor only fires onaudioprocess when connected to the
+    // destination — route through a zero-gain node so the live mic is NEVER
+    // audible on the device speaker (feedback + dining-room eavesdropping).
+    const mute = this.audioContext.createGain();
+    mute.gain.value = 0;
+    this.processor.connect(mute);
+    mute.connect(this.audioContext.destination);
 
     this.startSegment();
     this.silenceTimer = setInterval(() => this.checkSilence(), 250);

--- a/web/src/types/database.ts
+++ b/web/src/types/database.ts
@@ -4843,6 +4843,15 @@ export type Database = {
         }
         Returns: boolean
       }
+      tip_manager_fix_entry: {
+        Args: {
+          p_card: number
+          p_cash: number
+          p_entry_id: string
+          p_people: string[]
+        }
+        Returns: undefined
+      }
       tip_revoke_location_sessions: {
         Args: { p_location_id: string }
         Returns: number


### PR DESCRIPTION
## Summary
- generate every printed QR/NFC entry link on the canonical `https://tips.smelterpos.com` staff host instead of the manager page origin
- redirect already-printed `dashboard.smelterpos.com/e?t=...` links to the staff host while preserving the location token
- allow the official Smelter tips/dashboard origins through the tip Edge Function CORS policy, including complete POST preflight headers
- stop reporting connectivity/CORS/server failures as an inactive QR token
- add regression coverage for canonical token URLs, CORS behavior, error classification, and Sushi/Poki location isolation

## Root cause
The dashboard QR renderer derived the entry URL from `window.location.origin`, so QR codes opened on the new dashboard subdomain encoded that manager host. Separately, the deployed `ALLOWED_ORIGINS` value still names only the legacy tips domain; live preflight responses therefore return `Access-Control-Allow-Origin: https://tips.babytunasystems.com` for requests from both new Smelter domains. The browser blocks token validation, and the landing page incorrectly collapsed that network failure into “QR code inactive.”

## Verification
- `npm test` — 200 passed
- `npm run typecheck`
- `npm run lint`
- `npx next build --webpack`
- `deno test --no-config --allow-env=ALLOWED_ORIGINS supabase/functions/_shared/cors_test.ts` — 7 passed
- `deno check --no-config` for `tip-entry-auth`, `tip-entries`, and `tip-voice-parse`
- production server Host-header check: dashboard `/e?t=poki_token_123456` returns 307 to `https://tips.smelterpos.com/e?t=poki_token_123456`; tips host serves `/e` directly
- Playwright discovery compiles and registers the new Sushi/Poki isolation test

The live-writing Playwright suite was not executed because its production QR fixture secrets and explicit live-write opt-in are intentionally absent from this checkout.

## Deployment note
Deploy the three changed Supabase Edge Functions (`tip-entry-auth`, `tip-entries`, `tip-voice-parse`) with the web app. After deployment, managers can reprint QR stickers; already-printed dashboard-host stickers remain compatible via the redirect.