### PR TITLE
Tips dashboard: fix QR sheet wordmark tracking and print scaling

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -288,6 +288,9 @@ button:active,
 }
 
 @media print {
+  @page {
+    margin: 0.5in;
+  }
   .no-print {
     display: none !important;
   }
@@ -296,27 +299,50 @@ button:active,
     background: #ffffff;
   }
 
-  /* While the sticker View dialog is open, print ONLY the sticker sheet:
-     everything else goes invisible and the sheet is pinned to the page. */
-  body:has(.qr-print-sheet) * {
-    visibility: hidden;
+  /* While the sticker View dialog is open, print ONLY the sticker sheet.
+     Everything off the sheet's ancestor chain is taken out of the layout —
+     display:none, not visibility:hidden, since hidden boxes still paginate
+     and used to emit a blank second page. */
+  body:has(.qr-print-sheet)
+    *:not(:has(.qr-print-sheet)):not(.qr-print-sheet):not(.qr-print-sheet *) {
+    display: none !important;
   }
-  body:has(.qr-print-sheet) .qr-print-sheet,
-  body:has(.qr-print-sheet) .qr-print-sheet * {
-    visibility: visible;
+  /* Strip the modal chain (fixed backdrop, scroll clamp, padding, wells) so
+     the sheet just flows from the top of page one. */
+  body:has(.qr-print-sheet),
+  body:has(.qr-print-sheet) *:has(.qr-print-sheet) {
+    display: block !important;
+    position: static !important;
+    inset: auto !important;
+    transform: none !important;
+    width: auto !important;
+    max-width: none !important;
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    z-index: auto !important;
   }
+  /* One zoom scales the whole sheet — type, QR and numbered bullets keep the
+     exact proportions of the on-screen preview instead of each being resized
+     on its own. */
   body:has(.qr-print-sheet) .qr-print-sheet {
-    position: fixed;
-    inset: 0 auto auto 50%;
-    transform: translateX(-50%);
-    width: 5.5in;
-    max-width: none;
-    margin: 0.6in 0 0;
+    zoom: 1.5;
+    margin: 0 auto !important;
     border: none;
     box-shadow: none;
+    break-inside: avoid;
   }
-  body:has(.qr-print-sheet) .qr-print-code {
-    height: 3.2in;
-    width: 3.2in;
+  /* Browsers drop backgrounds when printing, which erased the black circles
+     behind 1-4 and left the numbers floating in white. */
+  body:has(.qr-print-sheet) .qr-print-sheet,
+  body:has(.qr-print-sheet) .qr-print-sheet * {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 }

--- a/web/src/components/manager/dashboard/DevicesPage.tsx
+++ b/web/src/components/manager/dashboard/DevicesPage.tsx
@@ -95,16 +95,18 @@ function StickerSheetDialog({
     <ModalShell title={`${location.label} — entry QR`} onClose={onClose} wide>
       <div className="mt-3 max-h-[62vh] overflow-y-auto rounded-well bg-well p-3">
         <div className="qr-print-sheet mx-auto flex max-w-[430px] flex-col items-center gap-1 rounded-[6px] border border-line bg-white px-8 py-9 text-center text-[#111]">
-          <div className="text-[11px] font-bold tracking-[0.18em]">
-            <span className="text-[#e84d38]">smelter</span>
-            <span className="text-[#888]"> · tip entry</span>
+          {/* The wordmark keeps the logo's tight tracking; only the label
+              after it gets the wide letter-spacing. */}
+          <div className="flex items-baseline justify-center gap-[5px] font-bold">
+            <span className="text-[14px] tracking-[-0.02em] text-[#e84d38]">smelter</span>
+            <span className="text-[11px] tracking-[0.18em] text-[#888]">· tip entry</span>
           </div>
           <h2 className="text-[26px] font-extrabold leading-tight">{location.name}</h2>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={qrDataUrl}
             alt={`Tip entry QR code for ${location.name}`}
-            className="qr-print-code my-3 h-[230px] w-[230px]"
+            className="my-3 h-[230px] w-[230px]"
           />
           <ol className="w-full list-none space-y-2 text-left text-[13.5px] leading-snug">
             {[


### PR DESCRIPTION
Wordmark now matches the logo's tracking. Print fixes: black number bullets survive printing (print-color-adjust), sheet scales proportionally instead of being re-sized in inches, and the blank second page is gone.