### PR TITLE
Tips v3: gratuity, day-scope, partial shares, notes

### DIFF
--- a/docs/mockups/tips-dashboard/HANDOFF-tip-dashboard-v2.md
+++ b/docs/mockups/tips-dashboard/HANDOFF-tip-dashboard-v2.md
@@ -1,0 +1,198 @@
+# Handoff — build the new Tip Dashboard (manager web) for real
+
+You are implementing a finalized, approved design. Do not redesign, simplify the
+scope, or add features beyond this document. When something here conflicts with
+what you find in the repo, the repo's *backend* is the truth for data shapes and
+this document is the truth for *product behavior* — stop and flag genuine
+contradictions instead of guessing.
+
+## Mission
+
+Replace the v1 manager page of the Babytuna tips web app with the new
+**Tip Dashboard**, exactly as specified by the interactive mockup at
+`docs/mockups/tips-dashboard/tip-dashboard-final.html`, wired to the live
+backend end to end — including the pieces that connect to the employee entry
+client (schedule pre-selection, device sessions, entry log).
+
+Open that mockup in a browser first (`python3 -m http.server` in its folder —
+file:// also works) and click through everything before writing code.
+
+**Design decisions already locked (do not revisit):**
+- Visual language: the mockup's **"2 · App style"** version — neutral white page
+  `#f5f5f4`, white cards, red accent `#e84d38`, pill buttons, red-tint active
+  nav. The version tabs and the dark top chrome bar in the mockup are
+  mockup-only controls — do NOT build them.
+- Table row identity: **strong** color coding — black `Sushi` chip, blue
+  (`#2563eb`) `Poki & Pho` chip, tinted cash/card column groups.
+- Overview visualization: **Trend & people** (red daily-total line + area, plus
+  "cash take-home by person" ranked bars). The daily-bars and week-grid
+  variants were rejected; don't build them.
+- Sidebar: collapsible (216px ↔ 66px icon rail), pages **Overview / Recorded
+  tips / Staff & schedule / Devices & entry log** (device cards ABOVE the entry
+  log on that page), profile block + **Log out** button at the bottom.
+- Page title is "Tip Dashboard" — no "Babytuna" suffix next to the h1.
+- All explanatory copy lives behind small ⓘ info-popovers, never as visible
+  paragraphs.
+- Full-width layout: no content max-width; tables must fit without horizontal
+  scrolling at ≥ ~1100px viewports (keep `overflow-x:auto` + sensible
+  min-widths only as a narrow-screen fallback).
+
+## Where you are working
+
+- Repo: `InventorySystem` (this repo). The web app is the top-level `web/`
+  Next.js project (App Router, Tailwind v4 tokens in
+  `web/src/app/globals.css`).
+- **Branch off `origin/main`** (currently at or past `a721b6b`). ⚠️ The LOCAL
+  `main` branch is a stale, diverged lineage — never base work on it. Do not
+  push to `main` yourself; open a PR.
+- Production: Vercel project `inventory-system` (root dir `web`) serves
+  https://tips.babytunasystems.com from `main`. Supabase project
+  `whrohvitvmcrmedepurd` (linked; CLI is authenticated).
+- Parallel work warning: branch `roadmap/integration` holds an unrelated
+  dashboard build (Team/Suppliers/Ordering pages under
+  `web/src/components/dashboard/` and `/dashboard` routes). Your work is the
+  **tips manager** surface only: stay in `/manager` routes and
+  `web/src/components/manager/` (+ `web/src/lib/tips/`), so the two merge
+  cleanly later.
+
+## Current v1 manager (what you are replacing)
+
+`web/src/app/manager/page.tsx` → `ManagerApp.tsx` with tabs (Entries / Roster /
+Admin), `LoginCard.tsx` (heading already says "Tip Dashboard"). Supabase email
+auth; manager = `profiles.role='manager'` via `public.current_user_is_manager()`
+(RLS on every `tip_*` table). Keep the login card flow; restyle to match the
+mockup shell. Keep `/manager/qr` (printable QR page) working — the device page
+links to it.
+
+## Backend you already have (do not rebuild)
+
+Tables (see `supabase/migrations/20260806120000_tips_web_foundation.sql` and
+`20260811204219_tip_entry_session_duplicate_guard.sql`; regenerate types or use
+`web/src/types/database.ts`):
+
+- `tip_employees` — id, name, `location_id` (NULL = works at BOTH locations),
+  active, sort_order.
+- `tip_entries` — one row per (business_date, location_id, meal_period
+  'lunch'|'dinner'); `cash_amount`/`card_amount` numeric(10,2);
+  split_count; entry_method 'typed'|'voice'; corrections_count; `entered_by` →
+  tip_employees; `flagged_anomaly` + `anomaly_reason`; `entry_session_id`;
+  **`created_at`/`updated_at`** (these power the entry log).
+- `tip_entry_people` — the split membership.
+- `tip_location_access` — per location: `entry_token_hash`,
+  `token_rotated_at` (PIN columns exist but PIN is DEAD — v2 is QR-only; never
+  surface PIN).
+- `tip_entry_sessions` — per-scan sessions: `closer_id`, `created_at`,
+  `last_seen_at`, `expires_at` (12h), `revoked`. A session ends after a save
+  (v2 behavior). These rows power "phones scanned in" + "recent scans".
+- RPCs (service-role/manager): `tip_rotate_entry_token`,
+  `tip_revoke_location_sessions`, `tip_save_entry` (13-param, duplicate-guard,
+  raises `already_recorded`).
+- Edge functions (live): `tip-entry-auth`, `tip-entries`, `tip-voice-parse`
+  (+`tip-voice-stream`). The employee entry app at `/`, `/e`, `/entry`,
+  `/closer` uses them. **Do not break the entry flow.**
+- Managers hit tables directly through supabase-js under RLS (v1 already does
+  this) — keep that pattern for dashboard reads/writes.
+
+Locations: `public.locations` — the two rows are Babytuna Sushi and Babytuna
+Poki & Pho; resolve ids at runtime, never hardcode.
+
+## New backend you must add (one additive migration, plus edge-fn edits)
+
+1. **Weekly schedule storage** — new table, e.g. `tip_employee_schedules`:
+   `(tip_employee_id, location_id, weekday smallint 0-6, meal 'lunch'|'dinner')`
+   unique across the tuple; manager-only RLS like the other tip tables; grants
+   mirroring `tip_employees`. An employee who works both locations has separate
+   rows per location (matches the mockup's per-location schedule lines).
+2. **Verify flow** — `tip_entries` add `flag_verified_at timestamptz`,
+   `flag_verified_by uuid references auth.users`. "Verify" on a flagged row
+   sets them (manager RLS update); verified rows stop counting as flagged in
+   KPIs/attention.
+3. **Schedule pre-selection on the phone (employee client connection)** —
+   extend the `tip-entry-auth`/`tip-entries` responses so the entry client
+   receives, for the session's location and current business date, the roster
+   with a `scheduled: boolean` per person for that meal period. Client change in
+   the entry flow: scheduled people come **pre-selected** in the "who's
+   splitting" chips and sort first; unscheduled staff sort to the bottom,
+   unselected. (This is the only entry-client change in scope. Business-date
+   rule: America/Los_Angeles with 4am rollover — reuse
+   `web/src/lib/tips/businessDate.ts`; meal close times: lunch 15:00, dinner
+   22:00.)
+
+Migration constraints: **additive only**, never edit an applied migration.
+Local `main`-lineage checkouts miss the `202608121*` roadmap migrations that
+ARE applied remotely — so validate with `supabase db push --dry-run
+--include-all` and expect to use `--include-all` when applying. Deploying
+edge-fn changes: deploy all touched functions together with the migration.
+
+## Page-by-page spec (the mockup is the visual truth; this is the data truth)
+
+Shared toolbar on every page: time-frame button (opens a card: This week / Last
+week / This month / This year — real date math over `business_date`, ‹ ›
+arrows step weeks), location segment (Both / Sushi / Poki & Pho), Export CSV
+(real download of the filtered ledger; reuse the CSV rules from
+`docs/mockups/tips-dashboard/core/tips-core.js` — per-record year from the
+record, quoted/escaped fields). Header strip: flagged count pill, cash pool
+total, card total, record count — all filter-aware.
+
+1. **Overview** — Trend & people (compute from `tip_entries` + people in
+   range): daily cash+card totals polyline; take-home = each entry's
+   `cash_amount / split_count` share summed per person (display rounded, and
+   note it's cash only). "Needs attention" list: unverified flagged entries →
+   Review (jumps to ledger), missing shifts (see entry-log rule) → See log,
+   plus device warnings (token never rotated). Each row navigates to the right
+   page.
+2. **Recorded tips** — the dense ledger: rows newest-first grouped by day with
+   day-total rows; columns Business date / Restaurant chip / Meal / Cash /
+   Split between (names · count) / Per person / Card → payroll / Entered by ·
+   method / actions. Flagged row: red tint + "⚑ check" chip + **Verify**
+   button (writes the new columns). **Fix** re-opens a slot for correction: a
+   manager edit dialog updating the entry + people under RLS (manager edits
+   don't go through `tip_save_entry`).
+3. **Staff & schedule** — add-hire form (name + works-at), then per-employee
+   rows: works-at select (maps to `location_id`: sushi id / poki id / NULL for
+   both), per-location schedule lines (Sushi chip black, Poki chip blue), 7
+   day-cells with L/D toggle pills persisting to `tip_employee_schedules`,
+   shifts/week count, **Rename** and **Deactivate/Reactivate** buttons
+   (deactivate = `active=false`, history intact; delete only if no recorded
+   history — mirror v1 rules). Location segment filters rows AND lines exactly
+   like the mockup.
+4. **Devices & entry log** — device cards FIRST: per location — QR sticker
+   status (`token_rotated_at`, or "never rotated" warning), **Rotate…**
+   (existing RPC + confirm dialog; plaintext shows once then link to
+   `/manager/qr` print page), sessions summary from `tip_entry_sessions`
+   (count in range, last scan time, recent scans with closer names), **Sign
+   out all** (`tip_revoke_location_sessions`). Then the entry log: one row per
+   entry in range — date, chip, meal, entered by, method, logged-at
+   (`created_at` in America/Los_Angeles), timing badge vs close time (green
+   ≤45min, amber later same night, red next-day). **Missing** rows (red, on
+   top): business dates in range where the schedule says someone was scheduled
+   for that location+meal but no `tip_entries` row exists and the shift's
+   close time has passed. KPIs: on-time %, median minutes after close, missing
+   count.
+
+Auth shell: keep LoginCard; after sign-in render the sidebar app. Log out =
+`supabase.auth.signOut()` back to the card. Profile block shows the signed-in
+user's name/email.
+
+## Definition of done
+
+- `npm run test`, `npm run typecheck`, `npm run lint`, `npm run build` all pass
+  in `web/` (add unit tests for new pure logic: range math, timing badges,
+  missing-shift derivation, take-home aggregation — put pure logic in
+  `web/src/lib/tips/`, unit-tested like the existing modules).
+- Entry flow regression: existing Playwright suite still passes (read
+  `web/e2e/README.md` FIRST — it writes live data, needs
+  `E2E_ALLOW_LIVE_WRITES=1`, run `cleanup.sql` before).
+- Every dashboard number is filter-consistent (range × location) and matches a
+  hand-checked SQL query for at least one week of real data.
+- Schedule set in the dashboard visibly pre-selects people on the entry phone
+  for that business date/meal.
+- No PIN UI anywhere; `/manager/qr` still prints; rotating a token still shows
+  plaintext exactly once.
+- Migration applied via `supabase db push --include-all` (dry-run first); the
+  paired edge functions deployed in the same window; PR opened against `main`
+  with screenshots of all four pages (desktop + one narrow-width shot showing
+  the scroll fallback).
+
+Ask David before: any schema change beyond the three listed, touching the
+entry flow beyond schedule pre-selection, or merging/deploying.

--- a/docs/mockups/tips-dashboard/tip-dashboard-final.html
+++ b/docs/mockups/tips-dashboard/tip-dashboard-final.html
@@ -1,0 +1,761 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Babytuna Tip Dashboard — final mockup · 3 versions</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+button{font:inherit;cursor:pointer;background:none;border:0;color:inherit}
+input,select{font:inherit}
+body{font-family:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",Roboto,Arial,sans-serif;background:var(--bg);color:var(--ink);font-size:14px;line-height:1.45}
+:root{--blue:#2563eb;--red:#e84d38;--redDeep:#c03520;--redTint:#fdecea;--amber:#b7791f;--green:#1f7a4d}
+
+/* ================= meta chrome (mockup-only controls) ================= */
+#chrome{position:sticky;top:0;z-index:60;background:#101319;color:#e7e9ee;display:flex;align-items:center;gap:16px;padding:8px 16px;font-size:12.5px;flex-wrap:wrap}
+#chrome .brandnote{color:#8a93a6;margin-right:auto}
+#chrome .grp{display:flex;align-items:center;gap:6px}
+#chrome .grp>span{color:#8a93a6;font-size:11px;text-transform:uppercase;letter-spacing:.06em}
+#chrome .grp button{padding:5px 12px;border-radius:7px;color:#c6ccd8;border:1px solid #2a3040;font-weight:600;font-size:12.5px}
+#chrome .grp button[aria-pressed="true"]{background:#e7e9ee;color:#101319;border-color:#e7e9ee}
+
+/* ================= theme variables per version ================= */
+body[data-v="v1"]{--bg:#eef0f3;--panel:#ffffff;--ink:#10141c;--sec:#5a6270;--mut:#98a0ac;--line:#e2e5ea;--hair:#edeff2;--well:#e9ebef;--rad:12px;--radIn:9px;--shadow:0 1px 2px rgba(16,20,28,.06),0 4px 14px rgba(16,20,28,.05);--btnPrimBg:#10141c;--btnPrimFg:#fff}
+body[data-v="v2"]{--bg:#f5f5f4;--panel:#ffffff;--ink:#1a1a1a;--sec:#5f5f5f;--mut:#9c9890;--line:rgba(0,0,0,.08);--hair:rgba(0,0,0,.06);--well:#ededec;--rad:20px;--radIn:14px;--shadow:none;--btnPrimBg:#e84d38;--btnPrimFg:#fff}
+body[data-v="v3"]{--bg:#f6f7f8;--panel:#ffffff;--ink:#171a1f;--sec:#565d68;--mut:#9aa1ab;--line:#e4e7eb;--hair:#eef0f3;--well:#eef0f2;--rad:10px;--radIn:8px;--shadow:0 1px 2px rgba(23,26,31,.05);--btnPrimBg:#171a1f;--btnPrimFg:#fff}
+
+/* ================= app shell — full width ================= */
+#app{display:flex;min-height:calc(100vh - 37px)}
+#sidenav{display:flex;flex-direction:column;width:216px;flex:none;padding:18px 12px;position:sticky;top:37px;height:calc(100vh - 37px)}
+#content{flex:1;min-width:0;padding:0 28px 60px}
+#sidenav .logo{font-weight:700;font-size:15px;padding:4px 10px 16px;letter-spacing:.01em}
+#sidenav .logo span{color:var(--red)}
+#sidenav button.nav{display:flex;align-items:center;gap:9px;width:100%;text-align:left;padding:9px 12px;border-radius:9px;font-size:13.5px;font-weight:600;margin-bottom:2px}
+#sidenav .navdot{width:7px;height:7px;border-radius:50%;background:var(--red);margin-left:auto}
+#sidenav .foot{margin-top:auto;font-size:11.5px;padding:10px}
+body[data-v="v1"] #sidenav,body[data-v="v2"] #sidenav{background:var(--panel);border-right:1px solid var(--line)}
+body[data-v="v1"] #sidenav .logo,body[data-v="v2"] #sidenav .logo{color:var(--ink)}
+body[data-v="v1"] #sidenav button.nav,body[data-v="v2"] #sidenav button.nav{color:var(--sec)}
+body[data-v="v1"] #sidenav button.nav:hover,body[data-v="v2"] #sidenav button.nav:hover{background:var(--well);color:var(--ink)}
+body[data-v="v1"] #sidenav button.nav[aria-current="true"]{background:var(--well);color:var(--ink);box-shadow:inset 3px 0 0 #10141c}
+body[data-v="v2"] #sidenav button.nav{border-radius:999px}
+body[data-v="v2"] #sidenav button.nav[aria-current="true"]{background:#fbeae7;color:#c03520}
+body[data-v="v1"] #sidenav .foot,body[data-v="v2"] #sidenav .foot{color:var(--mut)}
+body[data-v="v3"] #sidenav{background:#15181d}
+body[data-v="v3"] #sidenav .logo{color:#fff}
+body[data-v="v3"] #sidenav button.nav{color:#aeb5c0}
+body[data-v="v3"] #sidenav button.nav:hover{background:#1d2129;color:#e7e9ee}
+body[data-v="v3"] #sidenav button.nav[aria-current="true"]{background:#242a34;color:#fff;box-shadow:inset 3px 0 0 #e84d38}
+body[data-v="v3"] #sidenav .foot{color:#5c6472}
+/* nav icons + collapse */
+#sidenav .nico{width:18px;height:18px;flex:none}
+#sidenav .nico svg{width:100%;height:100%;display:block}
+#sidenav .snhead{display:flex;align-items:center;gap:6px}
+#sidenav .snhead .logo{flex:1;min-width:0;white-space:nowrap;overflow:hidden}
+#sidenav .sntoggle{width:26px;height:26px;border-radius:7px;font-weight:800;font-size:13px;color:inherit;opacity:.65;flex:none}
+#sidenav .sntoggle:hover{opacity:1}
+#sidenav .logomin{display:none}
+#sidenav.collapsed{width:66px;padding:18px 9px}
+#sidenav.collapsed .nlbl,#sidenav.collapsed .navdot,#sidenav.collapsed .logofull,#sidenav.collapsed .pmeta,#sidenav.collapsed .lgtxt{display:none}
+#sidenav.collapsed .logomin{display:inline}
+#sidenav.collapsed .snhead{flex-direction:column;gap:8px}
+#sidenav.collapsed button.nav{justify-content:center;padding:10px 0}
+#sidenav.collapsed .profile{justify-content:center;padding:8px 0}
+#sidenav.collapsed .logout{justify-content:center;padding:9px 0}
+/* profile + logout */
+#sidenav .foot{margin-top:auto;padding:10px 4px 4px;display:flex;flex-direction:column;gap:8px}
+.profile{display:flex;align-items:center;gap:10px;padding:8px 8px;border-radius:10px}
+.profile .avatar{width:32px;height:32px;border-radius:50%;background:var(--red);color:#fff;font-weight:800;font-size:14px;display:flex;align-items:center;justify-content:center;flex:none}
+.profile .pmeta{min-width:0;line-height:1.3}
+.profile .pmeta b{display:block;font-size:13px}
+.profile .pmeta span{font-size:11px;opacity:.75;display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.logout{display:flex;align-items:center;gap:9px;width:100%;padding:9px 12px;border-radius:9px;font-size:13px;font-weight:700;border:1px solid transparent}
+body[data-v="v1"] .logout,body[data-v="v2"] .logout{color:var(--redDeep);border-color:rgba(192,53,32,.3)}
+body[data-v="v1"] .logout:hover,body[data-v="v2"] .logout:hover{background:var(--redTint)}
+body[data-v="v2"] .logout{border-radius:999px}
+body[data-v="v3"] .logout{color:#f2b8ae;border-color:#3a2f2d}
+body[data-v="v3"] .logout:hover{background:#2a2023}
+body[data-v="v1"] .profile .pmeta b,body[data-v="v2"] .profile .pmeta b{color:var(--ink)}
+body[data-v="v3"] .profile .pmeta b{color:#fff}
+
+/* ================= top bar ================= */
+.topbar{display:flex;align-items:baseline;gap:14px;padding:24px 0 4px;flex-wrap:wrap}
+.topbar h1{font-size:21px;font-weight:800;letter-spacing:-.01em}
+.kpis{display:flex;gap:18px;margin-left:auto;align-items:baseline;flex-wrap:wrap}
+.kpi{font-size:13px;color:var(--sec)}
+.kpi b{color:var(--ink);font-size:15px;font-weight:800}
+.kpi .flagpill{background:var(--redTint);color:var(--redDeep);border:1px solid rgba(192,53,32,.25);border-radius:999px;padding:2px 10px;font-weight:700;font-size:12.5px}
+
+/* ================= toolbar ================= */
+.toolbar{position:sticky;top:37px;z-index:40;display:flex;align-items:center;gap:12px;padding:10px 14px;margin:12px 0 20px;background:var(--panel);border:1px solid var(--line);border-radius:var(--rad);box-shadow:var(--shadow);flex-wrap:wrap}
+body[data-v="v1"] .toolbar{background:rgba(255,255,255,.82);backdrop-filter:saturate(1.5) blur(14px);-webkit-backdrop-filter:saturate(1.5) blur(14px)}
+.weeknav{display:flex;align-items:center;gap:6px}
+.weeknav .arrow{width:28px;height:28px;border:1px solid var(--line);border-radius:8px;font-weight:700;color:var(--sec)}
+.weeknav .arrow:disabled{opacity:.3;cursor:default}
+.rangebtn{display:flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:10px;padding:6px 13px;font-weight:700;font-size:13.5px;background:var(--panel)}
+.rangebtn:hover{border-color:var(--mut)}
+.rangebtn .chev{color:var(--mut);font-size:10px}
+body[data-v="v2"] .rangebtn,body[data-v="v2"] .weeknav .arrow{border-radius:999px;border-color:transparent;background:var(--well)}
+.seg{display:flex;background:var(--well);border-radius:10px;padding:3px;gap:2px}
+.seg button{padding:5px 14px;border-radius:8px;font-weight:600;font-size:13px;color:var(--sec)}
+.seg button[aria-pressed="true"]{background:var(--panel);color:var(--ink);box-shadow:0 1px 2px rgba(16,20,28,.14)}
+body[data-v="v2"] .seg{border-radius:999px}
+body[data-v="v2"] .seg button{border-radius:999px}
+body[data-v="v2"] .seg button[aria-pressed="true"]{box-shadow:none}
+.toolbar .sp{margin-left:auto}
+.btn{border:1px solid var(--line);background:var(--panel);border-radius:10px;padding:6px 14px;font-weight:600;font-size:13px;color:var(--ink)}
+.btn:hover{border-color:var(--mut)}
+.btn.prim{background:var(--btnPrimBg);color:var(--btnPrimFg);border-color:var(--btnPrimBg)}
+.btn.danger{color:var(--redDeep);border-color:rgba(192,53,32,.3)}
+body[data-v="v2"] .btn{border-radius:999px;border-color:transparent;background:var(--well)}
+body[data-v="v2"] .btn.prim{background:#e84d38}
+body[data-v="v2"] .btn.danger{background:var(--redTint)}
+
+/* ================= sections / pages ================= */
+.sec{margin:0 0 30px;display:none}
+.sec.show{display:block}
+.sec>.shead{display:flex;align-items:center;gap:8px;margin-bottom:10px}
+.sec>.shead h3{font-size:16px;font-weight:800;letter-spacing:-.01em}
+body[data-v="v2"] .sec>.shead h3{font-size:15px}
+.sec>.shead .subcount{color:var(--mut);font-size:12.5px;font-weight:600}
+.info{width:20px;height:20px;border-radius:50%;border:1px solid var(--line);color:var(--mut);font-size:11px;font-weight:800;font-style:italic;font-family:Georgia,serif;line-height:1;flex:none}
+.info:hover{color:var(--ink);border-color:var(--mut)}
+.panelwrap{background:var(--panel);border:1px solid var(--line);border-radius:var(--rad);box-shadow:var(--shadow);overflow:hidden}
+
+/* ================= tables — fluid, scroll only when genuinely narrow ================= */
+.tablewrap{overflow-x:auto}
+table.led{width:100%;border-collapse:collapse;font-size:13px;min-width:740px}
+table.led.logt{min-width:620px}
+table.led th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--sec);font-weight:700;text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);background:var(--panel);white-space:nowrap}
+table.led th.r,table.led td.r{text-align:right}
+table.led td{padding:8px 12px;border-bottom:1px solid var(--hair);white-space:nowrap;vertical-align:middle}
+table.led td.money{font-variant-numeric:tabular-nums;font-weight:600}
+table.led td.money.big{font-weight:800}
+table.led td .names{color:var(--sec)}
+table.led td .names b{color:var(--ink);font-weight:600}
+table.led td .cnt{color:var(--mut);font-size:11.5px;margin-left:4px}
+table.led tr.daytotal td{background:var(--well);font-weight:800;font-size:12.5px;border-bottom:1px solid var(--line);padding:6px 12px}
+table.led tr.daytotal td:first-child{color:var(--sec);font-weight:700}
+table.led .by{color:var(--sec);font-size:12.5px}
+table.led .by .meth{color:var(--mut)}
+.minibtn{border:1px solid var(--line);border-radius:8px;padding:4px 11px;font-size:12px;font-weight:600;background:var(--panel);color:var(--ink)}
+.minibtn:hover{border-color:var(--mut)}
+.minibtn.verify,.minibtn.dangerb{border-color:rgba(192,53,32,.4);color:var(--redDeep)}
+body[data-v="v2"] .minibtn{border-radius:999px}
+.flagchip{display:inline-flex;align-items:center;gap:4px;background:var(--redTint);color:var(--redDeep);border-radius:6px;font-size:10.5px;font-weight:800;padding:2px 7px;margin-left:6px;text-transform:uppercase;letter-spacing:.03em}
+/* strong table color — final choice */
+.locname{display:inline-block;border-radius:6px;padding:1px 8px;font-size:12px;font-weight:700;color:#fff}
+tr.loc-sushi .locname,.schedline.sushi .locchip{background:#1a1a1a}
+tr.loc-poki .locname,.schedline.poki .locchip{background:var(--blue)}
+td.cashcol{background:rgba(216,144,32,.06)}
+td.cardcol{background:rgba(37,99,235,.055)}
+tr.flagged td{background:var(--redTint)}
+
+/* ================= entry log ================= */
+.logkpis{display:flex;gap:10px;padding:12px 14px;border-bottom:1px solid var(--line);flex-wrap:wrap}
+.logkpi{background:var(--well);border-radius:var(--radIn);padding:8px 14px;font-size:12.5px;color:var(--sec)}
+.logkpi b{display:block;font-size:16px;color:var(--ink);font-weight:800;margin-top:1px}
+.logkpi.bad b{color:var(--redDeep)}
+.tdot{display:inline-block;width:7px;height:7px;border-radius:50%;margin-right:6px;vertical-align:1px}
+.t-ok .tdot{background:var(--green)}
+.t-late .tdot{background:var(--amber)}
+.t-next .tdot{background:var(--redDeep)}
+.t-ok{color:var(--green);font-weight:600}
+.t-late{color:var(--amber);font-weight:600}
+.t-next{color:var(--redDeep);font-weight:600}
+tr.missrow td{background:var(--redTint);color:var(--redDeep);font-weight:600}
+
+/* ================= staff & schedule — fluid day grid ================= */
+.addrow{display:flex;align-items:flex-end;gap:12px;padding:13px 16px;border-bottom:1px solid var(--line);flex-wrap:wrap}
+.addrow label{display:flex;flex-direction:column;gap:4px;font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--sec)}
+.addrow input,.addrow select,.works-sel{border:1px solid var(--line);border-radius:var(--radIn);padding:6px 10px;font-size:13.5px;background:var(--panel);color:var(--ink)}
+.addrow input{width:180px}
+.legend{margin-left:auto;display:flex;gap:14px;align-items:center;font-size:12px;color:var(--sec)}
+.legend .sw{display:inline-block;width:11px;height:11px;border-radius:4px;margin-right:5px;vertical-align:-1px}
+.staffscroll{overflow-x:auto}
+.staffhead{display:grid;grid-template-columns:132px 112px 1fr 128px;gap:0 10px;padding:9px 16px;border-bottom:1px solid var(--line);font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--sec);font-weight:700;align-items:end;min-width:860px}
+.dayhead{display:grid;grid-template-columns:54px repeat(7,minmax(52px,1fr));gap:6px}
+.dayhead span{text-align:center}
+.staffrow{display:grid;grid-template-columns:132px 112px 1fr 128px;gap:0 10px;padding:10px 16px;border-bottom:1px solid var(--hair);align-items:center;min-width:860px}
+.staffrow:last-child{border-bottom:0}
+.staffrow .nm{font-weight:700}
+.staffrow .nm .inact{display:inline-block;background:var(--well);color:var(--mut);border-radius:5px;font-size:10px;font-weight:800;padding:1px 6px;margin-left:6px;text-transform:uppercase}
+.staffrow.isoff .nm,.staffrow.isoff .schedlines{opacity:.4}
+.schedlines{display:flex;flex-direction:column;gap:7px}
+.schedline{display:grid;grid-template-columns:54px repeat(7,minmax(52px,1fr));gap:6px;align-items:center}
+.locchip{font-size:10.5px;font-weight:800;text-transform:uppercase;letter-spacing:.04em;border-radius:6px;padding:3px 0;text-align:center;color:#fff}
+.daycell{display:flex;gap:4px;justify-content:center;background:var(--well);border-radius:8px;padding:4px}
+.daycell button{flex:1;max-width:34px;height:24px;font-size:11px;font-weight:800;border:1px solid var(--line);border-radius:6px;background:var(--panel);color:var(--mut);line-height:1}
+.schedline.sushi .daycell button[aria-pressed="true"]{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+.schedline.poki .daycell button[aria-pressed="true"]{background:var(--blue);color:#fff;border-color:var(--blue)}
+.daycell button:disabled{opacity:.4;cursor:default}
+.staffacts{display:flex;flex-direction:column;gap:6px;align-items:flex-start}
+.staffacts .shifts{color:var(--sec);font-weight:700;font-size:12px}
+.staffacts .actbtns{display:flex;gap:6px;flex-wrap:wrap}
+
+/* ================= device access ================= */
+.accessgrid{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+@media(max-width:940px){.accessgrid{grid-template-columns:1fr}}
+.access{background:var(--panel);border:1px solid var(--line);border-radius:var(--rad);box-shadow:var(--shadow);overflow:hidden}
+.access .ahead{display:flex;align-items:center;gap:9px;padding:13px 18px;border-bottom:1px solid var(--line)}
+.access .ahead h4{font-size:14.5px;font-weight:800}
+.access .ahead .dot{width:8px;height:8px;border-radius:50%}
+.access .ahead .dot.ok{background:var(--green)}
+.access .ahead .dot.warn{background:var(--amber)}
+.access .ahead .status{margin-left:auto;font-size:12px;color:var(--sec);font-weight:600}
+.access .body{padding:14px 18px;display:flex;flex-direction:column;gap:14px}
+.qrrow{display:flex;gap:14px;align-items:center}
+.qrbox{width:64px;height:64px;flex:none;border:1px solid var(--line);border-radius:10px;padding:7px;background:#fff}
+.qrmeta{flex:1;min-width:0}
+.qrmeta b{display:block;font-size:13.5px}
+.qrmeta .sub{color:var(--sec);font-size:12.5px;margin-top:1px}
+.qracts{display:flex;gap:8px;flex:none}
+.sessrow{background:var(--well);border-radius:var(--radIn);padding:11px 14px;display:flex;align-items:center;gap:12px}
+.sessrow .sess{flex:1;font-size:12.5px;color:var(--sec)}
+.sessrow .sess b{color:var(--ink);font-size:13.5px;display:block}
+.scanline{font-size:12px;color:var(--mut);display:flex;gap:14px;flex-wrap:wrap}
+.scanline span b{color:var(--sec);font-weight:600}
+
+/* ================= overview visualizations ================= */
+.vizhead{display:flex;align-items:center;gap:14px;padding:14px 18px;border-bottom:1px solid var(--line);flex-wrap:wrap}
+.vizhead b{font-size:14.5px;font-weight:800}
+.vizhead .vlegend{display:flex;gap:12px;font-size:12px;color:var(--sec);align-items:center}
+.vizhead .vlegend .sw{display:inline-block;width:11px;height:11px;border-radius:4px;margin-right:5px;vertical-align:-1px}
+.vizhead .vtotals{margin-left:auto;font-size:12.5px;color:var(--sec)}
+.vizhead .vtotals b{font-size:13px}
+/* option C — trend + people */
+.trendwrap{display:grid;grid-template-columns:1.7fr 1fr;gap:0}
+@media(max-width:900px){.trendwrap{grid-template-columns:1fr}}
+.trendbox{padding:20px 18px 10px;min-width:0}
+.tsvg{width:100%;height:200px;display:block}
+.tlbls{display:flex;justify-content:space-between;font-size:11px;color:var(--mut);font-weight:600;padding:6px 2px 10px}
+.people{border-left:1px solid var(--line);padding:16px 18px}
+@media(max-width:900px){.people{border-left:0;border-top:1px solid var(--line)}}
+.people h5{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--sec);font-weight:800;margin-bottom:12px}
+.prow{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+.prow .pname{width:56px;flex:none;font-weight:700;font-size:12.5px}
+.prow .pbarw{flex:1;background:var(--well);border-radius:6px;height:18px;overflow:hidden}
+.prow .pbar{height:100%;background:var(--ink);border-radius:6px;opacity:.85}
+.prow .pval{width:74px;flex:none;text-align:right;font-size:12.5px;font-weight:800;font-variant-numeric:tabular-nums}
+.prow .pshift{color:var(--mut);font-size:11px;margin-left:4px}
+/* needs attention */
+.attn{background:var(--panel);border:1px solid var(--line);border-radius:var(--rad);box-shadow:var(--shadow);overflow:hidden}
+.attn .arow{display:flex;align-items:center;gap:12px;padding:12px 17px;border-bottom:1px solid var(--hair);font-size:13.5px}
+.attn .arow:last-child{border-bottom:0}
+.attn .arow .adot{width:8px;height:8px;border-radius:50%;flex:none}
+.attn .arow .adot.red{background:var(--red)}
+.attn .arow .adot.amber{background:var(--amber)}
+.attn .arow .go{margin-left:auto}
+
+/* ================= popover & toast ================= */
+#pop{position:absolute;z-index:80;max-width:320px;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:0 6px 24px rgba(16,20,28,.16);padding:12px 14px;font-size:12.5px;color:var(--sec);line-height:1.5;display:none}
+#pop b{color:var(--ink)}
+#pop .ptitle{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--mut);font-weight:800;margin-bottom:8px}
+#pop .ropt{display:flex;align-items:baseline;gap:10px;width:100%;text-align:left;padding:8px 10px;border-radius:9px;font-size:13.5px;font-weight:600;color:var(--ink)}
+#pop .ropt:hover{background:var(--well)}
+#pop .ropt .rlbl{flex:none}
+#pop .ropt .rdates{color:var(--mut);font-size:12px;font-weight:500;margin-left:auto}
+#pop .ropt[aria-pressed="true"]{background:var(--well);box-shadow:inset 3px 0 0 var(--btnPrimBg)}
+#toast{position:fixed;left:50%;bottom:26px;transform:translateX(-50%);background:#15181d;color:#fff;border-radius:999px;padding:9px 18px;font-size:13px;font-weight:600;opacity:0;transition:opacity .18s;pointer-events:none;z-index:90;white-space:nowrap}
+#toast.show{opacity:1}
+</style>
+</head>
+<body data-v="v2">
+
+<div id="chrome">
+  <span class="brandnote">Babytuna · Tip Dashboard mockup — sample data, not wired to live</span>
+  <div class="grp" id="vtabs">
+    <span>Version</span>
+    <button data-vv="v1" aria-pressed="false">1 · Modern A</button>
+    <button data-vv="v2" aria-pressed="true">2 · App style</button>
+    <button data-vv="v3" aria-pressed="false">3 · Dark sidebar</button>
+  </div>
+</div>
+
+<div id="app">
+  <aside id="sidenav">
+    <div class="snhead">
+      <div class="logo"><span class="logofull">Babytuna <span>·</span> Tips</span><span class="logomin">B<span>·</span></span></div>
+      <button class="sntoggle" id="snToggle" aria-label="Collapse sidebar">‹</button>
+    </div>
+    <button class="nav" data-nav="overview" aria-current="true" title="Overview"><span class="nico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 3v18h18"/><path d="M6 15l4-5 3 3 5-7"/></svg></span><span class="nlbl">Overview</span><span class="navdot"></span></button>
+    <button class="nav" data-nav="ledger" title="Recorded tips"><span class="nico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M3 14h18M9 4v16"/></svg></span><span class="nlbl">Recorded tips</span></button>
+    <button class="nav" data-nav="staff" title="Staff &amp; schedule"><span class="nico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="9" cy="8" r="3.2"/><path d="M3.5 19c.8-3 3-4.5 5.5-4.5S13.7 16 14.5 19"/><circle cx="17" cy="9" r="2.5"/><path d="M15.5 14.7c2.3.2 4.1 1.6 4.8 4.3"/></svg></span><span class="nlbl">Staff &amp; schedule</span></button>
+    <button class="nav" data-nav="logdev" title="Devices &amp; entry log"><span class="nico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><path d="M14 14h3v3h-3zM18 18h3v3h-3z"/></svg></span><span class="nlbl">Devices &amp; entry log</span></button>
+    <div class="foot">
+      <div class="profile"><span class="avatar">D</span><span class="pmeta"><b>David</b><span>david@babytuna.com</span></span></div>
+      <button class="logout" id="logoutBtn" title="Log out"><span class="nico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5M21 12H9"/></svg></span><span class="lgtxt">Log out</span></button>
+    </div>
+  </aside>
+
+  <div id="content">
+    <header class="topbar">
+      <h1>Tip Dashboard</h1>
+      <div class="kpis" id="kpis"></div>
+    </header>
+
+    <div class="toolbar">
+      <div class="weeknav">
+        <button class="arrow" id="wPrev" aria-label="Previous week">‹</button>
+        <button class="rangebtn" id="rangeBtn" aria-haspopup="true"><span id="wLbl"></span><span class="chev">▼</span></button>
+        <button class="arrow" id="wNext" aria-label="Next week">›</button>
+      </div>
+      <div class="seg" id="locseg">
+        <button data-loc="both" aria-pressed="true">Both</button>
+        <button data-loc="sushi" aria-pressed="false">Sushi</button>
+        <button data-loc="poki" aria-pressed="false">Poki &amp; Pho</button>
+      </div>
+      <span class="sp"></span>
+      <button class="btn" id="csvBtn">Export CSV</button>
+    </div>
+
+    <section class="sec" id="sec-overview">
+      <div class="panelwrap" id="ovviz" style="margin-bottom:26px"></div>
+      <div class="shead"><h3>Needs attention</h3></div>
+      <div class="attn" id="attn"></div>
+    </section>
+
+    <section class="sec" id="sec-ledger">
+      <div class="shead">
+        <h3>Recorded tips</h3>
+        <span class="subcount" id="recCount"></span>
+        <button class="info" data-info="ledger" aria-label="About recorded tips">i</button>
+      </div>
+      <div class="panelwrap tablewrap">
+        <table class="led">
+          <thead>
+            <tr>
+              <th>Business date</th><th>Restaurant</th><th>Meal</th>
+              <th class="r">Cash</th><th>Split between</th><th class="r">Per person</th>
+              <th class="r">Card → payroll</th><th>Entered by</th><th></th>
+            </tr>
+          </thead>
+          <tbody id="recBody"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="sec" id="sec-access">
+      <div class="shead">
+        <h3>Device access</h3>
+        <button class="info" data-info="access" aria-label="About device access">i</button>
+      </div>
+      <div class="accessgrid" id="access"></div>
+    </section>
+
+    <section class="sec" id="sec-log">
+      <div class="shead">
+        <h3>Entry log</h3>
+        <span class="subcount">when each shift actually got recorded</span>
+        <button class="info" data-info="log" aria-label="About the entry log">i</button>
+      </div>
+      <div class="panelwrap">
+        <div class="logkpis" id="logkpis"></div>
+        <div class="tablewrap">
+          <table class="led logt">
+            <thead><tr>
+              <th>Business date</th><th>Restaurant</th><th>Meal</th><th>Entered by</th><th>Method</th><th>Logged at</th><th>Timing</th>
+            </tr></thead>
+            <tbody id="logBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="sec" id="sec-staff">
+      <div class="shead">
+        <h3>Staff &amp; schedule</h3>
+        <button class="info" data-info="staff" aria-label="About staff scheduling">i</button>
+      </div>
+      <div class="panelwrap">
+        <form class="addrow" id="addForm">
+          <label>New hire's name <input name="name" required placeholder="e.g. Dana" autocomplete="off"></label>
+          <label>Works at
+            <select name="works">
+              <option value="sushi">Sushi</option>
+              <option value="poki">Poki &amp; Pho</option>
+              <option value="both">Both</option>
+            </select>
+          </label>
+          <button class="btn prim">Add</button>
+          <span class="legend"><span><span class="sw" style="background:#1a1a1a"></span>Sushi</span><span><span class="sw" style="background:#2563eb"></span>Poki &amp; Pho</span><span style="color:var(--mut)">L = lunch · D = dinner</span></span>
+        </form>
+        <div class="staffscroll">
+          <div class="staffhead">
+            <span>Name</span><span>Works at</span>
+            <span class="dayhead"><span></span><span>Mon</span><span>Tue</span><span>Wed</span><span>Thu</span><span>Fri</span><span>Sat</span><span>Sun</span></span>
+            <span>Shifts / wk</span>
+          </div>
+          <div id="staffBody"></div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+</div>
+
+<div id="pop" role="dialog"></div>
+<div id="toast" role="status" aria-live="polite"></div>
+
+<script>
+'use strict';
+/* ============================ sample data ============================ */
+var LOCS={sushi:'Sushi',poki:'Poki & Pho'};
+var STAFF=[
+  {id:'maria',name:'Maria',works:'sushi',active:true,sched:{sushi:{mon:'LD',wed:'L',thu:'D',fri:'LD',sun:'D'}}},
+  {id:'jose',name:'Jose',works:'sushi',active:true,sched:{sushi:{tue:'D',wed:'LD',thu:'D',fri:'D',sat:'D'}}},
+  {id:'lena',name:'Lena',works:'poki',active:true,sched:{poki:{mon:'LD',wed:'D',thu:'L',sat:'L',sun:'LD'}}},
+  {id:'tom',name:'Tom',works:'poki',active:true,sched:{poki:{tue:'LD',thu:'D',fri:'D',sat:'LD',sun:'D'}}},
+  {id:'ken',name:'Ken',works:'both',active:true,sched:{sushi:{mon:'D',wed:'D',sat:'LD',sun:'L'},poki:{tue:'D',fri:'LD'}}},
+  {id:'rey',name:'Rey',works:'both',active:true,sched:{sushi:{tue:'LD',sun:'D'},poki:{mon:'L',fri:'D',sat:'D'}}},
+  {id:'aiko',name:'Aiko',works:'sushi',active:false,sched:{sushi:{}}}
+];
+var DAYS=['mon','tue','wed','thu','fri','sat','sun'];
+/* records: cash/card in cents; at = display time; dm = minutes after close (lunch 3 PM, dinner 10 PM); nd = logged next day */
+var WEEK0=[
+  {day:'Sun Aug 2',loc:'sushi',meal:'Dinner',cash:39800,card:64200,people:['Maria','Jose'],by:'Maria',meth:'dictated',at:'10:28 PM',dm:28,aug:true},
+  {day:'Sun Aug 2',loc:'poki',meal:'Dinner',cash:18150,card:36400,people:['Lena','Tom'],by:'Tom',meth:'typed',at:'10:47 PM',dm:47,aug:true},
+  {day:'Sat Aug 1',loc:'sushi',meal:'Dinner',cash:35250,card:58100,people:['Jose','Ken','Rey'],by:'Ken',meth:'typed',at:'10:09 PM',dm:9,aug:true},
+  {day:'Sat Aug 1',loc:'poki',meal:'Dinner',cash:19900,card:37250,people:['Lena','Rey'],by:'Rey',meth:'dictated',at:'10:51 PM',dm:51,aug:true},
+  {day:'Fri Jul 31',loc:'sushi',meal:'Dinner',cash:33400,card:54800,people:['Maria','Jose','Ken'],by:'Jose',meth:'typed',at:'10:22 PM',dm:22},
+  {day:'Fri Jul 31',loc:'poki',meal:'Dinner',cash:18475,card:34600,people:['Tom','Rey'],by:'Tom',meth:'typed',at:'11:12 PM',dm:72},
+  {day:'Thu Jul 30',loc:'sushi',meal:'Dinner',cash:30900,card:49750,people:['Maria','Ken'],by:'Maria',meth:'dictated',at:'10:16 PM',dm:16},
+  {day:'Wed Jul 29',loc:'poki',meal:'Dinner',cash:15700,card:30250,people:['Lena','Tom'],by:'Lena',meth:'typed',at:'10:39 PM',dm:39}
+];
+var WEEK1=[
+  {day:'Sun Aug 9',loc:'sushi',meal:'Dinner',cash:41200,card:68850,people:['Maria','Jose','Ken'],by:'Maria',meth:'dictated',at:'10:24 PM',dm:24,aug:true},
+  {day:'Sun Aug 9',loc:'sushi',meal:'Lunch',cash:9625,card:21000,people:['Ken'],by:'Ken',meth:'typed',at:'3:18 PM',dm:18,aug:true},
+  {day:'Sun Aug 9',loc:'poki',meal:'Dinner',cash:18800,card:40275,people:['Lena','Tom'],by:'Lena',meth:'typed',at:'10:41 PM',dm:41,aug:true},
+  {day:'Sat Aug 8',loc:'sushi',meal:'Dinner',cash:36650,card:59400,people:['Jose','Ken','Rey'],by:'Ken',meth:'typed',at:'10:12 PM',dm:12,aug:true},
+  {day:'Sat Aug 8',loc:'poki',meal:'Dinner',cash:20575,card:38800,people:['Lena','Tom','Rey'],by:'Rey',meth:'dictated',at:'11:05 PM',dm:65,aug:true},
+  {day:'Sat Aug 8',loc:'poki',meal:'Lunch',cash:7400,card:16525,people:['Lena'],by:'Lena',meth:'typed',at:'10:05 AM',dm:1145,nd:true,aug:true},
+  {day:'Fri Aug 7',loc:'sushi',meal:'Dinner',cash:310000,card:61000,people:['Maria','Jose'],by:'Jose',meth:'dictated',at:'10:31 PM',dm:31,flag:'3.1× the 4-week median — tap Verify after checking the drawer count',aug:true},
+  {day:'Fri Aug 7',loc:'sushi',meal:'Lunch',cash:8850,card:17400,people:['Maria'],by:'Maria',meth:'typed',at:'3:07 PM',dm:7,aug:true},
+  {day:'Fri Aug 7',loc:'poki',meal:'Dinner',cash:19725,card:35150,people:['Tom','Rey'],by:'Tom',meth:'typed',at:'10:44 PM',dm:44,aug:true},
+  {day:'Thu Aug 6',loc:'sushi',meal:'Dinner',cash:34400,card:56125,people:['Maria','Jose','Ken'],by:'Maria',meth:'dictated',at:'10:19 PM',dm:19,aug:true},
+  {day:'Thu Aug 6',loc:'poki',meal:'Dinner',cash:17250,card:33900,people:['Lena','Tom'],by:'Tom',meth:'typed',at:'10:52 PM',dm:52,aug:true},
+  {day:'Thu Aug 6',loc:'poki',meal:'Lunch',cash:6875,card:14250,people:['Lena'],by:'Lena',meth:'typed',at:'3:26 PM',dm:26,aug:true},
+  {day:'Wed Aug 5',loc:'sushi',meal:'Dinner',cash:29850,card:47300,people:['Jose','Ken'],by:'Jose',meth:'typed',at:'10:37 PM',dm:37,aug:true},
+  {day:'Wed Aug 5',loc:'poki',meal:'Dinner',cash:16400,card:31075,people:['Lena','Rey'],by:'Lena',meth:'dictated',at:'11:58 PM',dm:118,aug:true},
+  {day:'Tue Aug 4',loc:'sushi',meal:'Dinner',cash:31200,card:52450,people:['Jose','Rey'],by:'Rey',meth:'typed',at:'10:15 PM',dm:15,aug:true},
+  {day:'Tue Aug 4',loc:'sushi',meal:'Lunch',cash:7950,card:15300,people:['Rey'],by:'Rey',meth:'typed',at:'3:41 PM',dm:41,aug:true},
+  {day:'Tue Aug 4',loc:'poki',meal:'Dinner',cash:15925,card:29800,people:['Ken','Tom'],by:'Ken',meth:'dictated',at:'10:33 PM',dm:33,aug:true},
+  {day:'Mon Aug 3',loc:'sushi',meal:'Dinner',cash:27600,card:44150,people:['Maria','Ken'],by:'Maria',meth:'typed',at:'10:21 PM',dm:21,aug:true},
+  {day:'Mon Aug 3',loc:'poki',meal:'Dinner',cash:14800,card:27650,people:['Tom','Lena'],by:'Lena',meth:'typed',at:'10:58 PM',dm:58,aug:true},
+  {day:'Mon Aug 3',loc:'poki',meal:'Lunch',cash:6250,card:12900,people:['Rey'],by:'Rey',meth:'typed',at:'3:12 PM',dm:12,aug:true}
+];
+var MISSING=[{day:'Wed Aug 5',loc:'poki',meal:'Lunch',aug:true}];
+var RANGES={
+  week1:{lbl:'Aug 3 – 9, 2026',pick:'This week',recs:function(){return WEEK1},miss:function(){return MISSING}},
+  week0:{lbl:'Jul 27 – Aug 2, 2026',pick:'Last week',recs:function(){return WEEK0},miss:function(){return []}},
+  month:{lbl:'August 2026',pick:'This month',recs:function(){return WEEK1.concat(WEEK0.filter(function(r){return r.aug}))},miss:function(){return MISSING}},
+  year:{lbl:'2026 — year to date',pick:'This year',recs:function(){return WEEK1.concat(WEEK0)},miss:function(){return MISSING}}
+};
+var RANGEORDER=['week1','week0','month','year'];
+var ACCESS={
+ sushi:{rotated:'Aug 8, 2026',printed:true,phones:3,lastScan:'Sun 10:24 PM',scans:['Maria · Sun 10:01 PM','Ken · Sun 2:55 PM','Ken · Sat 9:48 PM']},
+ poki:{rotated:'Aug 8, 2026',printed:false,phones:2,lastScan:'Sun 10:12 PM',scans:['Lena · Sun 10:12 PM','Rey · Sat 10:31 PM']}
+};
+var INFO={
+ ledger:'<b>Cash</b> is pooled and handed out nightly — the per-person column is what each name takes home. <b>Card</b> tips ride payroll. A flagged row is unusually large against the 4-week history: check the drawer count, then Verify. Fix reopens a recorded shift for correction.',
+ log:'<b>Logged at</b> is the moment the closer saved the entry on the phone. Timing compares it to close — lunch closes 3 PM, dinner 10 PM. Green ≤ 45 min, amber later that night, red = next day or never logged.',
+ staff:'Scheduled people come <b>pre-selected</b> on the phone when the closer records that day\'s shift — they can still add or remove anyone before saving. Unscheduled staff sit at the bottom of the picker. People with recorded history can only be deactivated; Delete exists for someone added by mistake.',
+ access:'Each restaurant signs in by scanning its <b>QR sticker</b> — one scan per entry, the phone signs out after saving. Rotating replaces the sticker immediately; only a hash is stored, so print right after rotating. Sign out all is for a lost phone.'
+};
+
+/* ============================ state ============================ */
+var st={range:'week1',loc:'both',nav:'overview'};
+var PAGES={overview:['sec-overview'],ledger:['sec-ledger'],staff:['sec-staff'],logdev:['sec-access','sec-log']};
+
+/* ============================ utils ============================ */
+function $(s,c){return (c||document).querySelector(s)}
+function $$(s,c){return [].slice.call((c||document).querySelectorAll(s))}
+function money(c){return '$'+(c/100).toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2})}
+function kmoney(c){return '$'+Math.round(c/100).toLocaleString('en-US')}
+function esc(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;')}
+function toast(m){var t=$('#toast');t.textContent=m;t.classList.add('show');clearTimeout(t._h);t._h=setTimeout(function(){t.classList.remove('show')},2200)}
+function timing(r){
+  if(r.nd)return {cls:'t-next',txt:'next day · '+r.at};
+  if(r.dm<=45)return {cls:'t-ok',txt:'+'+r.dm+' min after close'};
+  return {cls:'t-late',txt:'+'+(r.dm>=60?Math.round(r.dm/60*10)/10+' hr':r.dm+' min')+' after close'};
+}
+function recsNow(){return RANGES[st.range].recs().filter(function(r){return st.loc==='both'||r.loc===st.loc})}
+function missNow(){return RANGES[st.range].miss().filter(function(m){return st.loc==='both'||m.loc===st.loc})}
+function shortDay(d){var p=d.split(' ');return p[0]+' '+p[2]}
+function chronoDays(){
+  var seen={},out=[];
+  RANGES[st.range].recs().slice().reverse().forEach(function(r){if(!seen[r.day]){seen[r.day]=1;out.push(r.day)}});
+  return out;
+}
+
+/* ============================ renders ============================ */
+function renderKpis(){
+  var rs=recsNow(),cash=0,card=0,flags=0;
+  rs.forEach(function(r){cash+=r.cash;card+=r.card;if(r.flag)flags++});
+  $('#kpis').innerHTML=
+    (flags?'<span class="kpi"><span class="flagpill">⚑ '+flags+' flagged</span></span>':'')+
+    '<span class="kpi">Cash pool <b>'+money(cash)+'</b></span>'+
+    '<span class="kpi">Card logged <b>'+money(card)+'</b></span>'+
+    '<span class="kpi">'+rs.length+' records</span>';
+  $('#wLbl').textContent=RANGES[st.range].lbl;
+  $('#wPrev').disabled=st.range!=='week1';
+  $('#wNext').disabled=st.range!=='week0';
+  $('#recCount').textContent=rs.length+' records';
+}
+function renderLedger(){
+  var rs=recsNow(),html='',day=null,dc=0,dd=0;
+  function totalRow(){if(day===null)return;html+='<tr class="daytotal"><td colspan="3">'+esc(day)+' — day total</td><td class="r money cashcol">'+money(dc)+'</td><td class="cashcol"></td><td class="cashcol"></td><td class="r money cardcol">'+money(dd)+'</td><td></td><td></td></tr>'}
+  rs.forEach(function(r){
+    if(r.day!==day){totalRow();day=r.day;dc=0;dd=0}
+    dc+=r.cash;dd+=r.card;
+    var per=money(Math.round(r.cash/r.people.length));
+    html+='<tr class="rec loc-'+r.loc+(r.flag?' flagged':'')+'">'+
+      '<td>'+esc(r.day)+'</td>'+
+      '<td><span class="locname">'+LOCS[r.loc]+'</span></td>'+
+      '<td>'+r.meal+'</td>'+
+      '<td class="r money cashcol">'+money(r.cash)+(r.flag?'<span class="flagchip">⚑ check</span>':'')+'</td>'+
+      '<td class="cashcol"><span class="names"><b>'+r.people.join(', ')+'</b><span class="cnt">· '+r.people.length+'</span></span></td>'+
+      '<td class="r money big cashcol">'+per+'</td>'+
+      '<td class="r money cardcol">'+money(r.card)+'</td>'+
+      '<td class="by">'+esc(r.by)+' <span class="meth">· '+r.meth+'</span></td>'+
+      '<td class="r"><button class="minibtn" data-fix="1">Fix</button>'+(r.flag?' <button class="minibtn verify" data-verify="1" title="'+esc(r.flag)+'">Verify</button>':'')+'</td>'+
+    '</tr>';
+  });
+  totalRow();
+  if(!rs.length)html='<tr><td colspan="9" style="text-align:center;color:var(--mut);padding:26px">No records in this range for this filter</td></tr>';
+  $('#recBody').innerHTML=html;
+}
+function renderLog(){
+  var rs=recsNow().slice(),ms=missNow(),html='';
+  var ok=rs.filter(function(r){return !r.nd&&r.dm<=45}).length;
+  var total=rs.length+ms.length;
+  var dms=rs.filter(function(r){return !r.nd}).map(function(r){return r.dm}).sort(function(a,b){return a-b});
+  var med=dms.length?dms[Math.floor(dms.length/2)]:0;
+  $('#logkpis').innerHTML=
+    '<span class="logkpi">Logged on time (≤ 45 min)<b>'+(total?Math.round(ok/total*100):0)+'%</b></span>'+
+    '<span class="logkpi">Median time after close<b>'+med+' min</b></span>'+
+    '<span class="logkpi'+(ms.length?' bad':'')+'">Missing in this range<b>'+ms.length+'</b></span>';
+  ms.forEach(function(m){
+    html+='<tr class="missrow"><td>'+esc(m.day)+'</td><td>'+LOCS[m.loc]+'</td><td>'+m.meal+'</td><td colspan="3">—</td><td>not logged</td></tr>';
+  });
+  rs.forEach(function(r){
+    var t=timing(r);
+    html+='<tr class="rec loc-'+r.loc+'"><td>'+esc(r.day)+'</td><td><span class="locname">'+LOCS[r.loc]+'</span></td><td>'+r.meal+'</td>'+
+      '<td>'+esc(r.by)+'</td><td class="by">'+r.meth+'</td><td class="money">'+r.at+'</td>'+
+      '<td class="'+t.cls+'"><span class="tdot"></span>'+t.txt+'</td></tr>';
+  });
+  $('#logBody').innerHTML=html;
+}
+function schedCells(s,loc){
+  var sc=(s.sched[loc])||{},html='';
+  DAYS.forEach(function(d){
+    var v=sc[d]||'';
+    html+='<span class="daycell">'+
+      '<button data-sch="'+s.id+':'+loc+':'+d+':L" aria-pressed="'+(v.indexOf('L')>=0)+'"'+(s.active?'':' disabled')+'>L</button>'+
+      '<button data-sch="'+s.id+':'+loc+':'+d+':D" aria-pressed="'+(v.indexOf('D')>=0)+'"'+(s.active?'':' disabled')+'>D</button>'+
+    '</span>';
+  });
+  return html;
+}
+function renderStaff(){
+  var html='';
+  STAFF.forEach(function(s){
+    var locs=s.works==='both'?['sushi','poki']:[s.works];
+    var show=locs.filter(function(l){return st.loc==='both'||l===st.loc});
+    if(!show.length)return;
+    var lines=show.map(function(l){
+      return '<div class="schedline '+l+'"><span class="locchip '+l+'">'+(l==='sushi'?'Sushi':'Poki')+'</span>'+schedCells(s,l)+'</div>';
+    }).join('');
+    var shifts=0;show.forEach(function(l){var sc=s.sched[l]||{};DAYS.forEach(function(d){shifts+=(sc[d]||'').length})});
+    html+='<div class="staffrow'+(s.active?'':' isoff')+'">'+
+      '<span class="nm">'+esc(s.name)+(s.active?'':'<span class="inact">inactive</span>')+'</span>'+
+      '<span><select class="works-sel" data-works="'+s.id+'"'+(s.active?'':' disabled')+'>'+
+        '<option value="sushi"'+(s.works==='sushi'?' selected':'')+'>Sushi</option>'+
+        '<option value="poki"'+(s.works==='poki'?' selected':'')+'>Poki &amp; Pho</option>'+
+        '<option value="both"'+(s.works==='both'?' selected':'')+'>Both</option></select></span>'+
+      '<span class="schedlines">'+lines+'</span>'+
+      '<span class="staffacts"><span class="shifts">'+shifts+' shifts</span><span class="actbtns">'+
+        (s.active?'<button class="minibtn" data-act="rename" data-id="'+s.id+'">Rename</button><button class="minibtn dangerb" data-act="deact" data-id="'+s.id+'">Deactivate</button>'
+                 :'<button class="minibtn" data-act="react" data-id="'+s.id+'">Reactivate</button>')+
+      '</span></span></div>';
+  });
+  $('#staffBody').innerHTML=html;
+}
+function qrSvg(){
+  return '<svg viewBox="0 0 21 21" width="100%" height="100%" aria-hidden="true"><rect width="21" height="21" fill="#fff"/><path fill="#111" d="M0 0h7v7H0zM2 2h3v3H2zM14 0h7v7h-7zM16 2h3v3h-3zM0 14h7v7H0zM2 16h3v3H2zM9 0h2v3H9zM9 4h3v2H9zM13 9h2v2h-2zM9 9h2v3H9zM16 9h5v2h-5zM9 14h2v2H9zM12 12h3v3h-3zM16 13h2v4h-2zM19 14h2v3h-2zM9 18h4v3H9zM14 18h3v2h-3zM18 19h3v2h-3z"/></svg>';
+}
+function renderAccess(){
+  var html='';
+  ['sushi','poki'].forEach(function(l){
+    var a=ACCESS[l];
+    html+='<div class="access"><div class="ahead"><span class="dot '+(a.printed?'ok':'warn')+'"></span><h4>'+LOCS[l]+'</h4>'+
+      '<span class="status">'+(a.printed?'Sticker active':'Rotated — not printed yet')+'</span></div>'+
+      '<div class="body">'+
+        '<div class="qrrow"><span class="qrbox">'+qrSvg()+'</span>'+
+          '<span class="qrmeta"><b>QR sticker</b><span class="sub">Rotated '+a.rotated+(a.printed?' · printed':' · <span style="color:var(--amber);font-weight:600">print it — old sticker is dead</span>')+'</span></span>'+
+          '<span class="qracts"><button class="btn" data-acc="print:'+l+'">Print</button><button class="btn" data-acc="rotate:'+l+'">Rotate…</button></span></div>'+
+        '<div class="sessrow"><span class="sess"><b>'+a.phones+' phones scanned in this week</b>Last scan '+a.lastScan+' · sessions end after each save</span>'+
+          '<button class="btn danger" data-acc="signout:'+l+'">Sign out all</button></div>'+
+        '<div class="scanline">'+a.scans.map(function(x){return '<span><b>'+esc(x.split(' · ')[0])+'</b> · '+esc(x.split(' · ')[1])+'</span>'}).join('')+'</div>'+
+      '</div></div>';
+  });
+  $('#access').innerHTML=html;
+}
+
+/* ---------- overview visualizations ---------- */
+function vizHead(title){
+  var rs=recsNow(),cash=0,card=0;
+  rs.forEach(function(r){cash+=r.cash;card+=r.card});
+  var legend=(st.loc==='both')
+    ?'<span class="vlegend"><span><span class="sw" style="background:#1a1a1a"></span>Sushi</span><span><span class="sw" style="background:#2563eb"></span>Poki &amp; Pho</span></span>'
+    :'';
+  return '<div class="vizhead"><b>'+title+' — '+RANGES[st.range].lbl+'</b>'+legend+
+    '<span class="vtotals">Cash <b>'+kmoney(cash)+'</b> · Card <b>'+kmoney(card)+'</b> · '+rs.length+' records</span></div>';
+}
+function ovTrend(){
+  var days=chronoDays(),rs=recsNow();
+  var per={};days.forEach(function(d){per[d]=0});
+  rs.forEach(function(r){per[r.day]+=r.cash+r.card});
+  var vals=days.map(function(d){return per[d]});
+  var max=Math.max.apply(null,vals.concat([1]));
+  var W=600,H=180,PAD=10;
+  var pts=vals.map(function(v,i){
+    var x=days.length>1?PAD+i*(W-2*PAD)/(days.length-1):W/2;
+    var y=H-PAD-(v/max)*(H-2*PAD);
+    return [Math.round(x),Math.round(y)];
+  });
+  var line=pts.map(function(p){return p.join(',')}).join(' ');
+  var area='0,'+H+' '+line+' '+W+','+H;
+  var svg='<svg class="tsvg" viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none">'+
+    '<polygon points="'+area+'" fill="rgba(232,77,56,.08)"/>'+
+    '<polyline points="'+line+'" fill="none" stroke="#e84d38" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>'+
+    pts.map(function(p,i){return '<circle cx="'+p[0]+'" cy="'+p[1]+'" r="3.5" fill="#e84d38"/>'}).join('')+
+    '</svg>';
+  var lbls='<div class="tlbls">'+days.map(function(d){return '<span>'+shortDay(d)+'</span>'}).join('')+'</div>';
+  /* top earners: cash share per person */
+  var take={},shifts={};
+  rs.forEach(function(r){
+    var share=Math.round(r.cash/r.people.length);
+    r.people.forEach(function(p){take[p]=(take[p]||0)+share;shifts[p]=(shifts[p]||0)+1});
+  });
+  var ppl=Object.keys(take).map(function(p){return {n:p,c:take[p],s:shifts[p]}}).sort(function(a,b){return b.c-a.c}).slice(0,6);
+  var pmax=ppl.length?ppl[0].c:1;
+  var phtml='<div class="people"><h5>Cash take-home by person</h5>';
+  ppl.forEach(function(p){
+    phtml+='<div class="prow"><span class="pname">'+esc(p.n)+'</span><span class="pbarw"><span class="pbar" style="width:'+Math.max(4,Math.round(p.c/pmax*100))+'%;display:block"></span></span><span class="pval">'+kmoney(p.c)+'<span class="pshift">· '+p.s+'</span></span></div>';
+  });
+  phtml+='</div>';
+  return '<div class="trendwrap"><div class="trendbox">'+svg+lbls+'</div>'+phtml+'</div>';
+}
+function renderOverview(){
+  $('#ovviz').innerHTML=vizHead('Tips trend')+ovTrend();
+  var rs=recsNow(),ms=missNow(),rows='';
+  rs.forEach(function(r){if(r.flag)rows+='<div class="arow"><span class="adot red"></span><span><b>'+esc(r.day)+' · '+LOCS[r.loc]+' dinner</b> — cash '+money(r.cash)+' looks unusually large</span><button class="btn go" data-goto="ledger">Review</button></div>'});
+  ms.forEach(function(m){rows+='<div class="arow"><span class="adot red"></span><span><b>'+esc(m.day)+' · '+LOCS[m.loc]+' '+m.meal.toLowerCase()+'</b> was never logged</span><button class="btn go" data-goto="logdev">See log</button></div>'});
+  if(!ACCESS.poki.printed)rows+='<div class="arow"><span class="adot amber"></span><span><b>Poki &amp; Pho QR</b> was rotated but the new sticker isn\'t printed yet</span><button class="btn go" data-goto="logdev">Devices</button></div>';
+  if(!rows)rows='<div class="arow"><span class="adot" style="background:var(--green)"></span>Nothing needs attention in this range.</div>';
+  $('#attn').innerHTML=rows;
+}
+function renderAll(){renderKpis();renderLedger();renderLog();renderStaff();renderAccess();renderOverview()}
+
+/* ============================ nav / version ============================ */
+function applyNav(){
+  $$('#sidenav .nav').forEach(function(b){b.setAttribute('aria-current',b.dataset.nav===st.nav)});
+  $$('.sec').forEach(function(s){s.classList.remove('show')});
+  (PAGES[st.nav]||[]).forEach(function(id){var el=document.getElementById(id);if(el)el.classList.add('show')});
+}
+$('#vtabs').addEventListener('click',function(e){
+  var b=e.target.closest('button[data-vv]');if(!b)return;
+  document.body.dataset.v=b.dataset.vv;
+  $$('#vtabs button').forEach(function(x){x.setAttribute('aria-pressed',x===b)});
+  window.scrollTo(0,0);
+});
+$('#sidenav').addEventListener('click',function(e){
+  var b=e.target.closest('button[data-nav]');if(!b)return;
+  st.nav=b.dataset.nav;applyNav();window.scrollTo(0,0);
+});
+
+/* ============================ toolbar events ============================ */
+$('#locseg').addEventListener('click',function(e){
+  var b=e.target.closest('button[data-loc]');if(!b)return;
+  st.loc=b.dataset.loc;
+  $$('#locseg button').forEach(function(x){x.setAttribute('aria-pressed',x===b)});
+  renderAll();
+});
+$('#wPrev').addEventListener('click',function(){if(st.range==='week1'){st.range='week0';renderAll()}});
+$('#wNext').addEventListener('click',function(){if(st.range==='week0'){st.range='week1';renderAll()}});
+$('#csvBtn').addEventListener('click',function(){toast('CSV exported — '+recsNow().length+' rows ('+RANGES[st.range].lbl+')')});
+$('#rangeBtn').addEventListener('click',function(e){
+  var pop=$('#pop');
+  var html='<div class="ptitle">Time frame</div>';
+  RANGEORDER.forEach(function(k){
+    html+='<button class="ropt" data-range="'+k+'" aria-pressed="'+(st.range===k)+'"><span class="rlbl">'+RANGES[k].pick+'</span><span class="rdates">'+RANGES[k].lbl+'</span></button>';
+  });
+  pop.innerHTML=html;
+  pop.style.display='block';
+  var r=e.currentTarget.getBoundingClientRect();
+  pop.style.left=(r.left+window.scrollX)+'px';
+  pop.style.top=(r.bottom+window.scrollY+8)+'px';
+  e.stopPropagation();
+});
+
+/* ============================ global click handling ============================ */
+document.addEventListener('click',function(e){
+  var t=e.target;
+  var pop=$('#pop');
+  var ro=t.closest('[data-range]');
+  if(ro){st.range=ro.dataset.range;pop.style.display='none';renderAll();return}
+  var go=t.closest('[data-goto]');if(go){st.nav=go.dataset.goto;applyNav();window.scrollTo(0,0);return}
+  if(t.closest('[data-fix]')){toast('Fix would reopen this shift on the entry phone (mockup)');return}
+  var v=t.closest('[data-verify]');if(v){var tr=v.closest('tr');tr.classList.remove('flagged');v.remove();tr.querySelector('.flagchip').remove();toast('Entry verified — flag cleared');return}
+  var sch=t.closest('[data-sch]');if(sch){
+    var p=sch.dataset.sch.split(':'),s=STAFF.find(function(x){return x.id===p[0]});
+    var sc=s.sched[p[1]]||(s.sched[p[1]]={});var cur=sc[p[2]]||'';
+    sc[p[2]]=cur.indexOf(p[3])>=0?cur.replace(p[3],''):cur+p[3];
+    renderStaff();return;
+  }
+  var act=t.closest('[data-act]');if(act){
+    var s2=STAFF.find(function(x){return x.id===act.dataset.id});
+    if(act.dataset.act==='deact'){s2.active=false;toast(s2.name+' deactivated — history stays')}
+    else if(act.dataset.act==='react'){s2.active=true;toast(s2.name+' reactivated')}
+    else{toast('Rename (mockup)')}
+    renderStaff();return;
+  }
+  var acc=t.closest('[data-acc]');if(acc){
+    var a=acc.dataset.acc.split(':');
+    if(a[0]==='print'){ACCESS[a[1]].printed=true;renderAccess();renderOverview();toast('Print dialog would open — sticker marked printed')}
+    else if(a[0]==='rotate'){toast('Rotate kills the old sticker immediately — confirm dialog in the real app')}
+    else{toast('All '+LOCS[a[1]]+' phone sessions revoked (mockup)')}
+    return;
+  }
+  var inf=t.closest('.info');
+  if(inf){
+    pop.innerHTML=INFO[inf.dataset.info];
+    pop.style.display='block';
+    var r=inf.getBoundingClientRect();
+    pop.style.left=Math.min(r.left+window.scrollX,window.scrollX+document.documentElement.clientWidth-340)+'px';
+    pop.style.top=(r.bottom+window.scrollY+8)+'px';
+    e.stopPropagation();return;
+  }
+  if(!t.closest('#pop'))pop.style.display='none';
+});
+$('#addForm').addEventListener('submit',function(e){
+  e.preventDefault();
+  var f=e.target,name=f.name.value.trim();if(!name)return;
+  var id=name.toLowerCase().replace(/[^a-z]/g,'')+Math.floor(Math.random()*999);
+  var works=f.works.value,sched={};(works==='both'?['sushi','poki']:[works]).forEach(function(l){sched[l]={}});
+  STAFF.push({id:id,name:name,works:works,active:true,sched:sched});
+  f.reset();renderStaff();toast(name+' added — tick their shifts so the phone pre-selects them');
+});
+
+$('#snToggle').addEventListener('click',function(){
+  var sn=$('#sidenav'),c=sn.classList.toggle('collapsed');
+  this.textContent=c?'›':'‹';
+  this.setAttribute('aria-label',c?'Expand sidebar':'Collapse sidebar');
+});
+$('#logoutBtn').addEventListener('click',function(){toast('Signed out (mockup) — real app returns to the sign-in card')});
+
+renderAll();applyNav();
+</script>
+</body>
+</html>

--- a/docs/mockups/tips-v3/CONTRACT.md
+++ b/docs/mockups/tips-v3/CONTRACT.md
@@ -1,0 +1,158 @@
+# Tips v3 — JSON contract (the seam between frontend and backend)
+
+Status: **DRAFT — pending written agreement from both sides.**
+Frontend owner: Claude (Fable). Backend owner: Codex (Sol).
+Source of truth for product behavior: `HANDOFF-tips-v3.md` + `tips-v3-final.html`.
+Where this file and the repo disagree about an existing data shape, the repo wins
+and the discrepancy gets flagged here before either side builds on it.
+
+## Principles
+
+1. **The client sends what the closer typed; the server does the subtraction.**
+   The server is authoritative — a stale client must never write a figure
+   derived from a lunch amount that has since changed.
+2. Money crosses the wire as decimal dollars (matching the existing payload
+   convention) but is computed in **integer cents** on both sides.
+3. Every new field is optional-with-default so an old client keeps working
+   through the deploy window: `gratuity = 0`, `enteredScope = "shift"`,
+   all weights `1`, `note = null`.
+
+## `tip-entry-auth` → `state` and `tip-entries` → `get_slot`
+
+`today` gains one key:
+
+```ts
+today: {
+  businessDate: string;
+  lunchRecorded: boolean;
+  dinnerRecorded: boolean;
+  defaultMeal: MealPeriod;
+  lunch: { cash: number; card: number; gratuity: number } | null; // NEW
+}
+```
+
+- `lunch` is the recorded lunch row for **this location** and **today's
+  business date**, shift-only figures, decimal dollars.
+- `null` when no lunch is recorded — the client then subtracts nothing and the
+  save gets flagged server-side (silently to the closer).
+- Client reads it defensively (`?? null`) so an older server degrades to
+  "no subtraction available".
+
+## `tip-entries` → `save` request
+
+```ts
+interface SavePayload {
+  meal: MealPeriod;
+  cash: number;          // as typed (decimal dollars)
+  card: number;          // as typed
+  gratuity: number;      // as typed, 0 when blank                      NEW
+  enteredScope: "shift" | "day";                                     // NEW
+  peopleIds: string[];
+  weights: number[];     // positional against peopleIds, each in (0,1] NEW
+  note: string | null;   // trimmed, ≤280 chars, null when empty        NEW
+  entryMethod: "typed" | "voice";
+  voiceVariant: VoiceVariant | null;
+  correctionsCount: number;
+  confirmAnomaly: boolean;
+}
+```
+
+Server-side rules on `save` (backend owner implements, frontend owner relies on):
+
+- `enteredScope === "day"` → subtract today's lunch row **field by field**
+  (cash−cash, card−card, gratuity−gratuity) at the same location. Store the
+  derived figures in `cash_amount`/`card_amount`/`gratuity_amount` and the
+  typed figures in `raw_*`. On `"shift"`, `raw_* = stored`.
+- Missing lunch row on a `"day"` save → subtract nothing, save succeeds
+  normally, set `flagged_anomaly = true`, `anomaly_reason = 'day_total_no_lunch'`.
+  **Silent to the entry device** — the response is an ordinary success.
+- Any derived amount < 0 → `400 { code: "negative_after_lunch" }`.
+- `weights.length !== peopleIds.length`, or any weight outside `(0,1]` →
+  `400 { code: "bad_weights" }`. A missing `weights` key (old client) means all `1`.
+- Missing `gratuity` → 0; missing `enteredScope` → `"shift"`; missing `note` → null.
+- The anomaly check runs on the **derived shift amounts**, never the raw ones.
+  Gratuity is not part of the anomaly rule.
+- Weighted allocation (largest remainder, ties by position) is the canonical
+  math in `web/src/lib/tips/split.ts` / `dayScope.ts`, mirrored into
+  `supabase/functions/_shared/tips.ts` under the existing keep-in-sync
+  comment convention.
+
+## `save` / `get_slot` response — `SlotEntry` gains
+
+```ts
+{
+  // ...existing fields unchanged...
+  gratuity: number;              // derived shift figure
+  enteredScope: "shift" | "day";
+  rawCash: number;
+  rawCard: number;
+  rawGratuity: number;
+  note: string | null;
+  people: { id: string; weight: number }[];  // weight in (0,1]
+}
+```
+
+## Schema (backend owner)
+
+As specified in HANDOFF-tips-v3.md §Schema, verbatim:
+- `tip_entries` + `gratuity_amount`, `entered_scope` ('shift'|'day', default
+  'shift'), `raw_cash_amount`, `raw_card_amount`, `raw_gratuity_amount`,
+  `note` (≤280, trimmed, null when empty), `note_at`.
+- `tip_entry_people` + `share_weight numeric(4,3) not null default 1`,
+  check `(0,1]`.
+- `tip_save_entry`: extend the 13-arg version from
+  `20260811204219_tip_entry_session_duplicate_guard.sql` (drop + recreate,
+  re-issue revoke/grant). New params: `p_gratuity numeric`,
+  `p_entered_scope text`, `p_raw_cash numeric`, `p_raw_card numeric`,
+  `p_raw_gratuity numeric`, `p_note text`, `p_weights numeric[]` (positional
+  against `p_people`, same length or raise).
+- Existing rows backfill to defaults ⇒ behavior identical to today.
+
+## Repo-alignment notes (from the codebase map, 2026-08-27)
+
+Verified against the repo; the repo's existing shapes win. Alignments:
+
+1. **`SlotEntry` keeps `peopleIds: string[]`** (existing field, `api.ts:46-60`
+   and `tip-entries/index.ts` `loadSlot`). The new `people: {id, weight}[]` is
+   **additive**; `peopleIds` stays populated for compatibility. Server derives
+   `peopleIds` = `people.map(p => p.id)` as today.
+2. **Wire money is decimal dollars** — matches existing `cash`/`card`
+   convention in `SavePayload` and `SlotEntry`. Server normalizes via the
+   existing `normalizeAmount()` in `_shared/tips.ts:211` (0 ≤ n < 100000,
+   rounds to cents). Gratuity uses the same normalization.
+3. **`today` extension** lands in `fetchToday()`
+   (`tip-entry-auth/index.ts:65-80`), which today only reads `meal_period`.
+   It must additionally read the lunch row's `cash_amount`, `card_amount`,
+   `gratuity_amount` and surface them as `lunch: {cash, card, gratuity} | null`
+   (decimal dollars). `get_slot` in `tip-entries` returns the same `today`
+   shape — currently it returns only `businessDate`; it gains a `today` object
+   or the `lunch` key alongside (backend owner picks; frontend reads
+   defensively from either `state` or `get_slot`, preferring the freshest).
+   **Decision: `get_slot` response gains `today` with the full shape above**,
+   so a meal switch refreshes the lunch figures without a `state` round-trip.
+4. **Anomaly**: check stays cash/card only (gratuity excluded per the locked
+   decision — no third `field` literal in `anomaly.ts` or its mirror). It runs
+   on the **derived** shift amounts. Stored history is always shift-only
+   figures, so the history series stays consistent.
+5. **`split_count`** stays `array_length(p_people, 1)` — headcount, not
+   weight-sum. Nothing overloads it.
+6. **Error envelope** matches existing style: `{ ok: false, code, error }` with
+   HTTP 400 for `negative_after_lunch` and `bad_weights`; the human `error`
+   strings are the backend owner's choice but must be register-appropriate.
+   The existing `needsConfirm` anomaly flow (status 200) is unchanged and runs
+   on derived amounts *after* the day-scope subtraction and negative check.
+7. **`gratuity_amount` check**: foundation table uses `>= 0` checks on
+   cash/card; the new columns get the same non-negative checks for the stored
+   (derived) figures; `raw_*` are nullable, populated on every new save.
+8. **Trend/totals**: `rangeTotals` and `dailyTrend` remain cash+card only —
+   gratuity is its own bucket and is *not* added to trend or totals (locked:
+   recorded, shown in detail, exported).
+9. **Old-client window**: `tip-entries` `save` currently requires `cash`,
+   `card`, `peopleIds` — new fields are read with defaults exactly as in the
+   rules above, so the currently deployed web build keeps saving unchanged
+   rows (`entered_scope='shift'`, `gratuity=0`, weights all 1, `raw_* = typed`).
+
+## Sign-off
+
+- [ ] Backend (Codex/Sol): agreed, including error codes and defaults.
+- [ ] Frontend (Claude/Fable): agreed.

--- a/docs/mockups/tips-v3/CONTRACT.md
+++ b/docs/mockups/tips-v3/CONTRACT.md
@@ -1,6 +1,7 @@
 # Tips v3 — JSON contract (the seam between frontend and backend)
 
-Status: **DRAFT — pending written agreement from both sides.**
+Status: **AGREED** (Sol: yes-with-amendments, both folded in below;
+Fable: agreed. 2026-08-27.)
 Frontend owner: Claude (Fable). Backend owner: Codex (Sol).
 Source of truth for product behavior: `HANDOFF-tips-v3.md` + `tips-v3-final.html`.
 Where this file and the repo disagree about an existing data shape, the repo wins
@@ -152,7 +153,29 @@ Verified against the repo; the repo's existing shapes win. Alignments:
    rules above, so the currently deployed web build keeps saving unchanged
    rows (`entered_scope='shift'`, `gratuity=0`, weights all 1, `raw_* = typed`).
 
+## Agreed amendments (Sol's review, 2026-08-27)
+
+1. **The 13-arg `tip_save_entry` stays as a compatibility wrapper.** The
+   migration creates the new extended function AND recreates the 13-arg
+   signature as a service-role wrapper that delegates with v3 defaults
+   (gratuity 0, scope 'shift', raw_* = typed, unit weights, no note) — the
+   currently deployed edge function keeps working until the functions deploy.
+   Both signatures get the revoke/grant treatment. The wrapper can be dropped
+   in a later cleanup migration once the functions are live.
+2. **Anomaly precedence on a no-lunch day save.** The `needsConfirm`
+   round-trip comes ONLY from the statistical outlier check (on derived
+   amounts) — the missing-lunch condition never prompts the closer. When both
+   conditions hold, the saved row has `flagged_anomaly = true` and
+   `anomaly_reason = 'day_total_no_lunch; ' + <statistical reason>` — the
+   `day_total_no_lunch` token always first so the dashboard's flag detection
+   can match on prefix. When only the lunch is missing, the reason is exactly
+   `day_total_no_lunch`.
+3. **Weights stay positional through server-side filtering.** The server
+   filters/dedupes `peopleIds` (UUID regex, dedupe) — the `weights` array
+   must be filtered in lockstep BEFORE any of that reshaping, so index i
+   always refers to the same person.
+
 ## Sign-off
 
-- [ ] Backend (Codex/Sol): agreed, including error codes and defaults.
-- [ ] Frontend (Claude/Fable): agreed.
+- [x] Backend (Codex/Sol): agreed with amendments 1–3 above.
+- [x] Frontend (Claude/Fable): agreed, including amendments 1–3.

--- a/docs/mockups/tips-v3/HANDOFF-tips-v3.md
+++ b/docs/mockups/tips-v3/HANDOFF-tips-v3.md
@@ -1,0 +1,412 @@
+# Handoff — Tips v3: gratuity, day-scope, partial shares, notes
+
+You are implementing a finalized, approved design. **Do not redesign, do not
+widen the scope, do not add features beyond this document.** Where this
+document and the repo disagree about a *data shape*, the repo wins and you
+flag it. Where they disagree about *product behavior*, this document and the
+mockup win.
+
+## The one artifact that is the truth
+
+`docs/mockups/tips-v3/tips-v3-final.html` — **open it in a browser and click
+through every state before writing a line of code.** It is live: the amounts
+recalculate, the badges cycle, the note attaches, the ledger rows unfold.
+Every number it prints is the number your build must print.
+
+`docs/mockups/tips-v3/tips-v3-proposals.html` is the rejected-options archive.
+**Do not build anything from it.** The four chosen options are A1, B1, C1, D2
+and they are already merged into the final file.
+
+Use the top-bar **lunch today** switch in the final mockup to see the
+edge-case states (no lunch on record; subtraction going negative).
+
+## Revision — read this first
+
+The mockup was revised after the first review. If you have seen an earlier
+version of this document or that file, re-read both. What changed:
+the field is called **Gratuity** (never "auto-grat"), it is **not** tinted
+green or anything else, all three amounts got an **underline** marking them
+editable, the "These numbers are" label is **gone**, the no-lunch warning is
+**no longer shown to the closer**, the note button says **Save**, and the
+confirmation screen now **holds 10 seconds and returns to the scan gate**.
+
+## What is being added
+
+1. **Gratuity** — a third amount on the entry screen next to Cash and Card.
+2. **Day-scope switch** — dinner can say "this Square number is the whole day",
+   and the app subtracts what lunch already recorded.
+3. **Partial shares** — a percentage badge per person on the split (100/75/50/25).
+4. **Note** — one optional free-text note per entry.
+5. **Recorded tips** — rows unfold to show all of the above.
+
+## Locked decisions — do not revisit
+
+- **No 18%-of-subtotal calculator.** The closer types the gratuity amount or
+  leaves the well blank. Blank means `0`.
+- **The field is called “Gratuity.”** Not "auto-grat", not "auto-gratuity", in
+  the UI, the copy, or the CSV header. Column and payload names use
+  `gratuity` to match.
+- **Gratuity is its own bucket.** It is not added to `card_amount`, and it is
+  **not** part of the cash pool that gets split. It is recorded, shown in the
+  detail panel, and exported. (See "Confirm with David" #1.)
+- **No tint on the gratuity well.** Cash, Card and Gratuity are visually
+  identical. Do not add a color token for it — the earlier green is gone.
+- **All three amounts get a rule under the value**, accent-red on focus. This
+  is the only cue that they are typeable, so it ships with the feature rather
+  than as polish. Note that `AmountWell` is shared with the voice sheet's
+  inline editors — the underline will appear there too, which is correct.
+- **The scope switch carries no label above it** and appears on dinner only,
+  defaulting to **Whole day**.
+  Lunch has no switch and always records what was typed.
+- **Subtraction is field by field** — cash−cash, card−card, grat−grat — against
+  today's recorded **lunch** row at the **same location**.
+- **Shares are weighted, not capped.** Full share = `pool ÷ Σweights`. One
+  person at 50% makes everyone else *larger*, not the pool smaller. Nothing is
+  left in the drawer beyond sub-cent rounding. (See "Confirm with David" #2.)
+- **The per-person list only renders when at least one weight is under 100%.**
+  An all-full split shows only the strip: `Split N ways · $41.00 each`.
+- **Weights apply to the cash pool only.** Card → payroll is untouched by them.
+- **Voice entry is out of scope this phase.** "Speak it in" keeps filling
+  cash / card / people exactly as it does today; the new fields stay typed. Do
+  not change `tip-voice-parse`, `tip-voice-stream`, `voiceSchema.ts`, or
+  `localVoiceParse.ts`.
+- Visual language is unchanged: cream `#f5f5f4` page, white cards, accent
+  `#e84d38`, existing tokens in `web/src/app/globals.css`. Add **no** new color tokens. The dark top bar and the "lunch today" switch in the mockup are
+  mockup-only chrome — do not build them.
+
+## Confirm with David before the migration lands
+
+These are stated as assumptions so you are not blocked. Ask once, early, in one
+message; build on the defaults meanwhile.
+
+1. **Is the 18% already inside the Card number Square reports?** Default
+   assumed: **no** — it arrives separately and is entered separately, so
+   `cash + card + auto_grat` is the entry total with no double count. If it is
+   actually inside the card figure, `gratuity_amount` becomes a carve-out that
+   must be *excluded* from every total that already counts card.
+2. **Reflow vs fixed cut** — default assumed **reflow** (weighted, as above and
+   as the mockup shows). The alternative is a full share fixed at
+   `pool ÷ heads` with the difference staying in the drawer.
+3. **Who may set a partial share** — default assumed **the closer, at entry**
+   (that is what the mockup does), with the manager able to change it in Fix.
+4. **A missing lunch on a whole-day dinner** — **decided: say nothing to the
+   closer.** No banner and no extra tap; the entry saves flagged for the
+   manager. Nothing at the register can fix it, so it is not the closer's
+   problem to read. The *only* warning the entry screen ever shows is the
+   blocking negative-amount one.
+
+## Division of work
+
+The seam is the **JSON contract** in the section below. Agree on it in writing
+before either side starts, then work in parallel.
+
+### Codex — backend
+
+- `supabase/migrations/<timestamp>_tips_v3_grat_scope_weights_notes.sql`
+- `supabase/functions/tip-entries/index.ts` (`save`, `get_slot`)
+- `supabase/functions/tip-entry-auth/index.ts` (`state`)
+- `supabase/functions/_shared/tips.ts` (mirror of the pure helpers)
+- RLS for the manager's direct-update path (the Fix dialog writes
+  `tip_entries` / `tip_entry_people` under RLS, not through the RPC)
+- Regenerating `web/src/types/database.ts`
+
+### Claude — frontend
+
+- `web/src/lib/tips/split.ts`, new `web/src/lib/tips/dayScope.ts` — the
+  **canonical** pure math plus its vitest coverage. Codex mirrors these into
+  `_shared/tips.ts`; the "keep both in sync" comment convention already used
+  for `anomaly.ts` / `businessDate.ts` applies here too.
+- `web/src/lib/tips/api.ts` — payload and state types
+- `web/src/components/entry/` — `EntryForm.tsx`, `RosterChips.tsx`,
+  `SplitStrip.tsx`, plus new `ScopeSwitch.tsx`, `PayoutList.tsx`, `NoteField.tsx`
+- `web/src/components/manager/dashboard/LedgerPage.tsx` — D2 rows, detail
+  panel, and the extended Fix dialog
+- `web/src/lib/tips/dashboardDerive.ts`, `dashboardCsv.ts`
+- vitest units + the playwright e2e additions
+
+Neither side edits the other's files. If you believe you must, say so and get
+agreement first.
+
+## Schema
+
+```sql
+alter table public.tip_entries
+  add column gratuity_amount   numeric(10,2) not null default 0,
+  add column entered_scope      text not null default 'shift'
+      check (entered_scope in ('shift','day')),
+  add column raw_cash_amount    numeric(10,2),
+  add column raw_card_amount    numeric(10,2),
+  add column raw_gratuity_amount numeric(10,2),
+  add column note               text,
+  add column note_at            timestamptz;
+
+alter table public.tip_entry_people
+  add column share_weight numeric(4,3) not null default 1
+      check (share_weight > 0 and share_weight <= 1);
+```
+
+- `raw_*` is **always** populated with what the closer typed. On
+  `entered_scope = 'shift'` they equal the stored amounts; on `'day'` they are
+  the pre-subtraction figures. The dashboard shows its work from these.
+- `cash_amount` / `card_amount` / `gratuity_amount` are **always** the
+  shift-only figures. Nothing downstream needs to know about scope to be right.
+- `note` ≤ 280 characters, trimmed, `null` when empty. `note_at` set whenever
+  the note text changes. The note's author is displayed from `entered_by`.
+- `share_weight` is one of `1, 0.75, 0.5, 0.25` today; the column allows any
+  value in `(0,1]` so a future custom percentage does not need a migration.
+- `split_count` stays as-is (the count of people). Do not overload it.
+- Every existing row backfills to the defaults, which reproduces exactly
+  today's behavior — verify that on a branch before merging.
+
+`tip_save_entry` changed signature, so it must be dropped and recreated. The
+**current** definition is in `20260811204219_tip_entry_session_duplicate_guard.sql`
+(the 13-arg version with `p_session_id`) — extend that one, not the original in
+the foundation migration, and re-issue the `revoke`/`grant` lines for the new
+signature. New parameters: `p_gratuity numeric`, `p_entered_scope text`,
+`p_raw_cash numeric`, `p_raw_card numeric`, `p_raw_gratuity numeric`,
+`p_note text`, `p_weights numeric[]`. `p_weights` is positional against
+`p_people` and must be the same length; raise if it is not.
+
+## The JSON contract
+
+**The client sends what the closer typed; the server does the subtraction.**
+The server is authoritative — a stale client must never be able to write a
+figure derived from a lunch amount that has since changed.
+
+`tip-entry-auth` → `state`, and `tip-entries` → `get_slot`, both gain today's
+recorded lunch on `today`:
+
+```ts
+today: {
+  businessDate: string;
+  lunchRecorded: boolean;
+  dinnerRecorded: boolean;
+  defaultMeal: MealPeriod;
+  lunch: { cash: number; card: number; gratuity: number } | null; // NEW
+}
+```
+
+`lunch` is `null` when nothing is recorded — that is the case that drives the
+amber warning and the flag. Read it defensively on the client (`?? null`) so an
+older server degrades to "no subtraction available".
+
+`tip-entries` → `save` payload gains:
+
+```ts
+interface SavePayload {
+  meal: MealPeriod;
+  cash: number;          // as typed
+  card: number;          // as typed
+  gratuity: number;      // as typed, 0 when blank        NEW
+  enteredScope: "shift" | "day";                       // NEW
+  peopleIds: string[];
+  weights: number[];     // positional against peopleIds  NEW
+  note: string | null;                                  // NEW
+  entryMethod: "typed" | "voice";
+  voiceVariant: VoiceVariant | null;
+  correctionsCount: number;
+  confirmAnomaly: boolean;
+}
+```
+
+Server-side rules on `save`:
+
+- `enteredScope === "day"` → subtract today's lunch row field by field. Missing
+  lunch row → subtract nothing, set `flagged_anomaly = true` and
+  `anomaly_reason = 'day_total_no_lunch'`. **This flag is silent to the entry
+  device** — the save succeeds normally and the closer sees the ordinary
+  confirmation. It surfaces only in Recorded tips.
+- Any derived amount `< 0` → reject `400` with
+  `{ code: "negative_after_lunch" }`. The client disables Save on this state,
+  but the server must not depend on that.
+- `weights` must be the same length as `peopleIds`, each in `(0,1]`, else `400`
+  `{ code: "bad_weights" }`. A missing `weights` array (old client) means all
+  `1`.
+- **The anomaly check runs on the DERIVED shift amounts**, never the raw ones —
+  otherwise every whole-day dinner looks like an outlier. Gratuity is not part
+  of the anomaly rule.
+- Absent new fields default to today's behavior: `gratuity = 0`,
+  `enteredScope = "shift"`, all weights `1`, `note = null`. An old client must
+  keep working through the deploy window.
+- `SlotEntry` in the response gains `gratuity`, `enteredScope`, `rawCash`,
+  `rawCard`, `rawGratuity`, `note`, and `people: {id, weight}[]`.
+
+## The math — canonical, with test vectors
+
+Money is integer cents everywhere. Never accumulate in floats.
+
+**Day scope.** `derived = typed − lunch[field]`, per field, only when
+`scope === 'day'` and a lunch row exists.
+
+**Allocation — largest remainder.** The shares must sum to the pool *exactly*.
+
+```
+raw_i   = poolCents × w_i / Σw
+base_i  = floor(raw_i)
+rest    = poolCents − Σ base_i
+```
+
+Distribute `rest` one cent at a time to the largest fractional parts, ties
+broken by the person's position in the split. This replaces
+`cashShareCents(cash, splitCount)` for weighted entries. Half-up rounding is
+**wrong** here — it can pay out more than the pool.
+
+Required test vectors (these are exactly what the mockup prints):
+
+| Pool | Weights | Result |
+|---|---|---|
+| $205.00 | 1, 1, 1, 1, 0.5 | 45.56, 45.56, 45.55, 45.55, **22.78** — sums to 205.00 |
+| $205.00 | 1, 1, 1, 1, 1 | 41.00 × 5 |
+| $205.00 | 1, 1, 0.75, 1, 1 | full share $43.16; Priya $32.37 |
+| $822.00 | 1, 0.25 | 657.60, 164.40 |
+| $118.00 | 1, 1, 1 | 39.33, 39.33, **39.34** |
+
+Invariants to assert as properties, not just examples: the shares always sum to
+the pool; no share is negative; a pool of 0 gives all zeros; one person takes
+everything; 30 people at mixed weights still sums exactly.
+
+## Frontend behavior — exact
+
+Read these against the mockup; the mockup wins on anything ambiguous.
+
+**Entry screen, top to bottom:** header · location · Lunch|Dinner segmented ·
+amounts card · roster card · per-person card (conditional) · split strip ·
+note line · sticky bar.
+
+- **Amounts card**: the scope segmented (`Whole day (Square)` / `Dinner only`)
+  with **no label above it**, then a **three-column** grid of Cash · Card ·
+  Gratuity. All three are the same `AmountWell` with the same neutral `--well`
+  background — no tint on any of them. Gratuity's placeholder is `0.00`.
+  Helper line: *"Leave gratuity blank on a night with no large parties."*
+- **Editable affordance**: `AmountWell` gains a `1.5px` bottom rule under the
+  `$ 000.00` line in `--color-disabled`, switching to `--color-accent` on
+  focus-within, with `caret-color` accent. Read-only renderings of the same
+  well (the saved screen) must **not** have the rule.
+- **Receipt** under the wells: `Entered (whole day)` → `− Lunch already
+  recorded` → `Dinner records`. The lunch line is hidden on `Dinner only`, and
+  the first label switches to `Entered (dinner only)`.
+- **Warnings**: exactly one. Any derived field negative → red banner **and
+  `Save` disabled**. There is no amber state and no no-lunch banner.
+- **Roster chips**: selected chips carry a `%` badge. Tapping the badge cycles
+  `100 → 75 → 50 → 25 → 100`; tapping the chip body still toggles selection.
+  The badge must be its own hit target — do not let a badge tap deselect the
+  person. Give it a real touch target (≥ 28px) even though it renders small.
+- **Per-person card**: renders **only** when some weight < 1. Title
+  `What each person takes`; a row per selected person, `NN% share` caption on
+  reduced ones, dollars right-aligned and tabular.
+- **Split strip**: `Split N ways` + `$X each` when even; `Full share` + `$X`
+  when uneven. Right side is always `of $Y cash`.
+- **Note**: dashed `+ Add a note` → textarea (280 cap, live `n / 280` counter)
+  → `Cancel` / **`Save`** (not "Attach"). Saving empty text collapses back to
+  the dashed button. Saved shows a one-line truncated preview with `edit`.
+- **Saved screen**: the same three wells as the entry form — Cash · Card ·
+  Gratuity, same grid, same type scale, same labels — but read-only, so
+  **without** the editable underline. Below them `full share $X` plus each
+  reduced person's dollars, the names, and the note if present.
+- **Saved screen timing**: it now holds **10 seconds**, not 4 —
+  `SAVED_SCREEN_MS` in `EntryForm.tsx` goes `4000 → 10000`. Show a countdown
+  ("Back to the scan screen in 10s") over a thin progress bar that drains, so
+  the wait is legible rather than a hang. `Done` still skips it. At zero it
+  runs the existing `finishSession()` path — end the session, return to the
+  scan gate at `/`. Do not build a new scan screen; that route already exists
+  ("Scan to enter" / "Every entry starts with the QR code by the register").
+  The mockup reproduces it only so you can see where the phone lands.
+
+**Recorded tips (D2):**
+
+- Existing columns keep their existing order, widths and tints. Two additions
+  only: a caret cell at the left, a note/action cell at the right.
+- Cash cell gains a `day −lunch` badge when `entered_scope = 'day'`, with the
+  raw figure in its `title`.
+- "Split between" shows `N names` plus a `1 partial` mark when any weight < 1.
+  "Per person" shows the full share with a `full share` caption — never a
+  misleading average.
+- Clicking a row unfolds three cards: **how this number was reached** (raw →
+  −lunch → recorded, then card and gratuity), **who takes what** (name,
+  weight, dollars, plus a Pool row that must equal the cash pool), and
+  **note** (author + time, or "No note on this entry.").
+- A flagged row auto-opens its detail when the range first loads.
+- The **Fix dialog** gains gratuity, the scope switch, per-person weights and
+  the note. It writes under RLS, not through `tip_save_entry` — keep the
+  existing ordering (add people → update amounts → remove people) so no
+  intermediate state is unrecoverable, and write weights with the people.
+- **No gratuity column** on the table itself.
+- `dashboardDerive.takeHomeByPerson` and the Overview ranking must use the
+  weighted allocation. Leaving them on `cash ÷ split_count` is a silent
+  money bug — treat it as part of this change, not a follow-up.
+- CSV gains `Gratuity`, `Entered scope`, `Raw cash`, `Raw card`, `Note`, and a
+  per-person weight; existing columns keep their position so old sheets do not
+  break.
+
+## Review protocol
+
+1. Agree the JSON contract in writing. Nothing else starts before that.
+2. Build in parallel. Each side runs its own checks green before handing over.
+3. **Cross-review.** Codex reviews the frontend diff; Claude reviews the
+   backend diff. Review against *this document and the mockup*, not against
+   taste. Each finding gets: file:line, what breaks, and the concrete input
+   that breaks it. Specifically hunt for:
+   - a number the UI shows that the server would not store
+   - float money anywhere
+   - shares that do not sum to the pool
+   - the anomaly check running on raw instead of derived amounts
+   - an old client, or an existing row, behaving differently than before
+   - `takeHomeByPerson` / CSV / Overview still assuming equal splits
+4. Fix, then re-review until both sides sign off with nothing outstanding.
+5. Only then run the joint verification below.
+6. If the two of you disagree twice on the same point, stop and ask David
+   rather than trading opinions a third time.
+
+## Verification — all of it must pass
+
+```bash
+cd web && npm run typecheck && npm run lint && npm run test
+```
+
+New unit coverage (vitest, in `web/src/lib/tips/__tests__/`):
+- `split.test.ts` — every vector and invariant in the math section
+- `dayScope.test.ts` — day vs shift, missing lunch, negative, zero
+- `dashboardDerive.test.ts` — weighted take-home, mixed weights across a range
+- `dashboardCsv.test.ts` — new columns, quoting, column order
+
+E2E (playwright, alongside `web/e2e/entry.spec.ts`):
+- dinner entered as a whole day → receipt shows the subtraction → saved entry
+  holds the derived amounts and the raw ones
+- badge cycling changes the dollars and the per-person card appears
+- all-100% split → per-person card absent, strip reads `Split N ways`
+- note saved → survives a save → visible in Recorded tips
+- no-lunch whole-day dinner → saves flagged **with no warning shown on the
+  entry screen**
+- saved screen holds ~10s, counts down, then lands on the scan gate; `Done`
+  short-circuits it
+
+Backend: apply the migration to a Supabase **branch**, not production. Prove
+(a) existing rows still read identically, (b) the RPC rejects mismatched
+weights, (c) a `day` save with no lunch flags rather than fails, (d) a negative
+derived amount is refused, (e) the manager Fix path can write weights under
+RLS and a non-manager cannot.
+
+Manual pass, side by side with the mockup at the same viewport: every state in
+the "lunch today" switch, the four badge values, empty gratuity, a 1-person
+split, and an 8-person split.
+
+## Branch, PR, deploy
+
+- `git fetch origin` then branch off **`origin/main`** (local `main` is behind).
+  One branch for both of you: `feat/tips-v3`. Do not push to `main`; open one PR.
+- Deploy order is **migration → edge functions → web**. The backend is
+  backward compatible by design, so the window where old clients are live is
+  safe; the reverse order is not.
+- Production: Supabase `whrohvitvmcrmedepurd`, Vercel project
+  `inventory-system` (root `web`), serving tips.smelterpos.com and
+  dashboard.smelterpos.com.
+
+## Done means
+
+- Every state in `tips-v3-final.html` reproduced in the real app, including the
+  numbers to the cent.
+- Typecheck, lint, unit and e2e green.
+- Both reviews signed off with nothing outstanding.
+- One PR, with a description that lists what changed and what David still has
+  to confirm from the four questions above.
+- Nothing from the rejected options file built. Voice untouched.

--- a/docs/mockups/tips-v3/tips-v3-api-harness.zsh
+++ b/docs/mockups/tips-v3/tips-v3-api-harness.zsh
@@ -1,0 +1,1858 @@
+#!/usr/bin/env zsh
+# Tips v3 black-box API harness (12 checks: functional round-trips, exact
+# persistence read-backs, old-client compatibility, cross-location isolation,
+# REST/RLS lockdown, session-token abuse, response leak scan, rate limiting).
+#
+# Authored by Codex/Luna, corrected and run by Claude against the throwaway
+# Supabase branch `tips-v3-verify` (12/12 pass, no leakage). It is checked in
+# so the suite can be re-pointed at a future verification branch.
+#
+# NEVER point this at production: it writes tip entries and deliberately trips
+# the auth rate limiter. Replace the URLs/keys/tokens below with a disposable
+# branch's values before running.
+#
+# Check 12 deliberately trips the auth rate limiter, which blocks token
+# validation for ~10 minutes. Before re-running, either wait it out or clear
+# the ledger on the branch: delete from public.tip_auth_attempts;
+#
+# Required env: TIPS_V3_FUNCTIONS_BASE, TIPS_V3_REST_BASE, TIPS_V3_ANON_KEY,
+# TIPS_V3_SUSHI_TOKEN, TIPS_V3_POKI_TOKEN.
+setopt NO_NOMATCH
+setopt PIPE_FAIL
+set -u
+
+FUNCTIONS_BASE="${TIPS_V3_FUNCTIONS_BASE:?e.g. https://<branch-ref>.supabase.co/functions/v1}"
+REST_BASE="${TIPS_V3_REST_BASE:?e.g. https://<branch-ref>.supabase.co/rest/v1}"
+AUTH_URL="${FUNCTIONS_BASE}/tip-entry-auth"
+ENTRIES_URL="${FUNCTIONS_BASE}/tip-entries"
+
+ANON_KEY="${TIPS_V3_ANON_KEY:?set to the verification branch anon key}"
+SUSHI_ENTRY_TOKEN="${TIPS_V3_SUSHI_TOKEN:?seeded sushi entry token}"
+POKI_ENTRY_TOKEN="${TIPS_V3_POKI_TOKEN:?seeded poki entry token}"
+
+WORK_DIR="$(mktemp -d /tmp/tips-v3-e2e.XXXXXX)" || exit 1
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+typeset -A STATUS BODYFILE ERRFILE
+typeset -a REQUESTS LEAK_FINDINGS
+REQUESTS=()
+LEAK_FINDINGS=()
+LEAK_COUNT=0
+
+body_excerpt() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+try:
+    raw = open(sys.argv[1], "rb").read()
+except Exception:
+    raw = b""
+
+if not raw:
+    out = "<empty>"
+else:
+    text = raw.decode("utf-8", "replace")
+    try:
+        out = json.dumps(json.loads(text), ensure_ascii=False, separators=(",", ":"))
+    except Exception:
+        out = text.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+
+if len(out) > 700:
+    out = out[:700] + "..."
+print(out)
+PY
+}
+
+request_post() {
+  local label="$1"
+  local url="$2"
+  local payload="$3"
+  local body="$WORK_DIR/${label}.body"
+  local status_file="$WORK_DIR/${label}.status"
+  local err="$WORK_DIR/${label}.err"
+  local http_status
+  local excerpt
+  local err_excerpt
+  local curl_rc
+
+  REQUESTS+=("$label")
+  : > "$body"
+  : > "$status_file"
+  : > "$err"
+
+  curl -sS --connect-timeout 15 --max-time 60 \
+    -X POST "$url" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: Bearer ${ANON_KEY}" \
+    -H "apikey: ${ANON_KEY}" \
+    --data-raw "$payload" \
+    -o "$body" \
+    -w '%{http_code}' \
+    > "$status_file" 2> "$err"
+  curl_rc=$?
+
+  http_status="$(<"$status_file")"
+  [[ -z "$http_status" ]] && http_status='000'
+
+  STATUS[$label]="$http_status"
+  BODYFILE[$label]="$body"
+  ERRFILE[$label]="$err"
+
+  excerpt="$(body_excerpt "$body")"
+  err_excerpt="$(body_excerpt "$err")"
+
+  if [[ "$curl_rc" -eq 0 ]]; then
+    print -r -- "HTTP ${label} status=${http_status} body=${excerpt}"
+  else
+    print -r -- "HTTP ${label} status=${http_status} body=${excerpt} curl_rc=${curl_rc} error=${err_excerpt}"
+  fi
+}
+
+request_get() {
+  local label="$1"
+  local url="$2"
+  local body="$WORK_DIR/${label}.body"
+  local status_file="$WORK_DIR/${label}.status"
+  local err="$WORK_DIR/${label}.err"
+  local http_status
+  local excerpt
+  local err_excerpt
+  local curl_rc
+
+  REQUESTS+=("$label")
+  : > "$body"
+  : > "$status_file"
+  : > "$err"
+
+  curl -sS --connect-timeout 15 --max-time 60 \
+    -X GET "$url" \
+    -H "Authorization: Bearer ${ANON_KEY}" \
+    -H "apikey: ${ANON_KEY}" \
+    -o "$body" \
+    -w '%{http_code}' \
+    > "$status_file" 2> "$err"
+  curl_rc=$?
+
+  http_status="$(<"$status_file")"
+  [[ -z "$http_status" ]] && http_status='000'
+
+  STATUS[$label]="$http_status"
+  BODYFILE[$label]="$body"
+  ERRFILE[$label]="$err"
+
+  excerpt="$(body_excerpt "$body")"
+  err_excerpt="$(body_excerpt "$err")"
+
+  if [[ "$curl_rc" -eq 0 ]]; then
+    print -r -- "HTTP ${label} status=${http_status} body=${excerpt}"
+  else
+    print -r -- "HTTP ${label} status=${http_status} body=${excerpt} curl_rc=${curl_rc} error=${err_excerpt}"
+  fi
+}
+
+status_of() {
+  local label="$1"
+  local value="${STATUS[$label]-000}"
+  [[ -z "$value" ]] && value='000'
+  print -r -- "$value"
+}
+
+response_code() {
+  python3 - "${BODYFILE[$1]}" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+
+code = None
+if isinstance(obj, dict):
+    code = obj.get("code") or obj.get("errorCode")
+    err = obj.get("error")
+    if isinstance(err, dict):
+        code = code or err.get("code") or err.get("errorCode")
+
+if code is not None:
+    print(str(code))
+PY
+}
+
+describe() {
+  local label="$1"
+  local code
+  code="$(response_code "$label" 2>/dev/null || true)"
+  print -r -- "${label}[status=$(status_of "$label"),code=${code:-none}]"
+}
+
+json_extract() {
+  local label="$1"
+  local json_path="$2"
+
+  python3 - "${BODYFILE[$label]}" "$json_path" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+
+cur = obj
+for part in sys.argv[2].split("."):
+    if not isinstance(cur, dict) or part not in cur:
+        sys.exit(1)
+    cur = cur[part]
+
+if cur is None:
+    sys.exit(1)
+
+if isinstance(cur, (dict, list)):
+    print(json.dumps(cur, ensure_ascii=False, separators=(",", ":")))
+elif isinstance(cur, bool):
+    print("true" if cur else "false")
+else:
+    print(str(cur))
+PY
+}
+
+make_validate_payload() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+print(json.dumps({"action": "validate_token", "token": sys.argv[1]}, separators=(",", ":")))
+PY
+}
+
+make_session_payload() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+print(json.dumps({"action": sys.argv[1], "sessionToken": sys.argv[2]}, separators=(",", ":")))
+PY
+}
+
+make_set_closer_payload() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+print(json.dumps({
+    "action": "set_closer",
+    "sessionToken": sys.argv[1],
+    "closerId": sys.argv[2],
+}, separators=(",", ":")))
+PY
+}
+
+make_get_slot_payload() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+print(json.dumps({
+    "action": "get_slot",
+    "sessionToken": sys.argv[1],
+    "meal": sys.argv[2],
+}, separators=(",", ":")))
+PY
+}
+
+make_save_payload() {
+  python3 - "$@" <<'PY'
+import json
+import re
+import sys
+
+(
+    session,
+    meal,
+    cash,
+    card,
+    gratuity,
+    scope,
+    ids_text,
+    weights_text,
+    note,
+    include_v3,
+    extra_text,
+) = sys.argv[1:]
+
+ids = json.loads(ids_text)
+weights = json.loads(weights_text)
+extra = json.loads(extra_text)
+
+payload = {
+    "action": "save",
+    "sessionToken": session,
+    "meal": meal,
+    "cash": "__CASH__",
+    "card": "__CARD__",
+    "peopleIds": ids,
+    "entryMethod": "typed",
+    "voiceVariant": None,
+    "correctionsCount": 0,
+    "confirmAnomaly": False,
+}
+
+if include_v3 == "1":
+    payload.update({
+        "gratuity": "__GRATUITY__",
+        "enteredScope": scope,
+        "weights": weights,
+        "note": None if note == "__NULL_NOTE__" else note,
+    })
+
+payload.update(extra)
+text = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+number_re = r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?"
+for marker, value in (
+    ("__CASH__", cash),
+    ("__CARD__", card),
+    ("__GRATUITY__", gratuity),
+):
+    if not re.fullmatch(number_re, value):
+        raise SystemExit("invalid numeric argument")
+    text = text.replace(json.dumps(marker), value)
+
+print(text)
+PY
+}
+
+roster_ids_json() {
+  python3 - "${BODYFILE[$1]}" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    print("[]")
+    raise SystemExit
+
+roster = obj.get("roster", []) if isinstance(obj, dict) else []
+scheduled = []
+other = []
+
+for row in roster:
+    if not isinstance(row, dict):
+        continue
+    ident = row.get("id")
+    if not isinstance(ident, str) or not ident:
+        continue
+    if row.get("scheduled") is True:
+        scheduled.append(ident)
+    elif ident not in other:
+        other.append(ident)
+
+ids = scheduled + [x for x in other if x not in scheduled]
+print(json.dumps(ids[:3], separators=(",", ":")))
+PY
+}
+
+id_at() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+try:
+    ids = json.loads(sys.argv[1])
+except Exception:
+    ids = []
+
+index = int(sys.argv[2])
+if index < len(ids):
+    print(str(ids[index]))
+else:
+    print("__missing_id_%d__" % (index + 1))
+PY
+}
+
+ids_prefix() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+try:
+    ids = json.loads(sys.argv[1])
+except Exception:
+    ids = []
+
+count = int(sys.argv[2])
+print(json.dumps(ids[:count], separators=(",", ":")))
+PY
+}
+
+weights_for_ids() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+try:
+    ids = json.loads(sys.argv[1])
+except Exception:
+    ids = []
+
+print(json.dumps([1] * len(ids), separators=(",", ":")))
+PY
+}
+
+json_ids_pair() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+print(json.dumps([sys.argv[1], sys.argv[2]], separators=(",", ":")))
+PY
+}
+
+decimal_sub() {
+  python3 - "$1" "$2" <<'PY'
+from decimal import Decimal
+import sys
+print(format(Decimal(sys.argv[1]) - Decimal(sys.argv[2]), "f"))
+PY
+}
+
+status_at_least() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+try:
+    ok = int(sys.argv[1]) >= int(sys.argv[2])
+except Exception:
+    ok = False
+raise SystemExit(0 if ok else 1)
+PY
+}
+
+assert_ping() {
+  local label="$1"
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+  python3 - "${BODYFILE[$label]}" <<'PY'
+import json
+import sys
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+raise SystemExit(0 if isinstance(obj, dict) else 1)
+PY
+}
+
+assert_validate() {
+  local label="$1"
+  local expected_location="$2"
+
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" "$expected_location" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+expected = sys.argv[2].lower()
+if not isinstance(obj, dict):
+    raise SystemExit(1)
+
+loc = obj.get("location")
+loc_name = loc.get("name", "") if isinstance(loc, dict) else loc
+if expected not in str(loc_name).strip().lower():
+    raise SystemExit(1)
+
+if not isinstance(obj.get("sessionToken"), str) or not obj["sessionToken"]:
+    raise SystemExit(1)
+
+roster = obj.get("roster")
+if not isinstance(roster, list) or not roster:
+    raise SystemExit(1)
+
+for row in roster:
+    if not isinstance(row, dict):
+        raise SystemExit(1)
+    if not isinstance(row.get("id"), str) or not row.get("id"):
+        raise SystemExit(1)
+    if not isinstance(row.get("name"), str) or not row.get("name"):
+        raise SystemExit(1)
+    if "scheduled" not in row:
+        raise SystemExit(1)
+
+today = obj.get("today")
+if not isinstance(today, dict):
+    raise SystemExit(1)
+
+for key in ("businessDate", "lunchRecorded", "dinnerRecorded", "defaultMeal", "lunch"):
+    if key not in today:
+        raise SystemExit(1)
+
+if "closer" not in obj:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_state() {
+  local label="$1"
+  local expected_location="$2"
+
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" "$expected_location" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(obj, dict):
+    raise SystemExit(1)
+
+if "error" in obj:
+    raise SystemExit(1)
+
+expected = sys.argv[2].lower()
+loc2 = obj.get("location")
+loc2_name = loc2.get("name", "") if isinstance(loc2, dict) else loc2
+if "location" in obj and expected not in str(loc2_name).strip().lower():
+    raise SystemExit(1)
+
+if "roster" in obj and not isinstance(obj["roster"], list):
+    raise SystemExit(1)
+
+if "today" in obj and not isinstance(obj["today"], dict):
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_set_closer() {
+  local label="$1"
+  local closer_id="$2"
+
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" "$closer_id" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(obj, dict):
+    raise SystemExit(1)
+
+if obj.get("ok") is False:
+    raise SystemExit(1)
+
+closer = obj.get("closer")
+if isinstance(closer, dict) and "id" in closer and str(closer["id"]) != sys.argv[2]:
+    raise SystemExit(1)
+if isinstance(closer, str) and closer != sys.argv[2]:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_ticket() {
+  local label="$1"
+
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(obj, dict):
+    raise SystemExit(1)
+
+ticket = obj.get("ticket") or obj.get("voiceTicket") or obj.get("voice_ticket")
+if not isinstance(ticket, str) or not ticket:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_end() {
+  local label="$1"
+  local http_status
+  http_status="$(status_of "$label")"
+
+  [[ "$http_status" == "200" || "$http_status" == "204" ]] || return 1
+  [[ "$http_status" == "204" ]] && return 0
+
+  python3 - "${BODYFILE[$label]}" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(obj, dict):
+    raise SystemExit(1)
+if obj.get("ok") is False or "error" in obj:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_session_invalid() {
+  local label="$1"
+  [[ "$(status_of "$label")" == "401" ]] || return 1
+  [[ "$(response_code "$label" 2>/dev/null || true)" == "session_invalid" ]] || return 1
+}
+
+assert_save_ok() {
+  local label="$1"
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(obj, dict):
+    raise SystemExit(1)
+if obj.get("ok") is not True:
+    raise SystemExit(1)
+if "businessDate" not in obj:
+    raise SystemExit(1)
+if not isinstance(obj.get("entry"), dict):
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_get_slot() {
+  local label="$1"
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(obj, dict):
+    raise SystemExit(1)
+
+for key in ("businessDate", "entry", "scheduledIds", "today"):
+    if key not in obj:
+        raise SystemExit(1)
+
+if obj["entry"] is not None and not isinstance(obj["entry"], dict):
+    raise SystemExit(1)
+if not isinstance(obj["scheduledIds"], list):
+    raise SystemExit(1)
+if not isinstance(obj["today"], dict):
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_entry_file() {
+  local label="$1"
+  local mode="$2"
+  local stored_cash="$3"
+  local stored_card="$4"
+  local stored_gratuity="$5"
+  local raw_cash="$6"
+  local raw_card="$7"
+  local raw_gratuity="$8"
+  local expected_scope="$9"
+  local expected_note="${10}"
+  local expected_ids="${11}"
+  local expected_weights="${12}"
+  local require_raw="${13}"
+
+  python3 - "${BODYFILE[$label]}" "$mode" "$stored_cash" "$stored_card" "$stored_gratuity" \
+    "$raw_cash" "$raw_card" "$raw_gratuity" "$expected_scope" "$expected_note" \
+    "$expected_ids" "$expected_weights" "$require_raw" <<'PY'
+from decimal import Decimal
+import json
+import sys
+
+MISSING = object()
+
+def load(path):
+    return json.load(open(path), parse_float=Decimal, parse_int=Decimal)
+
+def pick(obj, names):
+    for name in names:
+        if name in obj:
+            return obj[name], True
+    return MISSING, False
+
+def dec(value):
+    if isinstance(value, bool):
+        raise AssertionError("boolean numeric")
+    return Decimal(str(value))
+
+def same_num(actual, expected):
+    return dec(actual) == Decimal(expected)
+
+def people_and_weights(entry):
+    ids, ids_ok = pick(entry, ("peopleIds", "people_ids"))
+    weights, weights_ok = pick(entry, ("weights",))
+
+    if ids_ok and weights_ok and isinstance(ids, list) and isinstance(weights, list):
+        return ids, weights
+
+    people = entry.get("people")
+    if people is None:
+        people = entry.get("entryPeople")
+    if people is None:
+        people = entry.get("entry_people")
+    if people is None:
+        people = entry.get("tipEntryPeople")
+
+    if not isinstance(people, list):
+        raise AssertionError("missing people")
+
+    result_ids = []
+    result_weights = []
+    for person in people:
+        if not isinstance(person, dict):
+            raise AssertionError("bad person")
+        pid, pid_ok = pick(person, ("personId", "person_id", "employeeId", "employee_id", "id"))
+        weight, weight_ok = pick(person, ("weight", "share"))
+        if not pid_ok or not weight_ok:
+            raise AssertionError("missing person weight")
+        result_ids.append(pid)
+        result_weights.append(weight)
+
+    return result_ids, result_weights
+
+def check_entry(entry, stored, raw, scope, note_arg, ids_expected, weights_expected, require_raw):
+    if not isinstance(entry, dict):
+        raise AssertionError("entry missing")
+
+    cash, cash_ok = pick(entry, ("cash", "cashAmount", "cash_amount"))
+    card, card_ok = pick(entry, ("card", "cardAmount", "card_amount"))
+    gratuity, gratuity_ok = pick(entry, ("gratuity", "tip"))
+    entered_scope, scope_ok = pick(entry, ("enteredScope", "entered_scope"))
+    note, note_ok = pick(entry, ("note",))
+
+    if not cash_ok or not card_ok or not gratuity_ok or not scope_ok or not note_ok:
+        raise AssertionError("missing entry fields")
+
+    if not same_num(cash, stored[0]):
+        raise AssertionError("cash mismatch")
+    if not same_num(card, stored[1]):
+        raise AssertionError("card mismatch")
+    if not same_num(gratuity, stored[2]):
+        raise AssertionError("gratuity mismatch")
+    if entered_scope != scope:
+        raise AssertionError("scope mismatch")
+
+    expected_note = None if note_arg == "__NULL_NOTE__" else note_arg
+    if note != expected_note:
+        raise AssertionError("note mismatch")
+
+    ids_actual, weights_actual = people_and_weights(entry)
+    if ids_actual != ids_expected:
+        raise AssertionError("people order mismatch")
+    if len(weights_actual) != len(weights_expected):
+        raise AssertionError("weight length mismatch")
+
+    for actual, expected in zip(weights_actual, weights_expected):
+        if not same_num(actual, expected):
+            raise AssertionError("weight mismatch")
+
+    if require_raw == "1":
+        raw_values = []
+        for names in (
+            ("rawCash", "raw_cash", "raw_cash_amount"),
+            ("rawCard", "raw_card", "raw_card_amount"),
+            ("rawGratuity", "raw_gratuity", "raw_tip"),
+        ):
+            value, present = pick(entry, names)
+            if not present:
+                raise AssertionError("missing raw field")
+            raw_values.append(value)
+
+        for actual, expected in zip(raw_values, raw):
+            if not same_num(actual, expected):
+                raise AssertionError("raw value mismatch")
+
+try:
+    obj = load(sys.argv[1])
+    mode = sys.argv[2]
+    stored = sys.argv[3:6]
+    raw = sys.argv[6:9]
+    scope = sys.argv[9]
+    note_arg = sys.argv[10]
+    ids_expected = json.loads(sys.argv[11])
+    weights_expected = json.loads(sys.argv[12], parse_float=Decimal, parse_int=Decimal)
+    require_raw = sys.argv[13]
+
+    if mode == "entry":
+        entry = obj.get("entry")
+    elif mode == "today_lunch":
+        entry = obj.get("today", {}).get("lunch")
+        # CONTRACT: today.lunch is exactly {cash, card, gratuity} -- the
+        # figures the entry phone subtracts. It deliberately carries no
+        # scope/note/people, so assert only the three amounts here.
+        if not isinstance(entry, dict):
+            raise AssertionError("today.lunch missing")
+        for key, expected_value in zip(("cash", "card", "gratuity"), stored):
+            if key not in entry:
+                raise AssertionError("today.lunch missing " + key)
+            if not same_num(entry[key], expected_value):
+                raise AssertionError("today.lunch " + key + " mismatch")
+        raise SystemExit(0)
+    else:
+        raise AssertionError("bad mode")
+
+    check_entry(
+        entry,
+        stored,
+        raw,
+        scope,
+        note_arg,
+        ids_expected,
+        weights_expected,
+        require_raw,
+    )
+except Exception:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_entry_pair() {
+  local save_label="$1"
+  local get_label="$2"
+  shift 2
+
+  assert_entry_file "$save_label" entry "$@" || return 1
+  assert_entry_file "$get_label" entry "$@" || return 1
+}
+
+assert_lunch_roundtrip() {
+  local save_label="$1"
+  local get_label="$2"
+  local validate_label="$3"
+  shift 3
+
+  assert_entry_pair "$save_label" "$get_label" "$@" || return 1
+  assert_entry_file "$validate_label" today_lunch "$@" || return 1
+}
+
+assert_note() {
+  local label="$1"
+  local expected="$2"
+
+  python3 - "${BODYFILE[$label]}" "$expected" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+entry = obj.get("entry") if isinstance(obj, dict) else None
+if not isinstance(entry, dict):
+    raise SystemExit(1)
+
+if entry.get("note") != sys.argv[2]:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_null_note() {
+  assert_note "$1" '__NULL_NOTE__' 2>/dev/null
+}
+
+assert_error_coded_or_message() {
+  local label="$1"
+  local expected_status="$2"
+  local http_status
+  http_status="$(status_of "$label")"
+  [[ "$http_status" == "$expected_status" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" <<'PY'
+import json, sys
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+if not isinstance(obj, dict) or obj.get("ok") is not False:
+    raise SystemExit(1)
+code = obj.get("code")
+msg = obj.get("error")
+if isinstance(code, str) and code.strip():
+    raise SystemExit(0)
+if isinstance(msg, str) and msg.strip():
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+assert_error() {
+  local label="$1"
+  local expected_status="$2"
+  local expected_code_regex="$3"
+  local http_status
+  local code
+
+  http_status="$(status_of "$label")"
+  [[ "$http_status" == "$expected_status" ]] || return 1
+
+  code="$(response_code "$label" 2>/dev/null || true)"
+  [[ -n "$code" ]] || return 1
+
+  python3 - "$code" "$expected_code_regex" <<'PY'
+import re
+import sys
+raise SystemExit(0 if re.fullmatch(sys.argv[2], sys.argv[1].lower()) else 1)
+PY
+}
+
+assert_anomaly() {
+  local label="$1"
+  [[ "$(status_of "$label")" == "200" ]] || return 1
+
+  python3 - "${BODYFILE[$label]}" <<'PY'
+import json
+import sys
+
+try:
+    obj = json.load(open(sys.argv[1]))
+except Exception:
+    raise SystemExit(1)
+
+if not isinstance(obj, dict) or obj.get("ok") is not True:
+    raise SystemExit(1)
+
+entry = obj.get("entry")
+if not isinstance(entry, dict):
+    raise SystemExit(1)
+
+flag = entry.get("flaggedAnomaly")
+if flag is None:
+    flag = entry.get("flagged_anomaly")
+
+raise SystemExit(0 if flag is True else 1)
+PY
+}
+
+assert_rest_get() {
+  local label="$1"
+  local http_status
+  http_status="$(status_of "$label")"
+
+  python3 - "$http_status" "${BODYFILE[$label]}" <<'PY'
+import json
+import sys
+
+try:
+    status = int(sys.argv[1])
+except Exception:
+    raise SystemExit(1)
+
+if 400 <= status <= 599:
+    raise SystemExit(0)
+
+if status == 204:
+    raise SystemExit(0)
+
+if status != 200:
+    raise SystemExit(1)
+
+try:
+    obj = json.load(open(sys.argv[2]))
+except Exception:
+    raise SystemExit(1)
+
+raise SystemExit(0 if obj == [] else 1)
+PY
+}
+
+assert_rest_insert_failed() {
+  local label="$1"
+  local http_status
+  http_status="$(status_of "$label")"
+
+  python3 - "$http_status" <<'PY'
+import sys
+try:
+    status = int(sys.argv[1])
+except Exception:
+    raise SystemExit(1)
+raise SystemExit(0 if 400 <= status <= 599 else 1)
+PY
+}
+
+assert_isolation() {
+  local poki_slot_label="$1"
+  local poki_state_label="$2"
+  local sushi_auth_label="$3"
+  local poki_auth_label="$4"
+  local sushi_slot_label="$5"
+
+  python3 - "${BODYFILE[$poki_slot_label]}" "${BODYFILE[$poki_state_label]}" \
+    "${BODYFILE[$sushi_auth_label]}" "${BODYFILE[$poki_auth_label]}" \
+    "${BODYFILE[$sushi_slot_label]}" <<'PY'
+import json
+import sys
+from decimal import Decimal
+
+def load(path):
+    return json.load(open(path), parse_float=Decimal, parse_int=Decimal)
+
+def roster_ids(obj):
+    result = set()
+    for row in obj.get("roster", []) if isinstance(obj, dict) else []:
+        if isinstance(row, dict) and isinstance(row.get("id"), str):
+            result.add(row["id"])
+    return result
+
+def pick(obj, names):
+    for name in names:
+        if name in obj:
+            return obj[name], True
+    return None, False
+
+def entry_people(entry):
+    ids, ids_ok = pick(entry, ("peopleIds", "people_ids"))
+    if ids_ok and isinstance(ids, list):
+        return ids
+    people = entry.get("people") or entry.get("entryPeople") or entry.get("entry_people")
+    if not isinstance(people, list):
+        return []
+    result = []
+    for person in people:
+        if isinstance(person, dict):
+            for key in ("personId", "person_id", "employeeId", "employee_id", "id"):
+                if key in person:
+                    result.append(person[key])
+                    break
+    return result
+
+def number_tuple(entry):
+    if not isinstance(entry, dict):
+        return None
+    values = []
+    for names in (
+        ("cash", "cashAmount", "cash_amount"),
+        ("card", "cardAmount", "card_amount"),
+        ("gratuity", "tip"),
+    ):
+        value, ok = pick(entry, names)
+        if not ok:
+            return None
+        values.append(Decimal(str(value)))
+    return tuple(values)
+
+try:
+    poki_slot = load(sys.argv[1])
+    poki_state = load(sys.argv[2])
+    sushi_auth = load(sys.argv[3])
+    poki_auth = load(sys.argv[4])
+    sushi_slot = load(sys.argv[5])
+
+    sushi_ids = roster_ids(sushi_auth)
+    poki_ids = roster_ids(poki_auth)
+    sushi_only = sushi_ids - poki_ids
+
+    state_location = poki_state.get("location")
+    if isinstance(state_location, dict):
+        state_location = state_location.get("name", "")
+    if state_location is not None and "poki" not in str(state_location).lower():
+        raise AssertionError("Poki state location mismatch")
+
+    state_roster = poki_state.get("roster")
+    if not isinstance(state_roster, list):
+        raise AssertionError("Poki state roster missing")
+
+    state_ids = roster_ids(poki_state)
+    if state_ids & sushi_only:
+        raise AssertionError("Sushi-only employee in Poki state")
+
+    if poki_ids & sushi_only:
+        raise AssertionError("Sushi-only employee in Poki roster")
+
+    scheduled = poki_slot.get("scheduledIds")
+    if isinstance(scheduled, list) and set(scheduled) & sushi_only:
+        raise AssertionError("Sushi-only employee in Poki scheduledIds")
+
+    poki_entry = poki_slot.get("entry")
+    sushi_entry = sushi_slot.get("entry")
+
+    if sushi_entry is None or not isinstance(sushi_entry, dict):
+        raise AssertionError("Sushi comparison entry missing")
+
+    if poki_entry is not None:
+        if not isinstance(poki_entry, dict):
+            raise AssertionError("bad Poki entry")
+
+        if set(entry_people(poki_entry)) & sushi_only:
+            raise AssertionError("Sushi-only employee in Poki entry")
+
+        if number_tuple(poki_entry) == number_tuple(sushi_entry):
+            raise AssertionError("Poki returned Sushi financial values")
+
+        location = poki_entry.get("location")
+        if location is not None and str(location).lower() != "poki":
+            raise AssertionError("Poki entry location mismatch")
+except Exception:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+assert_poki_scope11() {
+  local save_label="$1"
+  local poki_get_label="$2"
+  local sushi_before_label="$3"
+  local sushi_after_label="$4"
+  local expected_ids="$5"
+  local expected_weights="$6"
+  local expected_cash="$7"
+  local expected_card="$8"
+  local expected_gratuity="$9"
+  local expected_note="${10}"
+
+  python3 - "${BODYFILE[$save_label]}" "${BODYFILE[$poki_get_label]}" \
+    "${BODYFILE[$sushi_before_label]}" "${BODYFILE[$sushi_after_label]}" \
+    "$expected_ids" "$expected_weights" "$expected_cash" "$expected_card" \
+    "$expected_gratuity" "$expected_note" <<'PY'
+from decimal import Decimal
+import json
+import sys
+
+def load(path):
+    return json.load(open(path), parse_float=Decimal, parse_int=Decimal)
+
+def pick(obj, names):
+    for name in names:
+        if name in obj:
+            return obj[name], True
+    return None, False
+
+def people(entry):
+    ids, ids_ok = pick(entry, ("peopleIds", "people_ids"))
+    weights, weights_ok = pick(entry, ("weights",))
+    if ids_ok and weights_ok and isinstance(ids, list) and isinstance(weights, list):
+        return ids, weights
+
+    rows = entry.get("people") or entry.get("entryPeople") or entry.get("entry_people")
+    if not isinstance(rows, list):
+        raise AssertionError("people missing")
+
+    ids = []
+    weights = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise AssertionError("bad person")
+        pid = None
+        for key in ("personId", "person_id", "employeeId", "employee_id", "id"):
+            if key in row:
+                pid = row[key]
+                break
+        if pid is None or "weight" not in row:
+            raise AssertionError("bad person fields")
+        ids.append(pid)
+        weights.append(row["weight"])
+    return ids, weights
+
+def signature(entry):
+    if not isinstance(entry, dict):
+        raise AssertionError("entry missing")
+
+    cash, cash_ok = pick(entry, ("cash", "cashAmount", "cash_amount"))
+    card, card_ok = pick(entry, ("card", "cardAmount", "card_amount"))
+    gratuity, gratuity_ok = pick(entry, ("gratuity", "tip"))
+    scope, scope_ok = pick(entry, ("enteredScope", "entered_scope"))
+    note, note_ok = pick(entry, ("note",))
+
+    if not all((cash_ok, card_ok, gratuity_ok, scope_ok, note_ok)):
+        raise AssertionError("entry field missing")
+
+    ids, weights = people(entry)
+    return (
+        Decimal(str(cash)),
+        Decimal(str(card)),
+        Decimal(str(gratuity)),
+        scope,
+        note,
+        tuple(ids),
+        tuple(Decimal(str(x)) for x in weights),
+    )
+
+try:
+    save = load(sys.argv[1])
+    poki_get = load(sys.argv[2])
+    sushi_before = load(sys.argv[3])
+    sushi_after = load(sys.argv[4])
+
+    expected_ids = json.loads(sys.argv[5])
+    expected_weights = json.loads(sys.argv[6], parse_float=Decimal, parse_int=Decimal)
+    expected = (
+        Decimal(sys.argv[7]),
+        Decimal(sys.argv[8]),
+        Decimal(sys.argv[9]),
+        "shift",
+        sys.argv[10],
+        tuple(expected_ids),
+        tuple(Decimal(str(x)) for x in expected_weights),
+    )
+
+    if save.get("ok") is not True:
+        raise AssertionError("save not ok")
+
+    if signature(save.get("entry")) != expected:
+        raise AssertionError("Poki save mismatch")
+
+    if signature(poki_get.get("entry")) != expected:
+        raise AssertionError("Poki read-back mismatch")
+
+    before_sig = signature(sushi_before.get("entry"))
+    after_sig = signature(sushi_after.get("entry"))
+    if before_sig != after_sig:
+        raise AssertionError("Sushi entry changed")
+
+    if set(expected_ids) & set(before_sig[5]):
+        raise AssertionError("Poki IDs already present in Sushi snapshot")
+except Exception:
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
+scan_all_responses() {
+  local sushi_roster_json
+  local poki_roster_json
+  local own_tokens_json
+  local token_owner_json
+  local label
+  local result
+
+  sushi_roster_json="$(json_extract auth_sushi_2 roster 2>/dev/null || print -r -- '[]')"
+  poki_roster_json="$(json_extract auth_poki_1 roster 2>/dev/null || print -r -- '[]')"
+
+  own_tokens_json="$(python3 - "$SESSION_SUSHI_1" "$SESSION_SUSHI" "$SESSION_SUSHI_3" \
+    "$SESSION_SUSHI_4" "$SESSION_POKI_1" "$SESSION_POKI_2" "$TICKET_SUSHI_1" <<'PY'
+import json
+import sys
+print(json.dumps([x for x in sys.argv[1:] if x], separators=(",", ":")))
+PY
+  )"
+
+  token_owner_json="$(python3 - "$SESSION_SUSHI_1" "$SESSION_SUSHI" "$SESSION_SUSHI_3" \
+    "$SESSION_SUSHI_4" "$SESSION_POKI_1" "$SESSION_POKI_2" "$TICKET_SUSHI_1" <<'PY'
+import json
+import sys
+
+owner = {}
+for value in sys.argv[1:5]:
+    if value:
+        owner[value] = "sushi"
+for value in sys.argv[5:7]:
+    if value:
+        owner[value] = "poki"
+if sys.argv[7]:
+    owner[sys.argv[7]] = "sushi"
+print(json.dumps(owner, separators=(",", ":")))
+PY
+  )"
+
+  for label in "${REQUESTS[@]}"; do
+    result="$(python3 - "${BODYFILE[$label]}" "$label" "$ANON_KEY" \
+      "$SUSHI_ENTRY_TOKEN" "$POKI_ENTRY_TOKEN" "$sushi_roster_json" \
+      "$poki_roster_json" "$own_tokens_json" "$token_owner_json" <<'PY'
+import json
+import re
+import sys
+
+path, label, anon_key, sushi_entry_token, poki_entry_token = sys.argv[1:6]
+sushi_roster_text, poki_roster_text, own_tokens_text, owner_text = sys.argv[6:10]
+
+try:
+    raw = open(path, "rb").read()
+except Exception:
+    raw = b""
+
+text = raw.decode("utf-8", "replace")
+lower = text.lower()
+findings = []
+
+for term in ("hash", "service", "secret", "postgres", "pg"):
+    if term in lower:
+        findings.append("keyword:" + term)
+
+for token_name, token in (
+    ("anon_key", anon_key),
+    ("sushi_entry_token", sushi_entry_token),
+    ("poki_entry_token", poki_entry_token),
+):
+    if token and token in text:
+        findings.append("token:" + token_name)
+
+try:
+    own_tokens = set(json.loads(own_tokens_text))
+except Exception:
+    own_tokens = set()
+
+try:
+    token_owner = json.loads(owner_text)
+except Exception:
+    token_owner = {}
+
+try:
+    parsed = json.loads(text)
+except Exception:
+    parsed = None
+
+def walk(value, key=""):
+    if isinstance(value, dict):
+        for k, v in value.items():
+            yield k, v
+            yield from walk(v, k)
+    elif isinstance(value, list):
+        for v in value:
+            yield from walk(v, key)
+
+if parsed is not None:
+    for key, value in walk(parsed):
+        if key.lower() in ("token", "sessiontoken", "ticket", "voiceticket", "voice_ticket"):
+            if isinstance(value, str) and value:
+                if value not in own_tokens:
+                    findings.append("unknown_token_field:" + key)
+                else:
+                    label_lower = label.lower()
+                    owner = token_owner.get(value)
+                    if owner == "sushi" and "poki" in label_lower:
+                        findings.append("cross_location_token:sushi")
+                    if owner == "poki" and "sushi" in label_lower:
+                        findings.append("cross_location_token:poki")
+
+def roster_values(text_value):
+    try:
+        rows = json.loads(text_value)
+    except Exception:
+        rows = []
+    values = []
+    for row in rows:
+        if isinstance(row, dict):
+            ident = row.get("id")
+            name = row.get("name")
+            if isinstance(ident, str) and ident:
+                values.append(ident)
+            if isinstance(name, str) and name:
+                values.append(name)
+    return values
+
+sushi_values = roster_values(sushi_roster_text)
+poki_values = roster_values(poki_roster_text)
+sushi_ids = {
+    row.get("id") for row in json.loads(sushi_roster_text)
+    if isinstance(row, dict) and isinstance(row.get("id"), str)
+}
+poki_ids = {
+    row.get("id") for row in json.loads(poki_roster_text)
+    if isinstance(row, dict) and isinstance(row.get("id"), str)
+}
+sushi_only = sushi_ids - poki_ids
+poki_only = poki_ids - sushi_ids
+
+try:
+    sushi_rows = json.loads(sushi_roster_text)
+except Exception:
+    sushi_rows = []
+try:
+    poki_rows = json.loads(poki_roster_text)
+except Exception:
+    poki_rows = []
+
+sushi_only_values = []
+for row in sushi_rows:
+    if isinstance(row, dict) and row.get("id") in sushi_only:
+        if isinstance(row.get("id"), str):
+            sushi_only_values.append(row["id"])
+        if isinstance(row.get("name"), str):
+            sushi_only_values.append(row["name"])
+
+poki_only_values = []
+for row in poki_rows:
+    if isinstance(row, dict) and row.get("id") in poki_only:
+        if isinstance(row.get("id"), str):
+            poki_only_values.append(row["id"])
+        if isinstance(row.get("name"), str):
+            poki_only_values.append(row["name"])
+
+label_lower = label.lower()
+if "poki" in label_lower:
+    forbidden_values = sushi_only_values
+elif "sushi" in label_lower:
+    forbidden_values = poki_only_values
+else:
+    # Location cannot be attributed from the label alone, so a cross-location
+    # claim would be unfounded here. Dedicated isolation checks (8, 11) cover
+    # this; keyword scanning below still applies to every response.
+    forbidden_values = []
+
+for value in forbidden_values:
+    needle = json.dumps(value, ensure_ascii=False)
+    if needle in text:
+        findings.append("other_location_data:" + value)
+
+seen = []
+for finding in findings:
+    if finding not in seen:
+        seen.append(finding)
+
+print(",".join(seen[:12]))
+PY
+    )"
+
+    if [[ -n "$result" ]]; then
+      print -r -- "LEAK_SCAN ${label}: ${result}"
+      LEAK_FINDINGS+=("${label}:${result}")
+      (( LEAK_COUNT += 1 ))
+    fi
+  done
+
+  if (( LEAK_COUNT == 0 )); then
+    print -r -- "LEAK_SCAN none"
+  fi
+}
+
+emit_check() {
+  local id="$1"
+  local short_name="$2"
+  local evidence="$3"
+
+  evidence="${evidence//$'\n'/ }"
+  if [[ -z "$evidence" ]]; then
+    print -r -- "CHECK ${id} ${short_name}: PASS"
+  else
+    print -r -- "CHECK ${id} ${short_name}: FAIL ${evidence}"
+  fi
+}
+
+PING_AUTH='{"action":"ping"}'
+PING_ENTRIES='{"action":"ping"}'
+VALIDATE_SUSHI='{"action":"validate_token","token":"e2e-tips-v3-sushi-token-2026"}'
+VALIDATE_POKI='{"action":"validate_token","token":"e2e-tips-v3-poki-token-2026"}'
+
+typeset r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12
+r1=''
+r2=''
+r3=''
+r4=''
+r5=''
+r6=''
+r7=''
+r8=''
+r9=''
+r10=''
+r11=''
+r12=''
+
+request_post ping_auth "$AUTH_URL" "$PING_AUTH"
+request_post ping_entries "$ENTRIES_URL" "$PING_ENTRIES"
+request_post auth_sushi_1 "$AUTH_URL" "$VALIDATE_SUSHI"
+request_post auth_poki_1 "$AUTH_URL" "$VALIDATE_POKI"
+
+SESSION_SUSHI_1="$(json_extract auth_sushi_1 sessionToken 2>/dev/null || print -r -- '')"
+SESSION_POKI_1="$(json_extract auth_poki_1 sessionToken 2>/dev/null || print -r -- '')"
+
+STATE_SUSHI_1="$(make_session_payload state "$SESSION_SUSHI_1")"
+request_post state_sushi_1 "$AUTH_URL" "$STATE_SUSHI_1"
+
+CLOSER_ID="$(id_at "$(roster_ids_json auth_sushi_1)" 0)"
+SET_CLOSER="$(make_set_closer_payload "$SESSION_SUSHI_1" "$CLOSER_ID")"
+request_post set_closer_sushi_1 "$AUTH_URL" "$SET_CLOSER"
+
+VOICE_SUSHI_1="$(make_session_payload voice_ticket "$SESSION_SUSHI_1")"
+request_post voice_sushi_1 "$AUTH_URL" "$VOICE_SUSHI_1"
+TICKET_SUSHI_1="$(json_extract voice_sushi_1 ticket 2>/dev/null || json_extract voice_sushi_1 voiceTicket 2>/dev/null || print -r -- '')"
+
+END_SUSHI_1="$(make_session_payload end_session "$SESSION_SUSHI_1")"
+request_post end_sushi_1 "$AUTH_URL" "$END_SUSHI_1"
+
+ENDED_STATE_SUSHI_1="$(make_session_payload state "$SESSION_SUSHI_1")"
+request_post ended_state_sushi_1 "$AUTH_URL" "$ENDED_STATE_SUSHI_1"
+
+if ! assert_ping ping_auth; then r1+="tip-entry-auth ping $(describe ping_auth); "; fi
+if ! assert_ping ping_entries; then r1+="tip-entries ping $(describe ping_entries); "; fi
+if ! assert_validate auth_sushi_1 sushi; then r1+="Sushi validate $(describe auth_sushi_1); "; fi
+if ! assert_validate auth_poki_1 poki; then r1+="Poki validate $(describe auth_poki_1); "; fi
+if ! assert_state state_sushi_1 sushi; then r1+="state $(describe state_sushi_1); "; fi
+if ! assert_set_closer set_closer_sushi_1 "$CLOSER_ID"; then r1+="set_closer $(describe set_closer_sushi_1); "; fi
+if ! assert_ticket voice_sushi_1; then r1+="voice_ticket $(describe voice_sushi_1); "; fi
+if ! assert_end end_sushi_1; then r1+="end_session $(describe end_sushi_1); "; fi
+if ! assert_session_invalid ended_state_sushi_1; then r1+="ended session invalidation $(describe ended_state_sushi_1); "; fi
+
+request_post auth_sushi_2 "$AUTH_URL" "$VALIDATE_SUSHI"
+SESSION_SUSHI="$(json_extract auth_sushi_2 sessionToken 2>/dev/null || print -r -- '')"
+
+SUSHI_IDS_JSON="$(roster_ids_json auth_sushi_2)"
+POKI_IDS_JSON="$(roster_ids_json auth_poki_1)"
+SUSHI_ID1="$(id_at "$SUSHI_IDS_JSON" 0)"
+SUSHI_ID2="$(id_at "$SUSHI_IDS_JSON" 1)"
+SUSHI_ID3="$(id_at "$SUSHI_IDS_JSON" 2)"
+POKI_ID1="$(id_at "$POKI_IDS_JSON" 0)"
+POKI_ID2="$(id_at "$POKI_IDS_JSON" 1)"
+SUSHI_TWO_JSON="$(json_ids_pair "$SUSHI_ID1" "$SUSHI_ID2")"
+POKI_TWO_JSON="$(json_ids_pair "$POKI_ID1" "$POKI_ID2")"
+SUSHI_LUNCH_WEIGHTS_JSON="$(weights_for_ids "$SUSHI_IDS_JSON")"
+POKI_WEIGHTS_JSON='[1,0.5]'
+SUSHI_DINNER_WEIGHTS_JSON='[1,0.5]'
+POKI_ONE_JSON="$(python3 - "$POKI_ID1" <<'PY'
+import json
+import sys
+print(json.dumps([sys.argv[1]], separators=(",", ":")))
+PY
+)"
+SUSHI_ONE_JSON="$(python3 - "$SUSHI_ID1" <<'PY'
+import json
+import sys
+print(json.dumps([sys.argv[1]], separators=(",", ":")))
+PY
+)"
+
+NOTE_PREFIX='Quotes "and", comma, emoji ☕, literal $5, '
+NOTE280="$(NOTE_PREFIX="$NOTE_PREFIX" python3 - <<'PY'
+import os
+prefix = os.environ["NOTE_PREFIX"]
+print(prefix + "x" * (280 - len(prefix)), end="")
+PY
+)"
+NOTE281="$(python3 - <<'PY'
+print("x" * 281, end="")
+PY
+)"
+NOTE_WS=$' \t  '
+
+LUNCH_CASH='118.00'
+LUNCH_CARD='142.00'
+LUNCH_GRATUITY='12.34'
+LUNCH_IDS_JSON="$SUSHI_IDS_JSON"
+LUNCH_WEIGHTS_JSON="$SUSHI_LUNCH_WEIGHTS_JSON"
+
+LUNCH_SAVE_PAYLOAD="$(make_save_payload "$SESSION_SUSHI" lunch "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" shift "$LUNCH_IDS_JSON" "$LUNCH_WEIGHTS_JSON" "$NOTE280" 1 '{}')"
+request_post sushi_lunch_save "$ENTRIES_URL" "$LUNCH_SAVE_PAYLOAD"
+
+LUNCH_GET_PAYLOAD="$(make_get_slot_payload "$SESSION_SUSHI" lunch)"
+request_post sushi_lunch_get "$ENTRIES_URL" "$LUNCH_GET_PAYLOAD"
+
+request_post auth_sushi_3 "$AUTH_URL" "$VALIDATE_SUSHI"
+SESSION_SUSHI_3="$(json_extract auth_sushi_3 sessionToken 2>/dev/null || print -r -- '')"
+
+if ! assert_validate auth_sushi_2 sushi; then r2+="fresh Sushi validate $(describe auth_sushi_2); "; fi
+if ! assert_save_ok sushi_lunch_save; then r2+="lunch save $(describe sushi_lunch_save); "; fi
+if ! assert_get_slot sushi_lunch_get; then r2+="lunch get_slot $(describe sushi_lunch_get); "; fi
+if ! assert_validate auth_sushi_3 sushi; then r2+="fresh read-back validate $(describe auth_sushi_3); "; fi
+if ! assert_lunch_roundtrip sushi_lunch_save sushi_lunch_get auth_sushi_3 \
+  "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" \
+  "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" \
+  shift "$NOTE280" "$LUNCH_IDS_JSON" "$LUNCH_WEIGHTS_JSON" 0; then
+  r2+="lunch persistence values/order/note $(describe sushi_lunch_get); "
+fi
+
+NEGATIVE_AFTER_LUNCH_PAYLOAD="$(make_save_payload "$SESSION_SUSHI" dinner '117.99' '141.99' '12.33' day "$SUSHI_TWO_JSON" "$SUSHI_DINNER_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post err_negative_after_lunch_pre "$ENTRIES_URL" "$NEGATIVE_AFTER_LUNCH_PAYLOAD"
+
+DINNER_CASH='323.00'
+DINNER_CARD='777.00'
+DINNER_GRATUITY='216.00'
+DINNER_STORED_CASH="$(decimal_sub "$DINNER_CASH" "$LUNCH_CASH")"
+DINNER_STORED_CARD="$(decimal_sub "$DINNER_CARD" "$LUNCH_CARD")"
+DINNER_STORED_GRATUITY="$(decimal_sub "$DINNER_GRATUITY" "$LUNCH_GRATUITY")"
+
+DINNER_SAVE_PAYLOAD="$(make_save_payload "$SESSION_SUSHI" dinner "$DINNER_CASH" "$DINNER_CARD" "$DINNER_GRATUITY" day "$SUSHI_TWO_JSON" "$SUSHI_DINNER_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post sushi_dinner_save "$ENTRIES_URL" "$DINNER_SAVE_PAYLOAD"
+
+DINNER_GET_PAYLOAD="$(make_get_slot_payload "$SESSION_SUSHI" dinner)"
+request_post sushi_dinner_get "$ENTRIES_URL" "$DINNER_GET_PAYLOAD"
+
+if ! assert_save_ok sushi_dinner_save; then r3+="dinner save $(describe sushi_dinner_save); "; fi
+if ! assert_get_slot sushi_dinner_get; then r3+="dinner get_slot $(describe sushi_dinner_get); "; fi
+if ! assert_entry_pair sushi_dinner_save sushi_dinner_get \
+  "$DINNER_STORED_CASH" "$DINNER_STORED_CARD" "$DINNER_STORED_GRATUITY" \
+  "$DINNER_CASH" "$DINNER_CARD" "$DINNER_GRATUITY" \
+  day '__NULL_NOTE__' "$SUSHI_TWO_JSON" "$SUSHI_DINNER_WEIGHTS_JSON" 1; then
+  r3+="derived/raw dinner persistence or person weights $(describe sushi_dinner_get); "
+fi
+
+RESAVE_CASH='500.00'
+RESAVE_CARD='900.00'
+RESAVE_GRATUITY='50.00'
+RESAVE_STORED_CASH="$(decimal_sub "$RESAVE_CASH" "$LUNCH_CASH")"
+RESAVE_STORED_CARD="$(decimal_sub "$RESAVE_CARD" "$LUNCH_CARD")"
+RESAVE_STORED_GRATUITY="$(decimal_sub "$RESAVE_GRATUITY" "$LUNCH_GRATUITY")"
+
+RESAVE_PAYLOAD="$(make_save_payload "$SESSION_SUSHI" dinner "$RESAVE_CASH" "$RESAVE_CARD" "$RESAVE_GRATUITY" day "$SUSHI_TWO_JSON" "$SUSHI_DINNER_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post sushi_dinner_resave_same "$ENTRIES_URL" "$RESAVE_PAYLOAD"
+
+request_post sushi_dinner_get_after_resave "$ENTRIES_URL" "$DINNER_GET_PAYLOAD"
+
+request_post auth_sushi_4 "$AUTH_URL" "$VALIDATE_SUSHI"
+SESSION_SUSHI_4="$(json_extract auth_sushi_4 sessionToken 2>/dev/null || print -r -- '')"
+OTHER_RESAVE_PAYLOAD="$(make_save_payload "$SESSION_SUSHI_4" dinner "$RESAVE_CASH" "$RESAVE_CARD" "$RESAVE_GRATUITY" day "$SUSHI_TWO_JSON" "$SUSHI_DINNER_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post sushi_dinner_resave_other "$ENTRIES_URL" "$OTHER_RESAVE_PAYLOAD"
+
+if ! assert_save_ok sushi_dinner_resave_same; then r4+="same-session resave $(describe sushi_dinner_resave_same); "; fi
+if ! assert_get_slot sushi_dinner_get_after_resave; then r4+="same-session resave read-back $(describe sushi_dinner_get_after_resave); "; fi
+if ! assert_entry_pair sushi_dinner_resave_same sushi_dinner_get_after_resave \
+  "$RESAVE_STORED_CASH" "$RESAVE_STORED_CARD" "$RESAVE_STORED_GRATUITY" \
+  "$RESAVE_CASH" "$RESAVE_CARD" "$RESAVE_GRATUITY" \
+  day '__NULL_NOTE__' "$SUSHI_TWO_JSON" "$SUSHI_DINNER_WEIGHTS_JSON" 1; then
+  r4+="overwrite values $(describe sushi_dinner_get_after_resave); "
+fi
+if ! assert_validate auth_sushi_4 sushi; then r4+="different-session validate $(describe auth_sushi_4); "; fi
+if ! assert_error sushi_dinner_resave_other 409 '^already_recorded$'; then
+  r4+="different-session conflict $(describe sushi_dinner_resave_other); "
+fi
+
+BAD_MEAL_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" brunch '1.00' '2.00' '3.00' shift "$POKI_TWO_JSON" "$POKI_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post err_bad_meal "$ENTRIES_URL" "$BAD_MEAL_PAYLOAD"
+
+NEGATIVE_AMOUNT_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '-1.00' '2.00' '3.00' shift "$POKI_TWO_JSON" "$POKI_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post err_negative_amount "$ENTRIES_URL" "$NEGATIVE_AMOUNT_PAYLOAD"
+
+LARGE_AMOUNT_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '100000.00' '2.00' '3.00' shift "$POKI_TWO_JSON" "$POKI_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post err_amount_too_large "$ENTRIES_URL" "$LARGE_AMOUNT_PAYLOAD"
+
+WEIGHT_MISMATCH_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '1.00' '2.00' '3.00' shift "$POKI_TWO_JSON" "$POKI_ONE_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post err_weights_mismatch "$ENTRIES_URL" "$WEIGHT_MISMATCH_PAYLOAD"
+
+WEIGHT_ZERO_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '1.00' '2.00' '3.00' shift "$POKI_TWO_JSON" '[0,1]' '__NULL_NOTE__' 1 '{}')"
+request_post err_weight_zero "$ENTRIES_URL" "$WEIGHT_ZERO_PAYLOAD"
+
+WEIGHT_HIGH_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '1.00' '2.00' '3.00' shift "$POKI_TWO_JSON" '[1.2,1]' '__NULL_NOTE__' 1 '{}')"
+request_post err_weight_high "$ENTRIES_URL" "$WEIGHT_HIGH_PAYLOAD"
+
+NO_PEOPLE_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '1.00' '2.00' '3.00' shift '[]' '[]' '__NULL_NOTE__' 1 '{}')"
+request_post err_no_people "$ENTRIES_URL" "$NO_PEOPLE_PAYLOAD"
+
+OTHER_ROSTER_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '1.00' '2.00' '3.00' shift "$SUSHI_ONE_JSON" '[1]' '__NULL_NOTE__' 1 '{}')"
+request_post err_other_roster "$ENTRIES_URL" "$OTHER_ROSTER_PAYLOAD"
+
+BAD_SCOPE_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" lunch '1.00' '2.00' '3.00' garbage "$POKI_TWO_JSON" "$POKI_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post err_bad_scope "$ENTRIES_URL" "$BAD_SCOPE_PAYLOAD"
+
+ANOMALY_PAYLOAD="$(make_save_payload "$SESSION_POKI_1" dinner '50.00' '60.00' '7.00' day "$POKI_TWO_JSON" "$POKI_WEIGHTS_JSON" '__NULL_NOTE__' 1 '{}')"
+request_post err_poki_anomaly "$ENTRIES_URL" "$ANOMALY_PAYLOAD"
+
+if ! assert_error_coded_or_message err_bad_meal 400; then r5+="bad meal $(describe err_bad_meal); "; fi
+if ! assert_error_coded_or_message err_negative_amount 400; then r5+="negative amount $(describe err_negative_amount); "; fi
+if ! assert_error_coded_or_message err_amount_too_large 400; then r5+="large amount $(describe err_amount_too_large); "; fi
+if ! assert_error err_weights_mismatch 400 '^bad_weights$'; then r5+="weight length $(describe err_weights_mismatch); "; fi
+if ! assert_error err_weight_zero 400 '^bad_weights$'; then r5+="weight zero $(describe err_weight_zero); "; fi
+if ! assert_error err_weight_high 400 '^bad_weights$'; then r5+="weight >1 $(describe err_weight_high); "; fi
+if ! assert_error err_no_people 400 '^no_people$'; then r5+="empty people $(describe err_no_people); "; fi
+if ! assert_error_coded_or_message err_other_roster 400; then r5+="other roster $(describe err_other_roster); "; fi
+if ! assert_error_coded_or_message err_bad_scope 400; then r5+="bad scope $(describe err_bad_scope); "; fi
+if ! assert_error err_negative_after_lunch_pre 400 '^negative_after_lunch$'; then r5+="negative after lunch $(describe err_negative_after_lunch_pre); "; fi
+if ! assert_anomaly err_poki_anomaly; then r5+="Poki no-lunch anomaly $(describe err_poki_anomaly); "; fi
+
+OLD_CASH='10.00'
+OLD_CARD='20.00'
+OLD_PAYLOAD="$(make_save_payload "$SESSION_SUSHI" lunch "$OLD_CASH" "$OLD_CARD" '0.00' shift "$LUNCH_IDS_JSON" "$LUNCH_WEIGHTS_JSON" '__NULL_NOTE__' 0 '{}')"
+request_post old_client_save "$ENTRIES_URL" "$OLD_PAYLOAD"
+request_post old_client_get "$ENTRIES_URL" "$LUNCH_GET_PAYLOAD"
+
+if ! assert_save_ok old_client_save; then r6+="old-client save $(describe old_client_save); "; fi
+if ! assert_get_slot old_client_get; then r6+="old-client get_slot $(describe old_client_get); "; fi
+if ! assert_entry_pair old_client_save old_client_get \
+  "$OLD_CASH" "$OLD_CARD" '0.00' \
+  "$OLD_CASH" "$OLD_CARD" '0.00' \
+  shift '__NULL_NOTE__' "$LUNCH_IDS_JSON" "$LUNCH_WEIGHTS_JSON" 1; then
+  r6+="old-client defaults/raw/weights $(describe old_client_get); "
+fi
+
+NOTE281_TRIMMED="$(python3 - "$NOTE281" <<'PY'
+import sys
+print(sys.argv[1].strip()[:280], end="")
+PY
+)"
+NOTE281_PAYLOAD="$(make_save_payload "$SESSION_SUSHI" lunch '11.00' '21.00' '1.00' shift "$LUNCH_IDS_JSON" "$LUNCH_WEIGHTS_JSON" "$NOTE281" 1 '{}')"
+request_post note_281_save "$ENTRIES_URL" "$NOTE281_PAYLOAD"
+request_post note_281_get "$ENTRIES_URL" "$LUNCH_GET_PAYLOAD"
+
+NOTE_WS_PAYLOAD="$(make_save_payload "$SESSION_SUSHI" lunch '12.00' '22.00' '2.00' shift "$LUNCH_IDS_JSON" "$LUNCH_WEIGHTS_JSON" "$NOTE_WS" 1 '{}')"
+request_post note_whitespace_save "$ENTRIES_URL" "$NOTE_WS_PAYLOAD"
+request_post note_whitespace_get "$ENTRIES_URL" "$LUNCH_GET_PAYLOAD"
+
+if ! assert_save_ok note_281_save; then r7+="281+ note save $(describe note_281_save); "; fi
+if ! assert_get_slot note_281_get; then r7+="281+ note get_slot $(describe note_281_get); "; fi
+if ! assert_note note_281_get "$NOTE281_TRIMMED"; then r7+="281+ note trim $(describe note_281_get); "; fi
+if ! assert_save_ok note_whitespace_save; then r7+="whitespace note save $(describe note_whitespace_save); "; fi
+if ! assert_get_slot note_whitespace_get; then r7+="whitespace note get_slot $(describe note_whitespace_get); "; fi
+if ! python3 - "${BODYFILE[note_whitespace_get]}" <<'PY'
+import json
+import sys
+obj = json.load(open(sys.argv[1]))
+entry = obj.get("entry")
+raise SystemExit(0 if isinstance(entry, dict) and entry.get("note") is None else 1)
+PY
+then
+  r7+="whitespace note null $(describe note_whitespace_get); "
+fi
+
+request_post sushi_dinner_get_isolation "$ENTRIES_URL" "$DINNER_GET_PAYLOAD"
+request_post poki_dinner_get_isolation "$ENTRIES_URL" "$(make_get_slot_payload "$SESSION_POKI_1" dinner)"
+request_post poki_state_isolation "$AUTH_URL" "$(make_session_payload state "$SESSION_POKI_1")"
+
+if ! assert_get_slot sushi_dinner_get_isolation; then r8+="Sushi isolation comparison slot $(describe sushi_dinner_get_isolation); "; fi
+if ! assert_get_slot poki_dinner_get_isolation; then r8+="Poki get_slot $(describe poki_dinner_get_isolation); "; fi
+if ! assert_state poki_state_isolation poki; then r8+="Poki state $(describe poki_state_isolation); "; fi
+if ! assert_isolation poki_dinner_get_isolation poki_state_isolation auth_sushi_2 auth_poki_1 sushi_dinner_get_isolation; then
+  r8+="cross-location slot/roster isolation $(describe poki_dinner_get_isolation); "
+fi
+
+request_get rest_get_tip_entries "${REST_BASE}/tip_entries?select=*"
+request_get rest_get_tip_entry_people "${REST_BASE}/tip_entry_people?select=*"
+request_get rest_get_tip_employees "${REST_BASE}/tip_employees?select=*"
+request_get rest_get_tip_location_access "${REST_BASE}/tip_location_access?select=*"
+request_get rest_get_tip_entry_sessions "${REST_BASE}/tip_entry_sessions?select=*"
+request_post rest_insert_tip_entries "${REST_BASE}/tip_entries" '{"business_date":"2026-08-28","location_id":"11111111-1111-1111-1111-111111111111","meal_period":"lunch","cash_amount":1,"card_amount":1,"entry_method":"typed"}'
+
+if ! assert_rest_get rest_get_tip_entries; then r10+="tip_entries REST $(describe rest_get_tip_entries); "; fi
+if ! assert_rest_get rest_get_tip_entry_people; then r10+="tip_entry_people REST $(describe rest_get_tip_entry_people); "; fi
+if ! assert_rest_get rest_get_tip_employees; then r10+="tip_employees REST $(describe rest_get_tip_employees); "; fi
+if ! assert_rest_get rest_get_tip_location_access; then r10+="tip_location_access REST $(describe rest_get_tip_location_access); "; fi
+if ! assert_rest_get rest_get_tip_entry_sessions; then r10+="tip_entry_sessions REST $(describe rest_get_tip_entry_sessions); "; fi
+if ! assert_rest_insert_failed rest_insert_tip_entries; then r10+="REST INSERT $(describe rest_insert_tip_entries); "; fi
+
+request_post auth_poki_2 "$AUTH_URL" "$VALIDATE_POKI"
+SESSION_POKI_2="$(json_extract auth_poki_2 sessionToken 2>/dev/null || print -r -- '')"
+
+FAKE_TOKEN="$(python3 - <<'PY'
+print("A" * 64, end="")
+PY
+)"
+request_post fake_token_state "$AUTH_URL" "$(make_session_payload state "$FAKE_TOKEN")"
+request_post ended_token_state_11 "$AUTH_URL" "$(make_session_payload state "$SESSION_SUSHI_1")"
+request_post sushi_lunch_snapshot_11 "$ENTRIES_URL" "$LUNCH_GET_PAYLOAD"
+
+LOCATION_INJECTION_PAYLOAD="$(make_save_payload "$SESSION_POKI_2" lunch "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" shift "$POKI_IDS_JSON" "$POKI_WEIGHTS_JSON" "$NOTE280" 1 '{"location":"Sushi"}')"
+request_post poki_save_sushi_payload "$ENTRIES_URL" "$LOCATION_INJECTION_PAYLOAD"
+
+SAVE_11_LABEL=''
+INJECTION_STATUS="$(status_of poki_save_sushi_payload)"
+
+if [[ "$INJECTION_STATUS" == "200" ]]; then
+  SAVE_11_LABEL='poki_save_sushi_payload'
+  if ! assert_save_ok "$SAVE_11_LABEL"; then r11+="location-injection save shape $(describe "$SAVE_11_LABEL"); "; fi
+else
+  if ! status_at_least "$INJECTION_STATUS" 400; then
+    r11+="location-injection unexpected status $(describe poki_save_sushi_payload); "
+  fi
+
+  INJECTION_CODE="$(response_code poki_save_sushi_payload 2>/dev/null || true)"
+  [[ -n "$INJECTION_CODE" ]] || r11+="location-injection missing error code; "
+
+  FALLBACK_PAYLOAD="$(make_save_payload "$SESSION_POKI_2" lunch "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" shift "$POKI_IDS_JSON" "$POKI_WEIGHTS_JSON" "$NOTE280" 1 '{}')"
+  request_post poki_save_scoped_fallback "$ENTRIES_URL" "$FALLBACK_PAYLOAD"
+  SAVE_11_LABEL='poki_save_scoped_fallback'
+
+  if ! assert_save_ok "$SAVE_11_LABEL"; then r11+="scoped fallback save $(describe "$SAVE_11_LABEL"); "; fi
+fi
+
+request_post poki_lunch_get_11 "$ENTRIES_URL" "$(make_get_slot_payload "$SESSION_POKI_2" lunch)"
+request_post sushi_lunch_get_11 "$ENTRIES_URL" "$LUNCH_GET_PAYLOAD"
+
+if ! assert_validate auth_poki_2 poki; then r11+="Poki session validate $(describe auth_poki_2); "; fi
+if ! assert_session_invalid fake_token_state; then r11+="made-up token $(describe fake_token_state); "; fi
+if ! assert_session_invalid ended_token_state_11; then r11+="ended token $(describe ended_token_state_11); "; fi
+if ! assert_get_slot sushi_lunch_snapshot_11; then r11+="Sushi pre-injection snapshot $(describe sushi_lunch_snapshot_11); "; fi
+if ! assert_get_slot poki_lunch_get_11; then r11+="Poki location read-back $(describe poki_lunch_get_11); "; fi
+if ! assert_get_slot sushi_lunch_get_11; then r11+="Sushi post-injection read-back $(describe sushi_lunch_get_11); "; fi
+
+if [[ -n "$SAVE_11_LABEL" ]]; then
+  if ! assert_entry_pair "$SAVE_11_LABEL" poki_lunch_get_11 \
+    "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" \
+    "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" \
+    shift "$NOTE280" "$POKI_IDS_JSON" "$POKI_WEIGHTS_JSON" 1; then
+    r11+="Poki scoped save values/people $(describe "$SAVE_11_LABEL"); "
+  fi
+
+  if ! assert_poki_scope11 "$SAVE_11_LABEL" poki_lunch_get_11 sushi_lunch_snapshot_11 sushi_lunch_get_11 \
+    "$POKI_IDS_JSON" "$POKI_WEIGHTS_JSON" "$LUNCH_CASH" "$LUNCH_CARD" "$LUNCH_GRATUITY" "$NOTE280"; then
+    r11+="session-derived Poki location or Sushi protection $(describe poki_lunch_get_11); "
+  fi
+else
+  r11+="no successful Poki scoped save; "
+fi
+
+WRONG_TOKEN="$(python3 - <<'PY'
+print("Z" * 64, end="")
+PY
+)"
+WRONG_VALIDATE_PAYLOAD="$(make_validate_payload "$WRONG_TOKEN")"
+
+RATE_429=0
+RATE_429_LABEL=''
+RATE_EVIDENCE=''
+
+for i in {1..25}; do
+  label="rate_wrong_${i}"
+  request_post "$label" "$AUTH_URL" "$WRONG_VALIDATE_PAYLOAD"
+  code="$(response_code "$label" 2>/dev/null || true)"
+  RATE_EVIDENCE+="${label}:${STATUS[$label]}/${code:-none} "
+  if [[ "${STATUS[$label]}" == "429" && "$code" == "rate_limited" ]]; then
+    RATE_429=1
+    [[ -z "$RATE_429_LABEL" ]] && RATE_429_LABEL="$label"
+  fi
+done
+
+if [[ "$RATE_429" -ne 1 ]]; then
+  r12+="no 429 rate_limited response (${RATE_EVIDENCE}); "
+fi
+
+scan_all_responses
+
+if (( LEAK_COUNT > 0 )); then
+  r9+="suspicious response bodies=${LEAK_COUNT}; "
+fi
+
+emit_check 1 session-lifecycle "$r1"
+emit_check 2 sushi-lunch-persistence "$r2"
+emit_check 3 sushi-dinner-derivation "$r3"
+emit_check 4 resave-conflict "$r4"
+emit_check 5 validation-errors "$r5"
+emit_check 6 old-client-compatibility "$r6"
+emit_check 7 note-handling "$r7"
+emit_check 8 location-isolation "$r8"
+emit_check 9 response-leakage "$r9"
+emit_check 10 rest-lockdown "$r10"
+emit_check 11 token-abuse-scoping "$r11"
+emit_check 12 rate-limiting "$r12"

--- a/docs/mockups/tips-v3/tips-v3-final.html
+++ b/docs/mockups/tips-v3/tips-v3-final.html
@@ -1,0 +1,502 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Smelter Tips v3 — FINAL (build exactly this)</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+button{font:inherit;cursor:pointer;background:none;border:0;color:inherit}
+input,textarea{font:inherit;color:inherit}
+:root{
+  --cream:#f5f5f4;--card:#fff;--well:#ededec;--accent:#e84d38;--tint:#fbeae7;--alert:#c03520;
+  --ink:#1a1a1a;--ink2:#5f5f5f;--ink3:#9c9890;--disabled:#c9c5bc;
+  --line:rgba(0,0,0,.08);--hair:rgba(0,0,0,.06);
+  --blue:#2563eb;--green:#1f7a4d;--amber:#b7791f;
+  --cashcol:rgba(216,144,32,.06);--cardcol:rgba(37,99,235,.055);--gratcol:rgba(31,122,77,.07);--flagtint:#fdecea;
+  --sans:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+}
+body{font-family:var(--sans);background:#e6e7e9;color:var(--ink);font-size:14px;line-height:1.45;-webkit-font-smoothing:antialiased}
+#chrome{position:sticky;top:0;z-index:80;background:#101319;color:#e7e9ee;padding:9px 18px;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+#chrome .brand{font-weight:700}#chrome .brand i{color:var(--accent);font-style:normal}
+#chrome .sub{color:#8a93a6;font-size:12px;margin-right:auto}
+#chrome .grp{display:flex;align-items:center;gap:6px}
+#chrome .grp>span{color:#8a93a6;font-size:10.5px;text-transform:uppercase;letter-spacing:.06em}
+#chrome .grp button{padding:5px 11px;border-radius:7px;font-size:12px;font-weight:600;color:#c6ccd8;border:1px solid #2a3040}
+#chrome .grp button[aria-pressed="true"]{background:#e7e9ee;color:#101319;border-color:#e7e9ee}
+main{padding:24px 20px 80px;max-width:1560px;margin:0 auto}
+h2{font-size:20px;letter-spacing:-.01em;margin-bottom:4px}
+.lede{color:var(--ink2);max-width:90ch;margin-bottom:18px}
+.lede b{color:var(--ink)}
+.panel{background:#fff;border:1px solid var(--line);border-radius:18px;overflow:hidden;margin-bottom:22px}
+.ph{padding:15px 18px;border-bottom:1px solid var(--hair);display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
+.ph b{font-size:16px}.ph span{color:var(--ink2);font-size:12.5px}
+.pb{padding:20px;background:#f0f0f1;display:flex;gap:22px;align-items:flex-start;flex-wrap:wrap;justify-content:center}
+.pb.flat{background:#fff;padding:0;display:block}
+.spec{padding:16px 18px;border-top:1px solid var(--hair);display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px}
+.spec h4{font-size:12px;text-transform:uppercase;letter-spacing:.06em;color:var(--ink3);margin-bottom:7px}
+.spec li{font-size:13px;color:var(--ink2);margin-bottom:6px;list-style:none;padding-left:13px;position:relative;line-height:1.5}
+.spec li::before{content:"";position:absolute;left:0;top:8px;width:5px;height:5px;border-radius:50%;background:var(--disabled)}
+.spec li b{color:var(--ink)}
+.spec code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;background:var(--well);border-radius:5px;padding:1px 5px;color:var(--ink)}
+/* phone */
+.phone{width:372px;flex:none;background:var(--cream);border-radius:26px;border:1px solid rgba(0,0,0,.1);padding:14px 13px 12px;display:flex;flex-direction:column;gap:11px}
+.cap{width:372px;flex:none;font-size:12px;color:var(--ink2);text-align:center;margin-top:-8px}
+.phead{display:flex;align-items:center;gap:8px}
+.phead b{font-size:24px;letter-spacing:-.02em}
+.phead .pill{margin-left:auto;background:var(--card);border-radius:999px;padding:5px 11px;font-size:12px}
+.phead .who{background:var(--card);border-radius:999px;padding:4px 10px 4px 4px;font-size:12px;display:flex;align-items:center;gap:6px}
+.av{width:21px;height:21px;border-radius:50%;background:var(--accent);color:#fff;font-size:10px;font-weight:800;display:flex;align-items:center;justify-content:center}
+.c{background:var(--card);border-radius:20px;padding:14px}
+.c.tight{padding:11px 14px}
+.row{display:flex;align-items:center;gap:10px}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--accent);flex:none}
+.chev{margin-left:auto;color:var(--ink3)}
+.slabel{font-size:10.5px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--ink3)}
+.seg{display:flex;background:var(--well);border-radius:999px;padding:3px;gap:3px}
+.seg button{flex:1;border-radius:999px;padding:9px 6px;font-size:13.5px;font-weight:600;color:var(--ink2)}
+.seg button.on{background:var(--card);color:var(--ink);box-shadow:0 1px 2px rgba(0,0,0,.07)}
+.seg button:disabled{color:var(--disabled)}
+.seg.sm button{padding:6px 8px;font-size:12px}
+.well{background:var(--well);border-radius:14px;padding:12px;display:block}
+/* The rule under the value is the "this is a field" cue — it is the only
+   thing separating an amount you can type from an amount you can only read. */
+.amt{display:flex;align-items:baseline;gap:3px;margin-top:3px;padding-bottom:4px;border-bottom:1.5px solid var(--disabled)}
+.amt:focus-within{border-bottom-color:var(--accent)}
+.amt input{caret-color:var(--accent)}
+.amt.ro{border-bottom:0;padding-bottom:0}
+.amt i{font-style:normal;font-size:15px;font-weight:700;color:var(--ink2)}
+.amt input{width:100%;background:none;border:0;outline:0;font-size:17px;font-weight:700;font-variant-numeric:tabular-nums}
+.amt input::placeholder{color:var(--ink3)}
+.g3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
+.chips{display:flex;flex-wrap:wrap;gap:7px}
+.chip{border:1px solid var(--line);background:var(--card);border-radius:999px;padding:7px 12px;font-size:13px;font-weight:600;color:var(--ink2);display:flex;align-items:center;gap:6px}
+.chip.on{background:var(--tint);border-color:var(--accent);color:var(--alert)}
+.chip .pct{font-size:10.5px;font-weight:800;background:#fff;border:1px solid var(--line);border-radius:999px;padding:1px 6px;color:var(--ink2)}
+.chip.on .pct{background:var(--accent);border-color:var(--accent);color:#fff}
+.strip{background:var(--card);border-radius:20px;padding:11px 14px;display:flex;align-items:baseline;gap:8px}
+.strip b{font-size:19px;letter-spacing:-.01em;font-variant-numeric:tabular-nums}
+.strip .of{margin-left:auto;color:var(--ink3);font-size:12.5px}
+.bar{display:flex;gap:9px}
+.bar button{flex:1;border-radius:999px;padding:13px;font-weight:700;font-size:14.5px;background:var(--card)}
+.bar button.prim{background:var(--accent);color:#fff;flex:1.3}
+.bar button:disabled{background:var(--disabled);color:#fff}
+.calc{border-top:1px dashed var(--line);margin-top:11px;padding-top:10px;display:grid;gap:5px;font-size:12.5px;font-variant-numeric:tabular-nums}
+.calc .ln{display:flex;color:var(--ink2)}
+.calc .ln span:last-child{margin-left:auto;font-weight:600;color:var(--ink)}
+.calc .ln.sub span:last-child{color:var(--alert)}
+.calc .ln.tot{border-top:1px solid var(--line);padding-top:6px;margin-top:2px;font-weight:800;color:var(--ink)}
+.calc .ln.tot span:last-child{font-size:15px}
+.mini{font-size:12px;color:var(--ink2)}
+.mini b{color:var(--ink)}
+.warn{background:var(--tint);color:var(--alert);border-radius:11px;padding:9px 11px;font-size:12.5px;margin-top:10px}
+.ghost{border:1px dashed var(--line);border-radius:12px;padding:11px;width:100%;text-align:center;font-size:12.5px;font-weight:600;color:var(--ink2);background:var(--card)}
+.rows{display:grid;gap:7px}
+.prow{display:flex;align-items:center;gap:10px;background:var(--well);border-radius:12px;padding:9px 11px}
+.prow .nm{font-weight:600;font-size:13.5px}
+.prow .sub{font-size:11px;color:var(--ink3)}
+.prow .amtv{margin-left:auto;font-weight:800;font-variant-numeric:tabular-nums}
+textarea{background:var(--well);border:0;border-radius:11px;padding:10px 11px;width:100%;outline:0;resize:none;font-size:13.5px;line-height:1.4}
+textarea::placeholder{color:var(--ink3)}
+.nglyph{font-size:10px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;color:var(--blue);background:rgba(37,99,235,.09);border-radius:5px;padding:2px 6px}
+.notepreview .mini{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+[data-screen]{display:flex;flex-direction:column;gap:11px;flex:1}
+.cdbar{height:3px;border-radius:2px;background:var(--well);overflow:hidden;margin-top:7px}
+.cdbar i{display:block;height:100%;background:var(--accent);transition:width .25s linear}
+.scanh1{font-size:28px;font-weight:700;letter-spacing:-.02em}
+.qrbox{width:76px;height:76px;border-radius:14px;background:var(--well);display:flex;align-items:center;justify-content:center;flex:none;color:var(--ink)}
+.replay{font-weight:700;color:var(--accent)}
+.saved .ok16{width:54px;height:54px;border-radius:50%;background:var(--tint);color:var(--accent);display:flex;align-items:center;justify-content:center;font-size:26px;font-weight:800;margin:0 auto}
+/* dashboard */
+.wideframe{width:100%;overflow-x:auto}
+.tbar{display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--line)}
+.tbar b{font-size:16px}.tbar .mini{color:var(--ink3)}
+.tbtn{border:1px solid var(--line);border-radius:8px;padding:5px 11px;font-size:12px;font-weight:700;color:var(--ink2);white-space:nowrap;cursor:pointer}
+.tbtn.sm{padding:3px 9px;font-size:11.5px}
+.tbtn.prim{background:var(--accent);border-color:var(--accent);color:#fff}
+table.ledger{width:100%;border-collapse:collapse;font-size:13px;min-width:940px}
+table.ledger th{text-align:left;font-size:10.5px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--ink3);padding:9px 11px;border-bottom:1px solid var(--line);white-space:nowrap}
+table.ledger td{padding:10px 11px;border-bottom:1px solid var(--hair)}
+table.ledger .r{text-align:right}
+table.ledger .cash{background:var(--cashcol)}
+table.ledger .card{background:var(--cardcol)}
+table.ledger .b{font-weight:700;font-variant-numeric:tabular-nums}
+table.ledger .xb{font-weight:800;font-variant-numeric:tabular-nums}
+table.ledger .mut{color:var(--ink3);font-size:12.5px}
+table.ledger tr.daytot td{background:#fafafa;font-weight:800;color:var(--ink2);font-size:12px;padding:6px 11px;font-variant-numeric:tabular-nums}
+table.ledger tr.flag td{background:var(--flagtint)}
+.lchip{font-size:11.5px;font-weight:700;border-radius:6px;padding:2px 8px;white-space:nowrap}
+.lchip.sushi{background:var(--tint);color:var(--alert)}
+.lchip.poki{background:rgba(37,99,235,.1);color:var(--blue)}
+.scope{font-size:10px;font-weight:800;text-transform:uppercase;background:#fff;border:1px solid var(--line);border-radius:5px;padding:1px 5px;color:var(--ink2);cursor:help}
+.mark{font-size:11px;font-weight:800;color:var(--green);background:var(--gratcol);border-radius:5px;padding:1px 5px}
+.sub2{font-weight:600;font-size:11.5px;color:var(--ink3)}
+.fchip{font-size:10.5px;font-weight:800;color:var(--alert);background:#fff;border:1px solid rgba(192,53,32,.3);border-radius:6px;padding:1px 6px}
+tr.exp{cursor:pointer}tr.exp:hover td{background:#fafafa}tr.exp.open td{background:#f6f7f8}
+.tw{width:26px}.tri{color:var(--ink3);font-size:11px}
+tr.det td{background:#f6f7f8;padding:0 11px 16px}
+.detgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:12px}
+.dcard{background:#fff;border:1px solid var(--line);border-radius:13px;padding:13px}
+.hair2{height:1px;background:var(--hair);margin:11px 0}
+table.mini2{width:100%;border-collapse:collapse;font-size:12.5px;margin-top:7px}
+table.mini2 td{padding:4px 0;border-bottom:1px solid var(--hair)}
+table.mini2 tr.tt td{border-bottom:0;border-top:1px solid var(--line);font-weight:800;padding-top:6px}
+.ntext{font-size:12.5px;color:var(--ink2);line-height:1.5;margin-top:7px}
+.ntext.mut{color:var(--ink3)}
+</style>
+</head>
+<body>
+<header id="chrome">
+  <div class="brand"><i>smelter</i> tips</div>
+  <div class="sub">v3 <b>FINAL</b> — chosen: A1 · B1 · C1 · D2 · build exactly this</div>
+  <div class="grp"><span>lunch today</span>
+    <button data-lunch="yes" aria-pressed="true">recorded $118 / $142</button>
+    <button data-lunch="no">not recorded</button>
+  </div>
+</header>
+<main>
+
+<h2>1 · The entry phone — dinner</h2>
+<p class="lede">A1, B1 and C1 all live on this one screen. It is fully live: type in a well, tap a badge, flip the scope switch, write a note. The right-hand phone is the same screen after saving. Use the <b>lunch today</b> switch in the top bar to see the no-lunch-on-record edge case.</p>
+
+<div class="panel">
+  <div class="ph"><b>Entry form</b><span>web/src/components/entry/EntryForm.tsx</span></div>
+  <div class="pb">
+    <div class="phone" id="entry">
+      <div class="phead"><b>Tips</b><span class="pill">Wed, Aug 27</span><span class="who"><span class="av">D</span>Dee</span></div>
+      <div class="c tight row"><span class="dot"></span><b>Babytuna Sushi</b><span class="chev">›</span></div>
+      <div class="seg"><button disabled>Lunch</button><button class="on">Dinner</button></div>
+
+      <div class="c">
+        <div class="seg sm" data-scope>
+          <button class="on" data-v="day">Whole day (Square)</button>
+          <button data-v="shift">Dinner only</button>
+        </div>
+        <div class="g3" style="margin-top:11px">
+          <label class="well"><span class="slabel">Cash</span><span class="amt"><i>$</i><input data-f="cash" value="323.00" inputmode="decimal" aria-label="Cash amount"></span></label>
+          <label class="well"><span class="slabel">Card</span><span class="amt"><i>$</i><input data-f="card" value="777.00" inputmode="decimal" aria-label="Card amount"></span></label>
+          <label class="well"><span class="slabel">Gratuity</span><span class="amt"><i>$</i><input data-f="grat" value="216.00" inputmode="decimal" placeholder="0.00" aria-label="Gratuity amount"></span></label>
+        </div>
+        <div class="mini" style="margin-top:8px;color:var(--ink3)">Leave gratuity blank on a night with no large parties.</div>
+        <div class="calc" data-calc>
+          <div class="ln"><span data-out="entlabel">Entered (whole day)</span><span data-out="ent">$1,316.00</span></div>
+          <div class="ln sub" data-lunchln><span>− Lunch already recorded</span><span data-out="lun">−$260.00</span></div>
+          <div class="ln tot"><span>Dinner records</span><span data-out="fin">$1,056.00</span></div>
+        </div>
+        <div class="warn" data-warn hidden></div>
+      </div>
+
+      <div class="c">
+        <div class="row"><span class="slabel">Who’s splitting</span><span class="mini" style="margin-left:auto;color:var(--ink3)">tap a badge to change a share</span></div>
+        <div class="chips" data-roster style="margin-top:10px"></div>
+      </div>
+
+      <div class="c tight" data-payoutcard>
+        <div class="slabel">What each person takes</div>
+        <div class="rows" data-payout style="margin-top:9px"></div>
+      </div>
+
+      <div class="strip"><span class="slabel" data-out="striplabel">Full share</span><b data-out="each">$45.56</b><span class="of" data-out="pool">of $205.00 cash</span></div>
+
+      <div data-noteclosed><button class="ghost" data-open>+ Add a note</button></div>
+      <div class="c" data-noteopen hidden>
+        <div class="row"><span class="slabel">Note</span><span class="mini" style="margin-left:auto;color:var(--ink3)" data-out="count">0 / 280</span></div>
+        <textarea data-f="note" rows="3" placeholder="Drawer was $20 short — Marco recounted, still short." style="margin-top:7px"></textarea>
+        <div class="row" style="margin-top:9px;gap:8px">
+          <button class="ghost" style="width:auto;padding:7px 14px" data-cancel>Cancel</button>
+          <button class="ghost" style="width:auto;padding:7px 14px;border-style:solid;background:var(--tint);border-color:var(--accent);color:var(--alert)" data-savenote>Save</button>
+        </div>
+      </div>
+      <div class="c tight notepreview" data-notedone hidden>
+        <div class="row"><span class="nglyph">note</span><span class="mini" data-out="notepreview"></span><button style="font-weight:700;color:var(--accent);margin-left:auto" data-edit>edit</button></div>
+      </div>
+
+      <div class="bar"><button class="prim">Speak it in</button><button data-save>Save</button></div>
+    </div>
+
+    <div class="phone saved" id="flow">
+      <div data-screen="saved">
+        <div style="padding:22px 6px 0;text-align:center">
+          <div class="ok16">✓</div>
+          <b style="display:block;font-size:26px;margin-top:14px">Saved</b>
+          <div class="mini" style="margin-top:4px">Dinner · Wed, Aug 27</div>
+        </div>
+        <div class="c">
+          <div class="row"><span class="dot"></span><b>Babytuna Sushi</b></div>
+          <div class="g3" style="margin-top:12px">
+            <div class="well"><span class="slabel">Cash</span><div class="amt ro"><i>$</i><b style="font-size:17px">205.00</b></div></div>
+            <div class="well"><span class="slabel">Card</span><div class="amt ro"><i>$</i><b style="font-size:17px">635.00</b></div></div>
+            <div class="well"><span class="slabel">Gratuity</span><div class="amt ro"><i>$</i><b style="font-size:17px">216.00</b></div></div>
+          </div>
+          <div class="mini" style="margin-top:11px">5 people · full share <b>$45.56</b>, Kenji <b>$22.78</b> (50%)</div>
+          <div class="mini" style="margin-top:3px;color:var(--ink3)">Ana, Marco, Priya, Dee, Kenji</div>
+          <div class="row" style="margin-top:11px"><span class="nglyph">note</span><span class="mini" style="flex:1">Drawer $20 short — Marco recounted.</span></div>
+        </div>
+        <div style="flex:1"></div>
+        <div>
+          <div class="mini" style="text-align:center;color:var(--ink3)">Back to the scan screen in <b data-out="cd">10</b>s</div>
+          <div class="cdbar"><i data-out="cdbar" style="width:100%"></i></div>
+        </div>
+        <div class="bar"><button data-done>Done</button></div>
+      </div>
+
+      <div data-screen="scan" hidden>
+        <div style="padding:34px 4px 0">
+          <h1 class="scanh1">Scan to enter</h1>
+          <p class="mini" style="margin-top:6px">Every entry starts with the QR code by the register</p>
+        </div>
+        <div class="c row" style="align-items:flex-start;gap:14px;margin-top:14px">
+          <span class="qrbox"><svg width="46" height="46" viewBox="0 0 56 56" fill="none" stroke="currentColor" stroke-width="3" aria-hidden>
+            <rect x="6" y="6" width="16" height="16" rx="3"/><rect x="34" y="6" width="16" height="16" rx="3"/><rect x="6" y="34" width="16" height="16" rx="3"/>
+            <rect x="11.5" y="11.5" width="5" height="5" fill="currentColor" stroke="none"/><rect x="39.5" y="11.5" width="5" height="5" fill="currentColor" stroke="none"/>
+            <rect x="11.5" y="39.5" width="5" height="5" fill="currentColor" stroke="none"/><rect x="34" y="34" width="6" height="6" fill="currentColor" stroke="none"/>
+            <rect x="44" y="34" width="6" height="6" fill="currentColor" stroke="none"/><rect x="34" y="44" width="6" height="6" fill="currentColor" stroke="none"/></svg></span>
+          <div style="padding-top:4px"><b>Two ways to scan</b><p class="mini" style="margin-top:3px;color:var(--ink2)">Use your camera app or scan it here.</p></div>
+        </div>
+        <div style="flex:1"></div>
+        <div class="bar"><button class="prim" style="flex:1">Scan the QR code</button></div>
+      </div>
+    </div>
+    <div class="cap">Confirmation holds 10s, then hands the phone back to the scan gate · <button class="replay" data-replay>replay</button></div>
+  </div>
+  <div class="spec">
+    <div>
+      <h4>A1 · gratuity + scope</h4>
+      <ul>
+        <li>Labelled <b>Gratuity</b> — not "auto-grat". Third well, visually <b>identical</b> to Cash and Card: no green, no tint of any kind. Blank is legal and means <code>0</code>. <b>No 18%-of-subtotal calculator</b>.</li>
+        <li>All three amounts carry a <b>rule under the value</b> that turns accent-red on focus. That underline is the only thing marking them as typeable — it is not decoration.</li>
+        <li>Scope switch sits directly above the wells with <b>no label over it</b>, defaults to <b>Whole day</b> on dinner, and is hidden entirely on lunch.</li>
+        <li>On <b>Whole day</b>: subtract today’s recorded lunch <b>field by field</b> (cash−cash, card−card, grat−grat) at this location. The receipt shows entered → −lunch → records.</li>
+        <li>Save stores <b>both</b> the typed figures and the derived shift figures.</li>
+      </ul>
+    </div>
+    <div>
+      <h4>B1 · partial shares</h4>
+      <ul>
+        <li>Badge on each selected chip: tapping cycles <b>100 → 75 → 50 → 25</b> and wraps. Tapping the chip body still toggles the person on/off.</li>
+        <li>Pool is distributed <b>by weight</b>: full share = <code>pool ÷ Σweights</code>. Kenji at 50% raises everyone else from $41.00 to $45.56.</li>
+        <li>“What each person takes” <b>only renders when at least one share is under 100%</b>. All-full nights show nothing but the strip.</li>
+        <li>Strip label: <code>Split N ways</code> when even, <code>Full share</code> when uneven.</li>
+        <li>Largest-remainder allocation — the shares must sum to the pool exactly, to the cent.</li>
+      </ul>
+    </div>
+    <div>
+      <h4>C1 · note + edge cases</h4>
+      <ul>
+        <li>Dashed “+ Add a note” under the strip → textarea (280 max, live counter) → Cancel / Attach → one-line preview with an <b>edit</b> affordance. Empty text on Attach collapses back to the dashed button.</li>
+        <li>Never required; no note = no column noise on the dashboard.</li>
+        <li>The note’s confirm button reads <b>Save</b>, not "Attach".</li>
+        <li><b>Lunch not on record + Whole day</b>: <b>show the closer nothing</b> — no banner, no extra tap. It still saves <b>flagged</b> with reason <code>day_total_no_lunch</code> for the manager. Nothing at the register can fix it, so it is not the closer’s problem to read.</li>
+        <li><b>Subtraction goes negative</b>: the one warning that does show — red, with <b>Save disabled</b> until it is fixed.</li>
+        <li><b>Saved screen</b>: the same three wells as the entry form (Cash · Card · Gratuity, same grid, same type) but read-only — <b>no underline</b>, since nothing on it is typeable. Holds <b>10 seconds</b> with a visible countdown, then hands the phone back to the scan gate; <b>Done</b> skips the wait.</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<h2>2 · Recorded tips — D2</h2>
+<p class="lede">Today’s columns stay exactly as they are; the row unfolds. Click any row. The detail panel is where the new data lives — the arithmetic that produced the number, the gratuity, the per-person weighted table, and the note in full.</p>
+
+<div class="panel">
+  <div class="ph"><b>Recorded tips</b><span>web/src/components/manager/dashboard/LedgerPage.tsx</span></div>
+  <div class="pb flat"><div class="wideframe" id="ledger">
+    <div class="tbar"><b>Recorded tips</b><span class="mini">Aug 21 – Aug 27 · 14 records · click a row for the breakdown</span><span class="tbtn" style="margin-left:auto">Export CSV</span></div>
+    <table class="ledger">
+      <thead><tr><th></th><th>Business date</th><th>Restaurant</th><th>Meal</th><th class="r cash">Cash pool</th><th>Split between</th><th class="r cash">Per person</th><th class="r card">Card → payroll</th><th>Entered by</th><th></th></tr></thead>
+      <tbody>
+        <tr class="daytot"><td colspan="4">Wed, Aug 27</td><td class="r cash">$323.00</td><td class="cash"></td><td class="cash"></td><td class="r card">$777.00</td><td colspan="2"></td></tr>
+        <tr class="exp open" data-exp>
+          <td class="tw"><span class="tri">▾</span></td><td>Wed, Aug 27</td><td><span class="lchip sushi">Sushi</span></td><td>Dinner</td>
+          <td class="r cash b"><span class="scope" title="Entered as a whole-day total, lunch subtracted">day −lunch</span> $205.00</td>
+          <td>5 names <span class="mark">1 partial</span></td>
+          <td class="r cash xb">$45.56 <span class="sub2">full share</span></td>
+          <td class="r card">$635.00</td><td class="mut">Dee · dictated</td>
+          <td class="r"><span class="nglyph">note</span></td>
+        </tr>
+        <tr class="det"><td></td><td colspan="9">
+          <div class="detgrid">
+            <div class="dcard">
+              <div class="slabel">How this number was reached</div>
+              <div class="calc" style="margin-top:8px;border:0;padding:0">
+                <div class="ln"><span>Entered from Square (whole day)</span><span>$323.00</span></div>
+                <div class="ln sub"><span>− lunch recorded 3:41 PM</span><span>−$118.00</span></div>
+                <div class="ln tot"><span>Dinner cash pool</span><span>$205.00</span></div>
+              </div>
+              <div class="hair2"></div>
+              <div class="calc" style="border:0;padding:0;margin:0">
+                <div class="ln"><span>Card → payroll</span><span>$635.00</span></div>
+                <div class="ln"><span>Gratuity</span><span>$216.00</span></div>
+              </div>
+            </div>
+            <div class="dcard">
+              <div class="slabel">Who takes what</div>
+              <table class="mini2"><tbody>
+                <tr><td>Ana</td><td class="r mut">full</td><td class="r b">$45.56</td></tr>
+                <tr><td>Marco</td><td class="r mut">full</td><td class="r b">$45.56</td></tr>
+                <tr><td>Priya</td><td class="r mut">full</td><td class="r b">$45.55</td></tr>
+                <tr><td>Dee</td><td class="r mut">full</td><td class="r b">$45.55</td></tr>
+                <tr><td>Kenji</td><td class="r mut">50%</td><td class="r b">$22.78</td></tr>
+                <tr class="tt"><td>Pool</td><td></td><td class="r b">$205.00</td></tr>
+              </tbody></table>
+            </div>
+            <div class="dcard">
+              <div class="slabel">Note · Dee, 10:52 PM</div>
+              <p class="ntext">Drawer $20 short — Marco recounted, still short. Kenji only came in 6–8 to cover Priya’s break.</p>
+              <div class="row" style="margin-top:11px;gap:8px"><span class="tbtn sm">Fix entry</span></div>
+            </div>
+          </div>
+        </td></tr>
+        <tr class="exp" data-exp>
+          <td class="tw"><span class="tri">▸</span></td><td>Wed, Aug 27</td><td><span class="lchip sushi">Sushi</span></td><td>Lunch</td>
+          <td class="r cash b">$118.00</td><td>3 names</td><td class="r cash xb">$39.33</td><td class="r card">$142.00</td><td class="mut">Ana · typed</td><td></td>
+        </tr>
+        <tr class="det" hidden><td></td><td colspan="9"><div class="detgrid">
+          <div class="dcard"><div class="slabel">How this number was reached</div><div class="calc" style="margin-top:8px;border:0;padding:0"><div class="ln tot"><span>Entered as lunch only</span><span>$118.00</span></div></div><div class="hair2"></div><div class="calc" style="border:0;padding:0;margin:0"><div class="ln"><span>Card → payroll</span><span>$142.00</span></div><div class="ln"><span>Gratuity</span><span>none</span></div></div></div>
+          <div class="dcard"><div class="slabel">Who takes what</div><table class="mini2"><tbody><tr><td>Ana</td><td class="r mut">full</td><td class="r b">$39.33</td></tr><tr><td>Priya</td><td class="r mut">full</td><td class="r b">$39.33</td></tr><tr><td>Dee</td><td class="r mut">full</td><td class="r b">$39.34</td></tr><tr class="tt"><td>Pool</td><td></td><td class="r b">$118.00</td></tr></tbody></table></div>
+          <div class="dcard"><div class="slabel">Note</div><p class="ntext mut">No note on this entry.</p><div class="row" style="margin-top:11px"><span class="tbtn sm">Fix entry</span></div></div>
+        </div></td></tr>
+        <tr class="exp flag" data-exp>
+          <td class="tw"><span class="tri">▸</span></td><td>Tue, Aug 26</td><td><span class="lchip poki">Poki &amp; Pho</span></td><td>Dinner</td>
+          <td class="r b">$822.00 <span class="fchip">⚑ check</span></td><td>2 names <span class="mark">1 partial</span></td><td class="r xb">$657.60 <span class="sub2">full share</span></td><td class="r">$210.00</td><td class="mut">Sam · typed</td><td class="r"><span class="tbtn sm prim">Verify</span></td>
+        </tr>
+        <tr class="det" hidden><td></td><td colspan="9"><div class="detgrid">
+          <div class="dcard"><div class="slabel">How this number was reached</div><div class="calc" style="margin-top:8px;border:0;padding:0"><div class="ln"><span>Entered from Square (whole day)</span><span>$822.00</span></div><div class="ln sub"><span>− lunch recorded</span><span>nothing on record</span></div><div class="ln tot"><span>Dinner cash pool</span><span>$822.00</span></div></div><p class="ntext" style="color:var(--alert)">Flagged <code>day_total_no_lunch</code> — a whole-day total was entered with no lunch to subtract.</p></div>
+          <div class="dcard"><div class="slabel">Who takes what</div><table class="mini2"><tbody><tr><td>Sam</td><td class="r mut">full</td><td class="r b">$657.60</td></tr><tr><td>Rey</td><td class="r mut">25%</td><td class="r b">$164.40</td></tr><tr class="tt"><td>Pool</td><td></td><td class="r b">$822.00</td></tr></tbody></table></div>
+          <div class="dcard"><div class="slabel">Note · Sam, 9:58 PM</div><p class="ntext">Party of 30 on the patio, one check.</p><div class="row" style="margin-top:11px;gap:8px"><span class="tbtn sm prim">Verify</span><span class="tbtn sm">Fix entry</span></div></div>
+        </div></td></tr>
+      </tbody>
+    </table>
+  </div></div>
+  <div class="spec">
+    <div><h4>Columns</h4><ul>
+      <li>Existing columns keep their existing widths and tints. <b>Two additions only</b>: a caret column at the left and a note/action cell at the right.</li>
+      <li>Cash cell gains a <code>day −lunch</code> badge when the entry was recorded from a whole-day total; hover shows the raw figure.</li>
+      <li>“Split between” shows <code>N names</code> + a <code>1 partial</code> mark when any weight &lt; 1; “Per person” shows the full share with a <code>full share</code> caption instead of a flat average.</li>
+      <li>Gratuity gets <b>no top-level column</b> — it lives in the detail panel and the CSV.</li>
+    </ul></div>
+    <div><h4>Detail panel</h4><ul>
+      <li>Three cards: <b>how this number was reached</b> (raw → −lunch → recorded, then card + grat), <b>who takes what</b> (every name, weight, dollars, and a Pool total that must equal the cash pool), <b>note</b> (author + time, or “No note on this entry.”).</li>
+      <li>Flagged rows: keep the red tint and Verify; a flagged row <b>auto-opens</b> its detail when the range first loads.</li>
+      <li>Fix dialog gains gratuity, the scope switch, per-person weights and the note.</li>
+    </ul></div>
+    <div><h4>Everything else</h4><ul>
+      <li>CSV export gains <code>auto_grat</code>, <code>entered_scope</code>, <code>raw_cash</code>, <code>raw_card</code>, <code>note</code>, and a per-person weight column.</li>
+      <li>Overview take-home-by-person must use the same weighted allocation, not <code>cash ÷ split_count</code>.</li>
+      <li>Voice entry is unchanged in this phase: it still fills cash / card / people only.</li>
+    </ul></div>
+  </div>
+</div>
+
+</main>
+<script>
+const $=(s,r=document)=>r.querySelector(s),$$=(s,r=document)=>[...r.querySelectorAll(s)];
+function M(n){const neg=n<-0.0001,v=Math.abs(Math.round(n*100)/100).toFixed(2),p=v.split(".");
+  return (neg?"−$":"$")+p[0].replace(/\B(?=(\d{3})+(?!\d))/g,",")+"."+p[1]}
+const num=el=>{const v=parseFloat(String(el.value).replace(/[^0-9.]/g,""));return isFinite(v)?v:0};
+function allocate(poolCents,weights){
+  const total=weights.reduce((a,b)=>a+b,0);
+  if(total<=0||poolCents<=0)return weights.map(()=>0);
+  const raw=weights.map(w=>poolCents*w/total),base=raw.map(Math.floor);
+  let rest=poolCents-base.reduce((a,b)=>a+b,0);
+  const order=raw.map((v,i)=>[v-Math.floor(v),i]).sort((a,b)=>b[0]-a[0]);
+  for(let k=0;k<rest;k++)base[order[k%order.length][1]]++;
+  return base;
+}
+/* lunch-on-record scenario */
+let LUNCH={cash:118,card:142,grat:0},hasLunch=true;
+$$("[data-lunch]").forEach(b=>b.onclick=()=>{
+  hasLunch=b.dataset.lunch==="yes";
+  $$("[data-lunch]").forEach(x=>x.setAttribute("aria-pressed",String(x===b)));
+  LUNCH=hasLunch?{cash:118,card:142,grat:0}:{cash:0,card:0,grat:0};
+  render();
+});
+/* entry screen */
+const P=$("#entry"),f=n=>$(`[data-f="${n}"]`,P),out=n=>$(`[data-out="${n}"]`,P);
+const CYCLE=[1,.75,.5,.25];
+const people=["Ana","Marco","Priya","Dee","Kenji"].map((n,i)=>({n,on:true,w:i===4?.5:1}));
+let scope="day";
+$$("[data-scope] button",P).forEach(b=>b.onclick=()=>{
+  scope=b.dataset.v;$$("[data-scope] button",P).forEach(x=>x.classList.toggle("on",x===b));render();
+});
+$$("input",P).forEach(i=>i.addEventListener("input",render));
+/* note */
+const closed=$("[data-noteclosed]",P),open=$("[data-noteopen]",P),done=$("[data-notedone]",P),ta=f("note");
+const show=(a,b,c)=>{closed.hidden=!a;open.hidden=!b;done.hidden=!c};
+$("[data-open]",P).onclick=()=>{show(0,1,0);ta.focus()};
+$("[data-cancel]",P).onclick=()=>show(1,0,0);
+$("[data-edit]",P).onclick=()=>{show(0,1,0);ta.focus()};
+$("[data-savenote]",P).onclick=()=>{
+  if(!ta.value.trim())return show(1,0,0);
+  out("notepreview").textContent=ta.value.trim();show(0,0,1);
+};
+ta.addEventListener("input",()=>out("count").textContent=`${ta.value.length} / 280`);
+
+function render(){
+  const cash=num(f("cash")),card=num(f("card")),grat=num(f("grat")),day=scope==="day";
+  const sub=day?LUNCH:{cash:0,card:0,grat:0};
+  const nc=cash-sub.cash,nd=card-sub.card,ng=grat-sub.grat;
+  out("entlabel").textContent=day?"Entered (whole day)":"Entered (dinner only)";
+  out("ent").textContent=M(cash+card+grat);
+  $("[data-lunchln]",P).hidden=!day;
+  out("lun").textContent="−"+M(sub.cash+sub.card+sub.grat);
+  out("fin").textContent=M(nc+nd+ng);
+
+  // Only the blocking case is surfaced. A whole-day dinner with no lunch on
+  // record still saves FLAGGED for the manager — the closer is never told,
+  // because there is nothing they can do about it at the register.
+  const negative=nc<0||nd<0||ng<0;
+  const warn=$("[data-warn]",P);
+  warn.hidden=!negative;
+  warn.innerHTML="Lunch already recorded more than this. Check the Square report — <b>Save is off until this is fixed.</b>";
+  $("[data-save]",P).disabled=negative;
+
+  /* roster + weights */
+  $("[data-roster]",P).innerHTML=people.map((x,i)=>
+    `<span class="chip${x.on?" on":""}" data-i="${i}">${x.n}${x.on?`<b class="pct" data-b="${i}">${Math.round(x.w*100)}%</b>`:""}</span>`).join("");
+  $$("[data-i]",P).forEach(c=>c.onclick=e=>{
+    if(e.target.dataset.b!==undefined){const i=+e.target.dataset.b;people[i].w=CYCLE[(CYCLE.indexOf(people[i].w)+1)%CYCLE.length]}
+    else{const i=+c.dataset.i;people[i].on=!people[i].on}
+    render();
+  });
+  const live=people.filter(x=>x.on),pool=Math.max(0,nc);
+  const cents=allocate(Math.round(pool*100),live.map(x=>x.w));
+  const uneven=live.some(x=>x.w<1);
+  $("[data-payoutcard]",P).hidden=!uneven||live.length===0;
+  $("[data-payout]",P).innerHTML=!uneven?"":live.map((x,i)=>
+    `<div class="prow"><span class="nm">${x.n}</span>${x.w<1?`<span class="sub">${Math.round(x.w*100)}% share</span>`:""}<span class="amtv">${M(cents[i]/100)}</span></div>`).join("");
+  const sumW=live.reduce((a,b)=>a+b.w,0);
+  out("striplabel").textContent=uneven?"Full share":`Split ${live.length} ways`;
+  out("each").textContent=sumW?M(pool/sumW):"$0.00";
+  out("pool").textContent="of "+M(pool)+" cash";
+}
+render();
+/* confirmation → scan gate */
+(function(){
+  const F=$("#flow"),saved=$('[data-screen="saved"]',F),scan=$('[data-screen="scan"]',F);
+  const HOLD=10; let left=HOLD,timer=null;
+  function tick(){
+    left-=1;
+    $('[data-out="cd"]',F).textContent=Math.max(0,left);
+    $('[data-out="cdbar"]',F).style.width=Math.max(0,left/HOLD*100)+"%";
+    if(left<=0)finish();
+  }
+  function finish(){clearInterval(timer);timer=null;saved.hidden=true;scan.hidden=false}
+  function start(){
+    clearInterval(timer);left=HOLD;saved.hidden=false;scan.hidden=true;
+    $('[data-out="cd"]',F).textContent=HOLD;$('[data-out="cdbar"]',F).style.width="100%";
+    timer=setInterval(tick,1000);
+  }
+  $("[data-done]",F).onclick=finish;
+  $("[data-replay]").onclick=start;
+  start();
+})();
+
+/* ledger rows */
+$$("[data-exp]",$("#ledger")).forEach(row=>row.onclick=()=>{
+  const det=row.nextElementSibling,isOpen=!det.hidden;
+  det.hidden=isOpen;row.classList.toggle("open",!isOpen);
+  row.querySelector(".tri").textContent=isOpen?"▸":"▾";
+});
+</script>
+</body>
+</html>

--- a/docs/mockups/tips-v3/tips-v3-proposals.html
+++ b/docs/mockups/tips-v3/tips-v3-proposals.html
@@ -1,0 +1,1402 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Smelter Tips v3 — interface proposals</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+button{font:inherit;cursor:pointer;background:none;border:0;color:inherit}
+input,textarea,select{font:inherit;color:inherit}
+:root{
+  --cream:#f5f5f4;--card:#fff;--well:#ededec;--accent:#e84d38;--tint:#fbeae7;--alert:#c03520;
+  --ink:#1a1a1a;--ink2:#5f5f5f;--ink3:#9c9890;--disabled:#c9c5bc;
+  --line:rgba(0,0,0,.08);--hair:rgba(0,0,0,.06);
+  --blue:#2563eb;--green:#1f7a4d;--amber:#b7791f;
+  --cashcol:rgba(216,144,32,.06);--cardcol:rgba(37,99,235,.055);--gratcol:rgba(31,122,77,.07);
+  --flagtint:#fdecea;
+  --sans:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+}
+body{font-family:var(--sans);background:#e6e7e9;color:var(--ink);font-size:14px;line-height:1.45;-webkit-font-smoothing:antialiased}
+.tnum{font-variant-numeric:tabular-nums}
+
+/* ---------- mockup chrome ---------- */
+#chrome{position:sticky;top:0;z-index:80;background:#101319;color:#e7e9ee;padding:9px 18px;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+#chrome .brand{font-weight:700;letter-spacing:-.01em}
+#chrome .brand i{color:var(--accent);font-style:normal}
+#chrome .sub{color:#8a93a6;font-size:12px;margin-right:auto}
+#chrome nav{display:flex;gap:6px;flex-wrap:wrap}
+#chrome nav button{padding:6px 13px;border-radius:8px;font-size:12.5px;font-weight:600;color:#c6ccd8;border:1px solid #2a3040}
+#chrome nav button[aria-pressed="true"]{background:#e7e9ee;color:#101319;border-color:#e7e9ee}
+
+/* ---------- page scaffolding ---------- */
+main{padding:26px 20px 90px;max-width:1560px;margin:0 auto}
+section[data-tab]{display:none}
+section[data-tab].live{display:block}
+.intro{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:20px 22px;margin-bottom:24px;max-width:1000px}
+.intro h2{font-size:21px;letter-spacing:-.01em;margin-bottom:8px}
+.intro p{color:var(--ink2);margin-bottom:9px;max-width:88ch}
+.intro p:last-child{margin-bottom:0}
+.intro b{color:var(--ink)}
+.rule{background:var(--well);border-radius:11px;padding:11px 13px;margin-top:12px;font-size:13px;color:var(--ink2)}
+.rule code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12.5px;color:var(--ink);background:#fff;padding:1px 5px;border-radius:5px;border:1px solid var(--line)}
+.ask{border-left:3px solid var(--accent);background:var(--tint);border-radius:0 11px 11px 0;padding:11px 14px;margin-top:12px;font-size:13px;color:#7c2a19}
+.ask b{color:var(--alert)}
+
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(392px,1fr));gap:20px;align-items:start}
+.stack{display:flex;flex-direction:column;gap:20px}
+
+/* ---------- option shell ---------- */
+.opt{background:var(--card);border:1px solid var(--line);border-radius:18px;overflow:hidden;display:flex;flex-direction:column}
+.oh{display:flex;gap:12px;padding:16px 18px;border-bottom:1px solid var(--hair)}
+.oh .no{flex:none;width:34px;height:34px;border-radius:9px;background:#101319;color:#fff;font-weight:800;font-size:12.5px;display:flex;align-items:center;justify-content:center;letter-spacing:.02em}
+.oh h3{font-size:16px;letter-spacing:-.01em;line-height:1.25}
+.oh p{color:var(--ink2);font-size:12.5px;margin-top:4px}
+.obody{padding:18px;background:#f0f0f1;display:flex;justify-content:center}
+.ofoot{padding:13px 18px 16px;border-top:1px solid var(--hair);display:grid;gap:6px}
+.ofoot div{font-size:12.5px;color:var(--ink2);display:flex;gap:8px}
+.ofoot div span{flex:none;font-weight:800;font-size:10px;letter-spacing:.06em;text-transform:uppercase;width:38px;padding-top:2px}
+.ofoot .up span{color:var(--green)}
+.ofoot .dn span{color:var(--amber)}
+.ofoot .qq span{color:var(--accent)}
+
+/* ---------- phone frame + app primitives ---------- */
+.phone{width:100%;max-width:372px;background:var(--cream);border-radius:26px;border:1px solid rgba(0,0,0,.1);padding:14px 13px 12px;display:flex;flex-direction:column;gap:11px}
+.phone.tall{min-height:640px}
+.phead{display:flex;align-items:center;gap:8px}
+.phead b{font-size:24px;letter-spacing:-.02em}
+.phead .pill{margin-left:auto;background:var(--card);border-radius:999px;padding:5px 11px;font-size:12px}
+.phead .who{background:var(--card);border-radius:999px;padding:4px 10px 4px 4px;font-size:12px;display:flex;align-items:center;gap:6px}
+.av{width:21px;height:21px;border-radius:50%;background:var(--accent);color:#fff;font-size:10px;font-weight:800;display:flex;align-items:center;justify-content:center}
+.c{background:var(--card);border-radius:20px;padding:14px}
+.c.tight{padding:11px 14px}
+.row{display:flex;align-items:center;gap:10px}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--accent);flex:none}
+.chev{margin-left:auto;color:var(--ink3)}
+.slabel{font-size:10.5px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--ink3)}
+.seg{display:flex;background:var(--well);border-radius:999px;padding:3px;gap:3px}
+.seg button{flex:1;border-radius:999px;padding:9px 6px;font-size:13.5px;font-weight:600;color:var(--ink2);text-align:center}
+.seg button.on{background:var(--card);color:var(--ink);box-shadow:0 1px 2px rgba(0,0,0,.07)}
+.seg.sm button{padding:6px 8px;font-size:12px}
+.seg.dark{background:#1a1a1a;padding:3px}
+.seg.dark button{color:#a6a6a6}
+.seg.dark button.on{background:#fff;color:#1a1a1a}
+.well{background:var(--well);border-radius:14px;padding:12px}
+.amt{display:flex;align-items:baseline;gap:3px;margin-top:2px}
+.amt i{font-style:normal;font-size:20px;font-weight:700;color:var(--ink2)}
+.amt input{width:100%;background:none;border:0;outline:0;font-size:22px;font-weight:700;letter-spacing:-.01em;font-variant-numeric:tabular-nums}
+.amt input::placeholder{color:var(--ink3)}
+.amt.sm input{font-size:17px}
+.amt.sm i{font-size:15px}
+.g2{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.g3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
+.chips{display:flex;flex-wrap:wrap;gap:7px}
+.chip{border:1px solid var(--line);background:var(--card);border-radius:999px;padding:7px 12px;font-size:13px;font-weight:600;color:var(--ink2);display:flex;align-items:center;gap:6px}
+.chip.on{background:var(--tint);border-color:var(--accent);color:var(--alert)}
+.chip .pct{font-size:10.5px;font-weight:800;background:#fff;border:1px solid var(--line);border-radius:999px;padding:1px 6px;color:var(--ink2)}
+.chip.on .pct{background:var(--accent);border-color:var(--accent);color:#fff}
+.strip{background:var(--card);border-radius:20px;padding:11px 14px;display:flex;align-items:baseline;gap:8px}
+.strip b{font-size:19px;letter-spacing:-.01em}
+.strip .of{margin-left:auto;color:var(--ink3);font-size:12.5px}
+.bar{display:flex;gap:9px}
+.bar button{flex:1;border-radius:999px;padding:13px;font-weight:700;font-size:14.5px;background:var(--card);text-align:center}
+.bar button.prim{background:var(--accent);color:#fff;flex:1.3}
+.mini{font-size:12px;color:var(--ink2)}
+.mini b{color:var(--ink)}
+.calc{border-top:1px dashed var(--line);margin-top:11px;padding-top:10px;display:grid;gap:5px;font-size:12.5px;font-variant-numeric:tabular-nums}
+.calc .ln{display:flex;color:var(--ink2)}
+.calc .ln span:last-child{margin-left:auto;font-weight:600;color:var(--ink)}
+.calc .ln.sub span:last-child{color:var(--alert)}
+.calc .ln.tot{border-top:1px solid var(--line);padding-top:6px;margin-top:2px;font-weight:800;color:var(--ink)}
+.calc .ln.tot span:last-child{font-size:15px}
+.warn{background:var(--tint);color:var(--alert);border-radius:11px;padding:9px 11px;font-size:12.5px;margin-top:10px}
+.ok{color:var(--green)}
+.hair{height:1px;background:var(--hair);margin:11px -14px}
+.ghost{border:1px dashed var(--line);border-radius:12px;padding:10px;width:100%;text-align:center;font-size:12.5px;font-weight:600;color:var(--ink2)}
+</style>
+</head>
+<body>
+<header id="chrome">
+  <div class="brand"><i>smelter</i> tips</div>
+  <div class="sub">v3 interface proposals · nothing implemented · pick per feature</div>
+  <nav id="tabs">
+    <button data-go="grat" aria-pressed="true">A · Auto-grat + dinner scope</button>
+    <button data-go="share">B · Partial shares</button>
+    <button data-go="notes">C · Notes</button>
+    <button data-go="dash">D · Dashboard</button>
+    <button data-go="q">Open questions</button>
+  </nav>
+</header>
+<main>
+
+<!-- ============================ A · AUTO-GRAT + DINNER SCOPE ============================ -->
+<section data-tab="grat" class="live">
+  <div class="intro">
+    <h2>A · Auto-gratuity input + “is this the whole day?” toggle</h2>
+    <p>Two problems in one card. <b>(1)</b> The 18% auto-gratuity needs somewhere to live. <b>(2)</b> Square’s dinner/close-out report bundles the <i>whole day</i>, so typing it in straight makes dinner look enormous and inflates every total — dinner has to be able to say “this number is the day, subtract what lunch already recorded.”</p>
+    <div class="rule">Sample day used in all four: lunch is already recorded at <code>cash $118.00 · card $142.00</code>. The closer reads Square at close and sees <code>cash $323.00 · card $777.00 · auto-grat $216.00</code> for the whole day. Dinner-only therefore = <code>cash $205.00 · card $635.00 · grat $216.00</code>. Type in any well to watch the math move.</p>
+    <div class="ask"><b>Before I build:</b> is the auto-grat <i>already inside</i> that Card number on the Square report (a carve-out — “of the $777, $216 is auto-grat”), or does it arrive separately and get added on top? A1 and A3 treat it as its own bucket; A2 and A4 let you say which. This changes the totals, not just the layout.</div>
+  </div>
+
+  <div class="grid">
+
+    <!-- A1 -->
+    <article class="opt">
+      <header class="oh"><span class="no">A1</span><div>
+        <h3>Three wells, one scope switch</h3>
+        <p>Today’s screen with the least surgery: auto-grat becomes a third well, and a small segmented control above the amounts declares what the numbers mean. Subtraction shows as a receipt under the card.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="a1">
+        <div class="phead"><b>Tips</b><span class="pill">Wed, Aug 27</span><span class="who"><span class="av">D</span>Dee</span></div>
+        <div class="c tight row"><span class="dot"></span><b>Babytuna Sushi</b><span class="chev">›</span></div>
+        <div class="seg"><button>Lunch</button><button class="on">Dinner</button></div>
+        <div class="c">
+          <div class="row" style="margin-bottom:9px"><span class="slabel">These numbers are</span></div>
+          <div class="seg sm" data-scope>
+            <button class="on" data-v="day">Whole day (Square)</button>
+            <button data-v="shift">Dinner only</button>
+          </div>
+          <div class="g3" style="margin-top:11px">
+            <label class="well"><span class="slabel">Cash</span><span class="amt sm"><i>$</i><input data-f="cash" value="323.00" inputmode="decimal"></span></label>
+            <label class="well"><span class="slabel">Card</span><span class="amt sm"><i>$</i><input data-f="card" value="777.00" inputmode="decimal"></span></label>
+            <label class="well" style="background:var(--gratcol);outline:1px solid rgba(31,122,77,.18)"><span class="slabel" style="color:var(--green)">Auto-grat</span><span class="amt sm"><i>$</i><input data-f="grat" value="216.00" inputmode="decimal"></span></label>
+          </div>
+          <div class="mini" style="margin-top:8px;color:var(--ink3)">Leave the auto-grat well blank on a night with no large parties.</div>
+          <div class="calc" data-mathbox>
+            <div class="ln"><span>Entered (whole day)</span><span data-out="ent">$1,316.00</span></div>
+            <div class="ln sub"><span>− Lunch already recorded</span><span data-out="lun">−$260.00</span></div>
+            <div class="ln tot"><span>Dinner records</span><span data-out="fin">$1,056.00</span></div>
+          </div>
+        </div>
+        <div class="c"><div class="slabel">Who’s splitting</div>
+          <div class="chips" style="margin-top:9px"><span class="chip on">Ana</span><span class="chip on">Marco</span><span class="chip on">Priya</span><span class="chip on">Dee</span><span class="chip">Kenji</span></div>
+        </div>
+        <div class="strip"><span class="slabel">Split 4 ways</span><b data-out="each">$51.25</b><span class="of">cash pool $205.00</span></div>
+        <div class="bar"><button class="prim">Speak it in</button><button>Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Nearly zero retraining — the screen still reads Cash / Card / grat left-to-right, and the receipt proves the subtraction on screen before saving.</div>
+        <div class="dn"><span>cost</span>Three wells is a tight fit on a small phone; the scope switch is easy to blow past on autopilot.</div>
+        <div class="qq"><span>ask</span>Should the switch default to “Whole day” on dinner and “Dinner only” on lunch?</div>
+        <div class="up"><span>final</span>Chosen. Auto-grat is typed in or left blank — no 18%-of-subtotal calculator.</div>
+      </div>
+    </article>
+
+    <!-- A2 -->
+    <article class="opt">
+      <header class="oh"><span class="no">A2</span><div>
+        <h3>Receipt tape</h3>
+        <p>No grid at all. The entry becomes a paper-tape of line items you add and edit, and “lunch already recorded” is a real negative line you tick on or off — the subtraction is a thing you can see and delete, not a mode.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="a2">
+        <div class="phead"><b>Dinner</b><span class="pill">Wed, Aug 27 · Sushi</span></div>
+        <div class="c" style="padding:16px 15px">
+          <div class="slabel">Close-out tape</div>
+          <div class="tape" style="margin-top:10px">
+            <label class="tline"><span class="tl">Cash counted</span><span class="tv"><i>$</i><input data-f="cash" value="323.00" inputmode="decimal"></span></label>
+            <label class="tline"><span class="tl">Card tips (Square)</span><span class="tv"><i>$</i><input data-f="card" value="777.00" inputmode="decimal"></span></label>
+            <label class="tline"><span class="tl">Auto-gratuity 18% <button data-gratcalc style="color:var(--accent);font-weight:700;font-size:11px">calc</button></span><span class="tv"><i>$</i><input data-f="grat" value="216.00" inputmode="decimal"></span></label>
+            <div data-gratcalcbox hidden class="tsub">
+              <span>18% of a subtotal of <i>$</i><input data-f="sub" value="1200.00" inputmode="decimal" class="inl"> =</span> <b data-out="gratcalc">$216.00</b> <button data-usegrat style="color:var(--accent);font-weight:700">use</button>
+            </div>
+            <div class="tsub" data-gratin>
+              <label><input type="checkbox" data-f="gratinside" checked> The auto-grat is already inside the Card line above</label>
+            </div>
+            <label class="tline neg" data-lunchline>
+              <span class="tl"><input type="checkbox" data-f="minuslunch" checked> Subtract lunch (already recorded)</span>
+              <span class="tv neg" data-out="lunchamt">−$260.00</span>
+            </label>
+            <div class="tline total"><span class="tl">Dinner records</span><span class="tv" data-out="fin">$840.00</span></div>
+          </div>
+          <div class="mini" style="margin-top:10px;color:var(--ink3)">Lunch line pulled from today’s record at 3:41 PM · <button style="color:var(--accent);font-weight:700">see it</button></div>
+        </div>
+        <div class="c tight"><div class="slabel">Splitting the cash · 4</div>
+          <div class="chips" style="margin-top:8px"><span class="chip on">Ana</span><span class="chip on">Marco</span><span class="chip on">Priya</span><span class="chip on">Dee</span><span class="chip">Kenji</span></div>
+        </div>
+        <div class="strip"><span class="slabel">Each</span><b data-out="each">$51.25</b><span class="of">cash pool $205.00</span></div>
+        <div class="bar"><button class="prim">Speak it in</button><button>Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>The subtraction is a visible, deletable line — a closer can see exactly why dinner is smaller than what Square printed. Also the only option that asks whether grat is inside the card line.</div>
+        <div class="dn"><span>cost</span>A checkbox is a weaker signal than a segmented control; more reading per entry.</div>
+        <div class="qq"><span>ask</span>Should the lunch line be tickable at all, or always applied when lunch exists?</div>
+      </div>
+    </article>
+
+    <!-- A3 -->
+    <article class="opt">
+      <header class="oh"><span class="no">A3</span><div>
+        <h3>Day bar — enter once, split the day</h3>
+        <p>The closer types the Square day total once. A stacked bar shows the day being carved: lunch is locked (already banked), dinner is the remainder, auto-grat is its own band. You read the answer off a picture instead of a number.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="a3">
+        <div class="phead"><b>Close out</b><span class="pill">Wed, Aug 27</span></div>
+        <div class="c">
+          <div class="slabel">Square day total — tips</div>
+          <div class="amt" style="margin-top:4px"><i>$</i><input data-f="daytotal" value="1100.00" inputmode="decimal"></div>
+          <div class="mini" style="margin-top:4px;color:var(--ink3)">cash $323.00 + card $777.00 · <button style="color:var(--accent);font-weight:700" data-splitday>enter separately</button></div>
+          <div class="hair"></div>
+          <div class="slabel">Of that, auto-gratuity 18%</div>
+          <div class="amt sm" style="margin-top:2px"><i>$</i><input data-f="grat" value="216.00" inputmode="decimal"></div>
+          <div class="stack2" data-out="bar" style="margin-top:14px"></div>
+          <div class="legend" data-out="legend"></div>
+        </div>
+        <div class="c tight">
+          <div class="row"><span class="slabel">Dinner gets</span><b class="tnum" style="margin-left:auto;font-size:19px" data-out="fin">$840.00</b></div>
+          <div class="mini" style="margin-top:3px">day $1,100.00 − lunch $260.00 · <b class="ok">reconciles</b></div>
+        </div>
+        <div class="c tight"><div class="slabel">Splitting the cash · 4</div>
+          <div class="chips" style="margin-top:8px"><span class="chip on">Ana</span><span class="chip on">Marco</span><span class="chip on">Priya</span><span class="chip on">Dee</span><span class="chip">Kenji</span></div>
+        </div>
+        <div class="bar"><button class="prim">Save dinner</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Impossible to double-count: the day is a fixed pie and lunch is visibly already gone. Reads at arm’s length, good after a long shift.</div>
+        <div class="dn"><span>cost</span>Biggest departure from today’s screen; if lunch was never recorded the bar has nothing to subtract and has to degrade into A1.</div>
+        <div class="qq"><span>ask</span>Is one blended “day total” usable, or must cash and card always stay separate on entry?</div>
+      </div>
+    </article>
+
+    <!-- A4 -->
+    <article class="opt">
+      <header class="oh"><span class="no">A4</span><div>
+        <h3>Guided — one question per screen</h3>
+        <p>Ask, don’t assume. Three plain-English questions with a live preview of the consequence. Slower, but a closer cannot get the day/shift thing wrong, and it explains itself to whoever is covering tonight.</p>
+      </div></header>
+      <div class="obody"><div class="phone tall" data-opt="a4">
+        <div class="phead"><b>Dinner</b><span class="pill">Wed, Aug 27</span></div>
+        <div class="dots" data-dots><i class="on"></i><i></i><i></i></div>
+
+        <div class="c step" data-step="0">
+          <h4>What does the Square report say?</h4>
+          <p class="qsub">Type it exactly as printed — we’ll sort out the rest.</p>
+          <div class="g2" style="margin-top:12px">
+            <label class="well"><span class="slabel">Cash</span><span class="amt sm"><i>$</i><input data-f="cash" value="323.00" inputmode="decimal"></span></label>
+            <label class="well"><span class="slabel">Card</span><span class="amt sm"><i>$</i><input data-f="card" value="777.00" inputmode="decimal"></span></label>
+          </div>
+        </div>
+
+        <div class="c step" data-step="1" hidden>
+          <h4>Is that the whole day, or dinner only?</h4>
+          <p class="qsub">Square’s close-out usually bundles lunch in.</p>
+          <div class="picks" data-scope style="margin-top:12px">
+            <button class="pick on" data-v="day"><b>The whole day</b><span>Lunch is in there. We’ll take out the $260.00 lunch already recorded and save <em data-out="prevday">$840.00</em> for dinner.</span></button>
+            <button class="pick" data-v="shift"><b>Dinner only</b><span>Nothing to take out. We’ll save <em data-out="prevshift">$1,100.00</em> for dinner.</span></button>
+          </div>
+        </div>
+
+        <div class="c step" data-step="2" hidden>
+          <h4>Any auto-gratuity tonight?</h4>
+          <p class="qsub">Large parties, 18% added to the check.</p>
+          <div class="seg" data-gyn style="margin-top:12px"><button class="on" data-v="y">Yes</button><button data-v="n">No</button></div>
+          <div data-gbox style="margin-top:11px">
+            <div class="g2">
+              <label class="well"><span class="slabel">Grat amount</span><span class="amt sm"><i>$</i><input data-f="grat" value="216.00" inputmode="decimal"></span></label>
+              <label class="well"><span class="slabel">or subtotal ×18%</span><span class="amt sm"><i>$</i><input data-f="sub" value="1200.00" inputmode="decimal"></span></label>
+            </div>
+            <div class="mini" style="margin-top:7px">18% of $1,200.00 = <b data-out="gratcalc">$216.00</b> <button style="color:var(--accent);font-weight:700" data-usegrat>use this</button></div>
+            <label class="tsub" style="margin-top:8px;display:block"><input type="checkbox" data-f="gratinside" checked> It’s already counted inside the card number</label>
+          </div>
+        </div>
+
+        <div class="c tight summary" data-summary>
+          <div class="calc" style="border:0;margin:0;padding:0">
+            <div class="ln"><span>Entered</span><span data-out="ent">$1,100.00</span></div>
+            <div class="ln sub"><span>− lunch</span><span data-out="lun">−$260.00</span></div>
+            <div class="ln"><span>of which auto-grat</span><span data-out="gratline">$216.00</span></div>
+            <div class="ln tot"><span>Dinner records</span><span data-out="fin">$840.00</span></div>
+          </div>
+        </div>
+        <div style="flex:1"></div>
+        <div class="bar"><button data-back>Back</button><button class="prim" data-next>Next</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Each choice previews its own result in dollars, so the wrong pick is visibly wrong. Best option for a closer who only does this twice a month.</div>
+        <div class="dn"><span>cost</span>Three screens instead of one; the fastest closers will resent it. Voice entry would need its own path.</div>
+        <div class="qq"><span>ask</span>Worth showing only on dinner, and keeping lunch as the one-screen form?</div>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- ============================ B · PARTIAL SHARES ============================ -->
+<section data-tab="share">
+  <div class="intro">
+    <h2>B · Somebody only worked two hours</h2>
+    <p>Right now the split is strictly equal: pool ÷ heads. These four give a person less than a full share — a helper who came in for two hours, someone who left at eight — without dropping them off the entry.</p>
+    <div class="rule">Sample: dinner cash pool <code>$205.00</code>, five names, Kenji at a half share. Every mockup below is live — change a weight and the dollars move.</div>
+    <div class="ask"><b>The question that decides the math</b> (and it is not a design question — pick one and I’ll build it): when Kenji takes a half share, where do the other $20.50 go?<br>
+      <b>Reflow</b> — the pool is fully distributed by weight, so everyone else goes <i>up</i>: $45.56 each instead of $41.00.<br>
+      <b>Fixed cut</b> — a full share stays pool ÷ heads ($41.00), Kenji gets $20.50, and the leftover $20.50 stays in the drawer like the remainder cents do today.<br>
+      B4 lets you flip between the two so you can see the difference in dollars.</div>
+    <div class="rule">Also worth knowing: with weights, plain half-up rounding can pay out a cent or two <i>more</i> than the pool. Today’s rule (remainder stays in the drawer) can’t go negative, so whichever design you pick I’d switch the allocator to largest-remainder so the shares always sum to exactly the pool.</div>
+  </div>
+
+  <div class="grid">
+
+    <!-- B1 -->
+    <article class="opt">
+      <header class="oh"><span class="no">B1</span><div>
+        <h3>Badge on the chip</h3>
+        <p>The roster stays exactly as it is. Every selected name grows a small percentage badge; tapping the badge cycles 100 → 75 → 50 → 25 → custom. Nothing new on screen until you need it.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="b1">
+        <div class="c">
+          <div class="row"><span class="slabel">Who’s splitting</span><span class="mini" style="margin-left:auto;color:var(--ink3)">tap a badge to change a share</span></div>
+          <div class="chips" data-roster style="margin-top:10px"></div>
+          <div class="warn" data-tip style="background:var(--well);color:var(--ink2)">Kenji is on a <b>half share</b> — tap 50% again for 25%, or hold for a custom number.</div>
+        </div>
+        <div class="c tight">
+          <div class="rows" data-payout></div>
+        </div>
+        <div class="strip"><span class="slabel">Full share</span><b data-out="full">$45.56</b><span class="of">cash pool $205.00</span></div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Zero new screens and zero cost when everyone is full — the common night looks identical to today.</div>
+        <div class="dn"><span>cost</span>A 10px badge is a small tap target, and “cycle through four values” is a habit you have to learn.</div>
+        <div class="qq"><span>ask</span>Are 100/75/50/25 the right presets, or do you want thirds?</div>
+        <div class="up"><span>final</span>Chosen. The per-person amounts only appear once somebody is under 100%.</div>
+      </div>
+    </article>
+
+    <!-- B2 -->
+    <article class="opt">
+      <header class="oh"><span class="no">B2</span><div>
+        <h3>Hours, not percents</h3>
+        <p>Nobody thinks “Kenji gets 50%” — they think “Kenji came in for two hours.” Enter hours per person; the split is by hours worked and the percentage is derived, shown only as a receipt.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="b2">
+        <div class="c">
+          <div class="row"><span class="slabel">Hours on the floor</span><button class="mini" style="margin-left:auto;color:var(--accent);font-weight:700" data-allfull>all full shift</button></div>
+          <div class="rows hrs" data-hours style="margin-top:9px"></div>
+        </div>
+        <div class="c tight">
+          <div class="calc" style="border:0;margin:0;padding:0">
+            <div class="ln"><span>Cash pool</span><span>$205.00</span></div>
+            <div class="ln"><span>Total hours</span><span data-out="th">18.0 h</span></div>
+            <div class="ln tot"><span>Per hour</span><span data-out="ph">$11.39</span></div>
+          </div>
+        </div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Matches how the shift is actually described out loud, and gives you an hours record on the dashboard for free — useful well beyond tips.</div>
+        <div class="dn"><span>cost</span>Every entry now needs hours for <i>everyone</i>, not just the odd one out. Someone has to know them at close.</div>
+        <div class="qq"><span>ask</span>Do you already have scheduled hours in the app we could pre-fill from, so the closer only fixes exceptions?</div>
+      </div>
+    </article>
+
+    <!-- B3 -->
+    <article class="opt">
+      <header class="oh"><span class="no">B3</span><div>
+        <h3>Drag the pool</h3>
+        <p>One bar, one segment per person, drag the dividers. You are not entering a percentage — you are physically handing out the money, and the bar can never add up to more or less than the pool.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="b3">
+        <div class="c">
+          <div class="row"><span class="slabel">Cash pool $205.00</span><button class="mini" style="margin-left:auto;color:var(--accent);font-weight:700" data-even>even it out</button></div>
+          <div class="wbar" data-bar style="margin-top:11px"></div>
+          <div class="wlegend" data-legend style="margin-top:12px"></div>
+          <div class="mini" style="margin-top:10px;color:var(--ink3)">Drag a divider · double-tap a name to give it a half share</div>
+        </div>
+        <div class="strip"><span class="slabel">Handed out</span><b data-out="sum">$205.00</b><span class="of ok" data-out="bal">balanced</span></div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Always sums to the pool exactly — no leftover-policy question, no rounding surprise. Fastest for “just give her a bit more.”</div>
+        <div class="dn"><span>cost</span>Fiddly with six-plus names on a phone, hard to hit a round number, and it invites arbitrary splits rather than a rule you can defend later.</div>
+        <div class="qq"><span>ask</span>Should dragging snap to 5% steps so the numbers stay tidy?</div>
+      </div>
+    </article>
+
+    <!-- B4 -->
+    <article class="opt">
+      <header class="oh"><span class="no">B4</span><div>
+        <h3>Full share / helper</h3>
+        <p>A list, not chips. Each person is <b>Full</b> or <b>Helper</b>; helpers pick a quarter, half or three-quarter share. The leftover policy is an explicit switch so the rule is stated, not implied.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="b4">
+        <div class="c">
+          <div class="slabel">Dinner · 5 on the split</div>
+          <div class="rows b4" data-list style="margin-top:10px"></div>
+        </div>
+        <div class="c tight">
+          <div class="slabel">The other $20.50</div>
+          <div class="seg sm" data-policy style="margin-top:8px"><button class="on" data-v="reflow">Reflow to the team</button><button data-v="drawer">Stays in the drawer</button></div>
+          <div class="calc" style="margin-top:10px">
+            <div class="ln"><span>Full share</span><span data-out="full">$45.56</span></div>
+            <div class="ln"><span>Kenji (½)</span><span data-out="half">$22.78</span></div>
+            <div class="ln tot"><span>Left in drawer</span><span data-out="left">$0.00</span></div>
+          </div>
+        </div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Plain words for the common case, and it forces the money question into the open where you can decide it once in settings.</div>
+        <div class="dn"><span>cost</span>Tallest screen of the four; a five-name split becomes five rows of controls.</div>
+        <div class="qq"><span>ask</span>Should the leftover policy be a per-entry choice, or fixed once per restaurant in settings?</div>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- ============================ C · NOTES ============================ -->
+<section data-tab="notes">
+  <div class="intro">
+    <h2>C · “Something weird is going on”</h2>
+    <p>A free-text note on the entry, written at close by whoever is entering. The design question is how much structure to put around it — a bare box is fastest to write and useless to search later; chips are the opposite.</p>
+    <div class="ask"><b>Two things I need from you:</b> should a note ever be <i>required</i> (e.g. on a flagged/unusual amount, or when someone gets a partial share)? And who reads them — manager only in the dashboard, or does the note ride along to the employee’s own take-home view?</div>
+  </div>
+
+  <div class="grid">
+
+    <!-- C1 -->
+    <article class="opt">
+      <header class="oh"><span class="no">C1</span><div>
+        <h3>Quiet line</h3>
+        <p>One dashed row under the split. Tap, it grows a box, you type, it collapses into a one-line preview. Invisible on a normal night.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="c1">
+        <div class="c tight"><div class="slabel">Splitting the cash · 4</div>
+          <div class="chips" style="margin-top:8px"><span class="chip on">Ana</span><span class="chip on">Marco</span><span class="chip on">Priya</span><span class="chip on">Dee</span></div>
+        </div>
+        <div class="strip"><span class="slabel">Each</span><b>$51.25</b><span class="of">of $205.00</span></div>
+        <div data-noteclosed>
+          <button class="ghost" data-open>+ Add a note</button>
+        </div>
+        <div class="c" data-noteopen hidden>
+          <div class="row"><span class="slabel">Note</span><span class="mini" style="margin-left:auto;color:var(--ink3)" data-out="count">0 / 280</span></div>
+          <textarea data-f="note" rows="3" placeholder="Register was $20 short — Marco recounted, still short." style="margin-top:7px"></textarea>
+          <div class="row" style="margin-top:9px;gap:8px"><button class="ghost" style="width:auto;padding:7px 14px" data-cancel>Cancel</button><button class="ghost" style="width:auto;padding:7px 14px;border-style:solid;background:var(--tint);border-color:var(--accent);color:var(--alert)" data-save>Attach</button></div>
+        </div>
+        <div class="c tight notepreview" data-notedone hidden>
+          <div class="row"><span class="nglyph">note</span><span class="mini" data-out="preview"></span><button class="chev" data-edit style="font-weight:700;color:var(--accent)">edit</button></div>
+        </div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Costs nothing on the 95% of nights with nothing to say.</div>
+        <div class="dn"><span>cost</span>Free text is unsearchable and unaggregatable — you’ll read them one at a time forever.</div>
+        <div class="qq"><span>ask</span>Is 280 characters enough?</div>
+      </div>
+    </article>
+
+    <!-- C2 -->
+    <article class="opt">
+      <header class="oh"><span class="no">C2</span><div>
+        <h3>Reason chips + text</h3>
+        <p>Pick what happened from a short list, then add detail if you want. The chip is the part the dashboard can filter, count and chart; the text is for the human.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="c2">
+        <div class="c">
+          <div class="slabel">Anything worth flagging?</div>
+          <div class="chips" data-reasons style="margin-top:10px"></div>
+          <textarea data-f="note" rows="2" placeholder="Add detail (optional)" style="margin-top:11px"></textarea>
+          <div class="mini" style="margin-top:8px;color:var(--ink3)">Lands on the dashboard as:</div>
+          <div class="dashpreview" data-out="preview"></div>
+        </div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Two taps beats typing at 11pm, and “drawer short” becomes a number you can trend by person and location.</div>
+        <div class="dn"><span>cost</span>The list has to be right — a missing chip pushes people into “Other” and you’re back to free text.</div>
+        <div class="qq"><span>ask</span>What are the five things that actually go wrong? My guesses are on the chips — replace them.</div>
+      </div>
+    </article>
+
+    <!-- C3 -->
+    <article class="opt">
+      <header class="oh"><span class="no">C3</span><div>
+        <h3>Note on a person</h3>
+        <p>The note hangs off a name instead of the entry. “Kenji — came in 6–8 to cover.” Pairs with B: the note is the receipt for why somebody’s share is not full.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="c3">
+        <div class="c">
+          <div class="row"><span class="slabel">Splitting the cash</span><span class="mini" style="margin-left:auto;color:var(--ink3)">tap a name to annotate</span></div>
+          <div class="rows c3" data-people style="margin-top:10px"></div>
+        </div>
+        <div class="c tight">
+          <div class="slabel">Note on the whole entry</div>
+          <input data-f="entrynote" placeholder="optional" class="plain" style="margin-top:7px">
+        </div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Answers “why did Kenji get $22.78?” at the exact spot the question gets asked, months later.</div>
+        <div class="dn"><span>cost</span>New table (a note per person per entry) and more places to look on the dashboard.</div>
+        <div class="qq"><span>ask</span>Should a partial share <i>require</i> a per-person note?</div>
+      </div>
+    </article>
+
+    <!-- C4 -->
+    <article class="opt">
+      <header class="oh"><span class="no">C4</span><div>
+        <h3>Raise it</h3>
+        <p>Not a note field — an escalation. One button, a severity, and the entry lands on the dashboard flagged for attention, alongside the amounts the anomaly rule already flags.</p>
+      </div></header>
+      <div class="obody"><div class="phone" data-opt="c4">
+        <div class="c tight"><div class="slabel">Dinner · Sushi · Wed, Aug 27</div>
+          <div class="row" style="margin-top:7px"><b style="font-size:19px">$205.00</b><span class="mini" style="margin-left:auto">cash · 4 ways</span></div>
+        </div>
+        <button class="ghost raise" data-open>⚑ Something’s off tonight</button>
+        <div class="sheet" data-sheet hidden>
+          <div class="grab"></div>
+          <h4>What’s off?</h4>
+          <div class="seg sm" data-sev style="margin-top:11px"><button data-v="fyi" class="on">Just noting it</button><button data-v="check">Manager should check</button></div>
+          <textarea data-f="note" rows="3" placeholder="Drawer was $20 short. Recounted twice." style="margin-top:11px"></textarea>
+          <div class="mini" style="margin-top:9px;color:var(--ink3)" data-out="hint">Saves quietly with the entry — no alert.</div>
+          <div class="bar" style="margin-top:12px"><button data-cancel>Cancel</button><button class="prim" data-save>Attach &amp; save</button></div>
+        </div>
+        <div class="c tight flagged" data-done hidden>
+          <div class="row"><span class="fchip">⚑ check</span><span class="mini" data-out="preview"></span></div>
+        </div>
+        <div class="bar"><button class="prim">Save</button></div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Reuses the flag lane you already have — flagged rows are already tinted and have a Verify button in Recorded tips.</div>
+        <div class="dn"><span>cost</span>Framing everything as a problem discourages ordinary notes (“party of 30 on the patio”).</div>
+        <div class="qq"><span>ask</span>Should a raised note ever notify you, or only sit on the dashboard until you look?</div>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- ============================ D · DASHBOARD ============================ -->
+<section data-tab="dash">
+  <div class="intro">
+    <h2>D · Recorded tips, once all of that exists</h2>
+    <p>Four new things have to be visible without wrecking a table that already has nine columns: the <b>auto-grat</b> bucket, the fact that a dinner row was <b>derived from a day total</b> (and what was subtracted), <b>unequal shares</b>, and <b>notes</b>. These four make different bets about where that detail lives.</p>
+    <div class="rule">Same night in all four. Wed Aug 27 dinner at Sushi: Square said <code>$323.00</code> cash for the day, lunch had banked <code>$118.00</code>, so the row records <code>$205.00</code> — split five ways with Kenji on a half share, plus <code>$216.00</code> of auto-grat and a note about the drawer.</div>
+    <div class="ask"><b>Ask:</b> should the ledger show the <i>recorded</i> dinner number ($205.00) with the day total tucked behind a badge, or show <i>both</i> columns permanently? And does auto-grat belong in the cash pool column, the card column, or a third column of its own — that depends on your answer to the A-tab question about where the grat money actually goes.</div>
+  </div>
+
+  <div class="stack">
+
+    <!-- D1 -->
+    <article class="opt">
+      <header class="oh"><span class="no">D1</span><div>
+        <h3>Wider ledger — everything on the row</h3>
+        <p>Add the columns and live with the width. Scope shows as a badge on the cash cell, unequal shares as a fraction next to the name, notes as a glyph that opens a tooltip. Nothing to click to understand a row.</p>
+      </div></header>
+      <div class="obody" style="padding:0;background:#fff"><div class="wideframe">
+        <div class="tbar"><b>Recorded tips</b><span class="mini">Aug 21 – Aug 27 · 14 records</span><span class="tbtn">Export CSV</span></div>
+        <table class="ledger">
+          <thead><tr>
+            <th>Business date</th><th>Restaurant</th><th>Meal</th>
+            <th class="r cash">Cash pool</th><th class="r grat">Auto-grat</th>
+            <th>Split between</th><th class="r cash">Per person</th>
+            <th class="r card">Card → payroll</th><th>Note</th><th>Entered by</th><th></th>
+          </tr></thead>
+          <tbody>
+            <tr class="daytot"><td colspan="3">Wed, Aug 27</td><td class="r cash">$323.00</td><td class="r grat">$216.00</td><td class="cash"></td><td class="cash"></td><td class="r card">$777.00</td><td colspan="3"></td></tr>
+            <tr>
+              <td>Wed, Aug 27</td><td><span class="lchip sushi">Sushi</span></td><td>Dinner</td>
+              <td class="r cash b"><span class="scope" title="Entered as a whole-day total">day −lunch</span> $205.00</td>
+              <td class="r grat">$216.00</td>
+              <td>Ana, Marco, Priya, Dee, <span class="wname">Kenji <i>½</i></span></td>
+              <td class="r cash xb">$45.56 <span class="sub2">· Kenji $22.78</span></td>
+              <td class="r card">$635.00</td>
+              <td><span class="nglyph" data-tip="Drawer $20 short — Marco recounted, still short.">note</span></td>
+              <td class="mut">Dee · dictated</td><td class="r"><span class="tbtn sm">Fix</span></td>
+            </tr>
+            <tr>
+              <td>Wed, Aug 27</td><td><span class="lchip sushi">Sushi</span></td><td>Lunch</td>
+              <td class="r cash b">$118.00</td><td class="r grat mut">—</td>
+              <td>Ana, Priya, Dee</td><td class="r cash xb">$39.33</td><td class="r card">$142.00</td>
+              <td></td><td class="mut">Ana · typed</td><td class="r"><span class="tbtn sm">Fix</span></td>
+            </tr>
+            <tr class="flag">
+              <td>Tue, Aug 26</td><td><span class="lchip poki">Poki &amp; Pho</span></td><td>Dinner</td>
+              <td class="r b">$612.00 <span class="fchip">⚑ check</span></td><td class="r mut">—</td>
+              <td>Sam, <span class="wname">Rey <i>¼</i></span></td><td class="r xb">$489.60 <span class="sub2">· Rey $122.40</span></td>
+              <td class="r">$210.00</td>
+              <td><span class="nglyph" data-tip="Party of 30 on the patio, one check.">note</span></td>
+              <td class="mut">Sam · typed</td><td class="r"><span class="tbtn sm prim">Verify</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Scannable and exportable — the CSV can mirror the columns exactly, which matters when this feeds payroll.</div>
+        <div class="dn"><span>cost</span>Eleven columns needs a wide screen; the per-person cell stops being one number the moment shares are unequal.</div>
+        <div class="qq"><span>ask</span>Do you ever read this on a phone, or is it always the office laptop?</div>
+      </div>
+    </article>
+
+    <!-- D2 -->
+    <article class="opt">
+      <header class="oh"><span class="no">D2</span><div>
+        <h3>Narrow ledger, row opens up</h3>
+        <p>The table keeps today’s columns and stays calm. Click a row and it unfolds in place: the day-total arithmetic, the auto-grat, every name with its share in dollars, and the note in full.</p>
+      </div></header>
+      <div class="obody" style="padding:0;background:#fff"><div class="wideframe" data-opt="d2">
+        <div class="tbar"><b>Recorded tips</b><span class="mini">click a row for the breakdown</span></div>
+        <table class="ledger">
+          <thead><tr><th></th><th>Business date</th><th>Restaurant</th><th>Meal</th><th class="r cash">Cash pool</th><th>Split between</th><th class="r cash">Per person</th><th class="r card">Card → payroll</th><th>Entered by</th></tr></thead>
+          <tbody>
+            <tr class="exp open" data-exp><td class="tw"><span class="tri">▾</span></td><td>Wed, Aug 27</td><td><span class="lchip sushi">Sushi</span></td><td>Dinner</td>
+              <td class="r cash b">$205.00</td><td>5 names <span class="mark">·2 adj</span></td><td class="r cash xb">$45.56 <span class="sub2">avg</span></td><td class="r card">$635.00</td><td class="mut">Dee</td></tr>
+            <tr class="det" data-det><td></td><td colspan="8">
+              <div class="detgrid">
+                <div class="dcard">
+                  <div class="slabel">How this number was reached</div>
+                  <div class="calc" style="margin-top:8px">
+                    <div class="ln"><span>Entered from Square (whole day)</span><span>$323.00</span></div>
+                    <div class="ln sub"><span>− lunch recorded 3:41 PM</span><span>−$118.00</span></div>
+                    <div class="ln tot"><span>Dinner cash pool</span><span>$205.00</span></div>
+                  </div>
+                  <div class="hair2"></div>
+                  <div class="calc">
+                    <div class="ln"><span>Card → payroll</span><span>$635.00</span></div>
+                    <div class="ln"><span>of which auto-gratuity 18%</span><span>$216.00</span></div>
+                  </div>
+                </div>
+                <div class="dcard">
+                  <div class="slabel">Who takes what</div>
+                  <table class="mini2"><tbody>
+                    <tr><td>Ana</td><td class="r mut">full</td><td class="r b">$45.56</td></tr>
+                    <tr><td>Marco</td><td class="r mut">full</td><td class="r b">$45.56</td></tr>
+                    <tr><td>Priya</td><td class="r mut">full</td><td class="r b">$45.56</td></tr>
+                    <tr><td>Dee</td><td class="r mut">full</td><td class="r b">$45.56</td></tr>
+                    <tr><td>Kenji</td><td class="r mut">½ · 2h</td><td class="r b">$22.76</td></tr>
+                    <tr class="tt"><td>Pool</td><td></td><td class="r b">$205.00</td></tr>
+                  </tbody></table>
+                </div>
+                <div class="dcard">
+                  <div class="slabel">Note · Dee, 10:52 PM</div>
+                  <p class="ntext">Drawer $20 short — Marco recounted, still short. Kenji only came in 6–8 to cover Priya’s break.</p>
+                  <div class="row" style="margin-top:11px;gap:8px"><span class="tbtn sm">Fix entry</span><span class="tbtn sm">Reply</span></div>
+                </div>
+              </div>
+            </td></tr>
+            <tr class="exp" data-exp><td class="tw"><span class="tri">▸</span></td><td>Wed, Aug 27</td><td><span class="lchip sushi">Sushi</span></td><td>Lunch</td>
+              <td class="r cash b">$118.00</td><td>3 names</td><td class="r cash xb">$39.33</td><td class="r card">$142.00</td><td class="mut">Ana</td></tr>
+            <tr class="det" data-det hidden><td></td><td colspan="8"><div class="detgrid"><div class="dcard"><div class="slabel">How this number was reached</div><div class="calc" style="margin-top:8px"><div class="ln tot"><span>Entered as lunch only</span><span>$118.00</span></div></div></div><div class="dcard"><div class="slabel">Who takes what</div><table class="mini2"><tbody><tr><td>Ana</td><td class="r mut">full</td><td class="r b">$39.33</td></tr><tr><td>Priya</td><td class="r mut">full</td><td class="r b">$39.33</td></tr><tr><td>Dee</td><td class="r mut">full</td><td class="r b">$39.34</td></tr></tbody></table></div><div class="dcard"><div class="slabel">Note</div><p class="ntext mut">No note on this entry.</p></div></div></td></tr>
+          </tbody>
+        </table>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>The everyday view gets no busier, and the breakdown has room to actually explain itself — including the “$323 became $205” arithmetic in words.</div>
+        <div class="dn"><span>cost</span>A click per row; comparing two nights’ notes means opening two rows.</div>
+        <div class="qq"><span>ask</span>Should the row auto-open when it’s flagged?</div>
+      </div>
+    </article>
+
+    <!-- D3 -->
+    <article class="opt">
+      <header class="oh"><span class="no">D3</span><div>
+        <h3>Day cards — reconcile the day</h3>
+        <p>Stop thinking in rows. One card per business day showing the day as a whole: what Square said, what lunch took, what dinner took, whether it balances. The double-count problem becomes visible at a glance.</p>
+      </div></header>
+      <div class="obody" style="padding:20px;background:#f0f0f1"><div class="wideframe plain">
+        <div class="daycard">
+          <div class="dchead"><b>Wed, Aug 27</b><span class="lchip sushi">Babytuna Sushi</span><span class="recon ok">day reconciles</span><span class="dtot">$1,100.00 <i>total tips</i></span></div>
+          <div class="dcbar"><span class="sl" style="width:23.6%">Lunch $260.00</span><span class="sd" style="width:76.4%">Dinner $840.00</span></div>
+          <div class="dcgrid">
+            <div class="dcol">
+              <div class="slabel">Lunch · 11:30–3:41</div>
+              <div class="big">$118.00 <i>cash pool</i></div>
+              <div class="mini">card $142.00 · no auto-grat</div>
+              <div class="chips" style="margin-top:9px"><span class="chip sm">Ana $39.33</span><span class="chip sm">Priya $39.33</span><span class="chip sm">Dee $39.34</span></div>
+            </div>
+            <div class="dcol">
+              <div class="slabel">Dinner · 4:00–10:52 <span class="scope">entered as day total</span></div>
+              <div class="big">$205.00 <i>cash pool</i></div>
+              <div class="mini">Square said $323.00 for the day − $118.00 lunch</div>
+              <div class="mini">card $635.00 · <b class="ok">auto-grat $216.00</b></div>
+              <div class="chips" style="margin-top:9px"><span class="chip sm">Ana $45.56</span><span class="chip sm">Marco $45.56</span><span class="chip sm">Priya $45.56</span><span class="chip sm">Dee $45.56</span><span class="chip sm half">Kenji ½ $22.76</span></div>
+            </div>
+            <div class="dcol notecol">
+              <div class="slabel">Notes</div>
+              <p class="ntext"><b>Dee, 10:52 PM</b> — Drawer $20 short, Marco recounted, still short.</p>
+              <p class="ntext"><b>on Kenji</b> — came in 6–8 to cover Priya’s break.</p>
+            </div>
+          </div>
+        </div>
+        <div class="daycard slim">
+          <div class="dchead"><b>Tue, Aug 26</b><span class="lchip poki">Poki &amp; Pho</span><span class="recon warn">lunch never recorded</span><span class="dtot">$822.00 <i>total tips</i></span></div>
+          <div class="dcbar"><span class="sm2" style="width:100%">Dinner $822.00 — entered as day total with nothing to subtract</span></div>
+        </div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>The only layout that makes “did we double-count the day?” a first-class question — and it surfaces the nasty case (a day-total dinner with no lunch on record) instead of hiding it.</div>
+        <div class="dn"><span>cost</span>Poor for scanning three weeks; you’d still want the flat table underneath for export and search.</div>
+        <div class="qq"><span>ask</span>Would this replace Recorded tips, or sit next to it as a second view?</div>
+      </div>
+    </article>
+
+    <!-- D4 -->
+    <article class="opt">
+      <header class="oh"><span class="no">D4</span><div>
+        <h3>List + inspector</h3>
+        <p>Entries on the left, one persistent inspector on the right. Arrow-key down the list and everything — arithmetic, shares, note, fix controls — refreshes in place. Built for working through a week of flagged rows.</p>
+      </div></header>
+      <div class="obody" style="padding:0;background:#fff"><div class="wideframe" data-opt="d4">
+        <div class="splitpane">
+          <div class="lpane">
+            <div class="lsearch">Search notes, names, amounts…</div>
+            <div class="litem on" data-e="0"><div class="row"><b>Wed, Aug 27</b><span class="mut" style="margin-left:auto">Dinner</span></div><div class="row"><span class="lchip sushi">Sushi</span><span class="mut">5 names · ½ share</span><b style="margin-left:auto">$205.00</b></div><div class="lnote">“Drawer $20 short — Marco recounted…”</div></div>
+            <div class="litem" data-e="1"><div class="row"><b>Wed, Aug 27</b><span class="mut" style="margin-left:auto">Lunch</span></div><div class="row"><span class="lchip sushi">Sushi</span><span class="mut">3 names</span><b style="margin-left:auto">$118.00</b></div></div>
+            <div class="litem flag" data-e="2"><div class="row"><b>Tue, Aug 26</b><span class="mut" style="margin-left:auto">Dinner</span></div><div class="row"><span class="lchip poki">Poki &amp; Pho</span><span class="fchip">⚑ check</span><b style="margin-left:auto">$612.00</b></div><div class="lnote">“Party of 30 on the patio, one check.”</div></div>
+          </div>
+          <div class="rpane" data-out="insp"></div>
+        </div>
+      </div></div>
+      <div class="ofoot">
+        <div class="up"><span>good</span>Fastest for the actual job — verifying flagged entries and reading notes in a batch, without losing your place in the list.</div>
+        <div class="dn"><span>cost</span>Half the width goes to one entry; worst layout for comparing totals across a week.</div>
+        <div class="qq"><span>ask</span>Is “work through the flagged ones” a real weekly habit, or do you mostly just export?</div>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- ============================ QUESTIONS ============================ -->
+<section data-tab="q">
+  <div class="intro" style="max-width:1000px">
+    <h2>What I need from you</h2>
+    <p>Answer these and I can build any combination you pick — you’re choosing one option per tab (e.g. <b>A2 + B4 + C2 + D2</b>), and they mix freely.</p>
+  </div>
+  <div class="qgrid">
+    <div class="qcard"><span class="qn">1</span><h4>Where does the auto-grat money actually go?</h4><p>Is the 18% <b>already inside</b> the card number Square reports (so it’s a carve-out, tracked but not added), or does it arrive separately and get added on top? And once it’s in — does it join the pooled cash split, ride payroll like card tips, or go to the server(s) who had that party?</p><p class="qwhy">This decides the totals and the dashboard column, not just the layout.</p></div>
+    <div class="qcard"><span class="qn">2</span><h4>Is 18% fixed?</h4><p>Same rate at both restaurants, forever? Should the closer be able to type a grat amount straight from the report, compute it from a party subtotal, or both? And does it apply per-party (several parties a night) or as one nightly total?</p></div>
+    <div class="qcard"><span class="qn">3</span><h4>What exactly gets subtracted on a whole-day dinner?</h4><p>Lunch cash, lunch card, both, and the lunch auto-grat too? My assumption: subtract like-for-like, field by field, from today’s recorded lunch at the same restaurant.</p></div>
+    <div class="qcard"><span class="qn">4</span><h4>What if lunch was never recorded?</h4><p>Then a whole-day dinner number has nothing to subtract and silently records the whole day as dinner. Options: block the save, warn and let it through flagged, or let the manager subtract later from the dashboard. I’d warn + flag.</p></div>
+    <div class="qcard"><span class="qn">5</span><h4>Store the number they typed?</h4><p>I’d store both the raw Square figure and the derived shift figure, so the dashboard can always show its work and a fix is reversible. Any objection to keeping the raw number?</p></div>
+    <div class="qcard"><span class="qn">6</span><h4>Reflow or fixed cut?</h4><p>The B-tab question. When Kenji takes ½, do the other four go up to $45.56 (pool fully distributed), or stay at $41.00 with $20.50 left in the drawer? Per-entry choice, or fixed once per restaurant?</p></div>
+    <div class="qcard"><span class="qn">7</span><h4>Who can set a partial share?</h4><p>The closer at entry, or manager-only from the dashboard after the fact? Closer is faster; manager-only is harder to abuse, since the person entering can shave a coworker’s share.</p></div>
+    <div class="qcard"><span class="qn">8</span><h4>Does the card side split too?</h4><p>Today per-person on the dashboard is cash-only (card rides payroll). If someone works a half shift, does their card/payroll allocation get the same weight?</p></div>
+    <div class="qcard"><span class="qn">9</span><h4>Who reads the notes?</h4><p>Manager only, or do notes ride along to the employee view? Anything naming a coworker becomes an HR artifact the moment it’s visible — worth deciding now, not after the first awkward one.</p></div>
+    <div class="qcard"><span class="qn">10</span><h4>Voice entry</h4><p>“Speak it in” currently parses cash, card and names. Should it also handle “eight forty for the day”, “Kenji half”, and a spoken note — or do the new fields stay typed for now?</p></div>
+  </div>
+</section>
+
+</main>
+
+<style>
+/* ---------- shared small parts ---------- */
+textarea,input.plain,input.inl{background:var(--well);border:0;border-radius:11px;padding:10px 11px;width:100%;outline:0;resize:none;font-size:13.5px;line-height:1.4}
+textarea::placeholder,input.plain::placeholder{color:var(--ink3)}
+input.inl{display:inline-block;width:78px;padding:2px 7px;border-radius:7px;font-weight:700;font-variant-numeric:tabular-nums}
+.rows{display:grid;gap:7px}
+.chip.sm{padding:5px 9px;font-size:11.5px;font-weight:700}
+.chip.sm.half{background:var(--gratcol);border-color:rgba(31,122,77,.3);color:var(--green)}
+h4{font-size:16px;letter-spacing:-.01em}
+.qsub{font-size:12.5px;color:var(--ink2);margin-top:4px}
+
+/* ---------- A2 receipt tape ---------- */
+.tape{display:grid;gap:0}
+.tline{display:flex;align-items:center;gap:10px;padding:10px 0;border-bottom:1px dashed var(--line)}
+.tline .tl{font-size:13.5px;color:var(--ink2);display:flex;align-items:center;gap:7px}
+.tline .tv{margin-left:auto;display:flex;align-items:baseline;gap:2px;font-variant-numeric:tabular-nums}
+.tline .tv i{font-style:normal;color:var(--ink3);font-size:13px}
+.tline .tv input{width:86px;text-align:right;background:none;border:0;outline:0;font-size:16px;font-weight:700;font-variant-numeric:tabular-nums;border-bottom:1px solid var(--line);padding-bottom:1px}
+.tline.neg .tl{color:var(--alert)}
+.tline .tv.neg{color:var(--alert);font-weight:700;font-size:15px}
+.tline.total{border-bottom:0;border-top:2px solid var(--ink);margin-top:4px;padding-top:9px}
+.tline.total .tl{color:var(--ink);font-weight:800;font-size:14px}
+.tline.total .tv{font-size:20px;font-weight:800}
+.tsub{font-size:12px;color:var(--ink2);padding:8px 0;border-bottom:1px dashed var(--line);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.tsub label{display:flex;align-items:center;gap:7px;cursor:pointer}
+input[type=checkbox]{width:16px;height:16px;accent-color:var(--accent)}
+
+/* ---------- A3 day bar ---------- */
+.stack2{height:46px;border-radius:11px;overflow:hidden;display:flex;background:var(--well)}
+.stack2 span{display:flex;align-items:center;justify-content:center;font-size:11.5px;font-weight:800;color:#fff;transition:width .18s ease-out;overflow:hidden;white-space:nowrap}
+.stack2 .s-lunch{background:var(--ink3)}
+.stack2 .s-dinner{background:var(--accent)}
+.stack2 .s-grat{background:var(--green)}
+.legend{display:flex;gap:14px;margin-top:9px;flex-wrap:wrap;font-size:11.5px;color:var(--ink2)}
+.legend b{display:flex;align-items:center;gap:6px;font-weight:600}
+.legend i{width:9px;height:9px;border-radius:3px;display:inline-block}
+
+/* ---------- A4 wizard ---------- */
+.dots{display:flex;gap:5px;justify-content:center}
+.dots i{width:22px;height:3px;border-radius:2px;background:var(--disabled)}
+.dots i.on{background:var(--accent)}
+.picks{display:grid;gap:9px}
+.pick{text-align:left;border:1.5px solid var(--line);border-radius:15px;padding:12px 13px;display:block;background:var(--card)}
+.pick b{display:block;font-size:15px;margin-bottom:3px}
+.pick span{font-size:12.5px;color:var(--ink2);line-height:1.4}
+.pick em{font-style:normal;font-weight:800;color:var(--ink)}
+.pick.on{border-color:var(--accent);background:var(--tint)}
+.pick.on span{color:#7c2a19}
+.summary{background:#1a1a1a;color:#fff}
+.summary .calc .ln{color:#a6a6a6}
+.summary .calc .ln span:last-child{color:#fff}
+.summary .calc .ln.sub span:last-child{color:#ff9b88}
+.summary .calc .ln.tot{border-top-color:#333;color:#fff}
+
+/* ---------- B ---------- */
+.rows .prow{display:flex;align-items:center;gap:10px;background:var(--well);border-radius:12px;padding:9px 11px}
+.rows .prow .nm{font-weight:600;font-size:13.5px}
+.rows .prow .amtv{margin-left:auto;font-weight:800;font-variant-numeric:tabular-nums}
+.rows .prow .sub{font-size:11px;color:var(--ink3)}
+.step2{display:flex;align-items:center;gap:2px;background:var(--card);border-radius:999px;padding:2px;margin-left:auto}
+.step2 button{width:26px;height:26px;border-radius:50%;font-weight:800;color:var(--ink2)}
+.step2 .v{min-width:44px;text-align:center;font-weight:800;font-size:12.5px;font-variant-numeric:tabular-nums}
+.hrs .prow{padding:8px 9px 8px 12px}
+.wbar{display:flex;height:56px;border-radius:13px;overflow:hidden;background:var(--well);position:relative;touch-action:none;user-select:none}
+.wseg{position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;color:#fff;font-size:11px;font-weight:800;overflow:hidden;white-space:nowrap}
+.wseg .wv{font-size:10px;opacity:.85;font-weight:700}
+.whandle{position:absolute;top:0;bottom:0;width:14px;margin-left:-7px;cursor:ew-resize;z-index:3;display:flex;align-items:center;justify-content:center}
+.whandle::after{content:"";width:3px;height:26px;border-radius:2px;background:rgba(255,255,255,.85)}
+.wlegend{display:grid;gap:5px}
+.wlegend .wl{display:flex;align-items:center;gap:8px;font-size:12.5px}
+.wlegend .wl i{width:9px;height:9px;border-radius:3px}
+.wlegend .wl b{margin-left:auto;font-variant-numeric:tabular-nums}
+.wlegend .wl span.pc{color:var(--ink3);font-size:11.5px;width:38px;text-align:right;font-variant-numeric:tabular-nums}
+.b4 .prow{display:block;padding:10px 11px}
+.b4 .prow .top{display:flex;align-items:center;gap:10px}
+.b4 .prow .seg{margin-left:auto;width:154px;background:var(--card)}
+.b4 .prow .seg button{padding:5px;font-size:11.5px}
+.b4 .presets{display:flex;gap:6px;margin-top:9px}
+.b4 .presets button{flex:1;border:1px solid var(--line);background:var(--card);border-radius:9px;padding:6px;font-size:12px;font-weight:700;color:var(--ink2)}
+.b4 .presets button.on{background:var(--accent);border-color:var(--accent);color:#fff}
+
+/* ---------- C ---------- */
+.nglyph{font-size:10px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;color:var(--blue);background:rgba(37,99,235,.09);border-radius:5px;padding:2px 6px;cursor:help}
+.notepreview .mini{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+.dashpreview{margin-top:7px;border:1px solid var(--line);border-radius:11px;padding:9px 10px;font-size:12px;background:#fbfbfb}
+.dashpreview .dp{display:flex;gap:7px;align-items:center;flex-wrap:wrap}
+.rchip{font-size:11px;font-weight:800;border-radius:6px;padding:2px 7px;background:var(--well);color:var(--ink2)}
+.rchip.on{background:var(--tint);color:var(--alert)}
+.raise{border-color:rgba(232,77,56,.4);color:var(--alert);font-weight:700;padding:13px}
+.sheet{background:var(--card);border-radius:24px;padding:16px 15px 15px;border:1px solid var(--line)}
+.grab{width:38px;height:4px;border-radius:2px;background:var(--disabled);margin:0 auto 12px}
+.flagged{background:var(--flagtint)}
+.fchip{font-size:10.5px;font-weight:800;color:var(--alert);background:#fff;border:1px solid rgba(192,53,32,.3);border-radius:6px;padding:1px 6px;white-space:nowrap}
+.c3 .prow{gap:8px}
+.c3 .prow .nb{margin-left:auto;font-size:11px;font-weight:800;color:var(--blue)}
+.c3 .noteline{margin-top:7px}
+
+/* ---------- D ---------- */
+.wideframe{width:100%;overflow-x:auto;background:#fff}
+.wideframe.plain{background:transparent;display:grid;gap:16px}
+.tbar{display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--line)}
+.tbar b{font-size:16px}
+.tbar .mini{color:var(--ink3)}
+.tbtn{margin-left:auto;border:1px solid var(--line);border-radius:8px;padding:5px 11px;font-size:12px;font-weight:700;color:var(--ink2);white-space:nowrap;cursor:pointer}
+.tbtn.sm{margin-left:0;padding:3px 9px;font-size:11.5px}
+.tbtn.prim{background:var(--accent);border-color:var(--accent);color:#fff}
+table.ledger{width:100%;border-collapse:collapse;font-size:13px;min-width:900px}
+table.ledger th{text-align:left;font-size:10.5px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--ink3);padding:9px 11px;border-bottom:1px solid var(--line);white-space:nowrap}
+table.ledger td{padding:10px 11px;border-bottom:1px solid var(--hair);vertical-align:middle}
+table.ledger .r{text-align:right}
+table.ledger .cash{background:var(--cashcol)}
+table.ledger .card{background:var(--cardcol)}
+table.ledger .grat{background:var(--gratcol)}
+table.ledger .b{font-weight:700;font-variant-numeric:tabular-nums}
+table.ledger .xb{font-weight:800;font-variant-numeric:tabular-nums}
+table.ledger .mut{color:var(--ink3);font-size:12.5px}
+table.ledger tr.daytot td{background:#fafafa;font-weight:800;color:var(--ink2);font-size:12px;padding:6px 11px;font-variant-numeric:tabular-nums}
+table.ledger tr.flag td{background:var(--flagtint)}
+.lchip{font-size:11.5px;font-weight:700;border-radius:6px;padding:2px 8px;white-space:nowrap}
+.lchip.sushi{background:var(--tint);color:var(--alert)}
+.lchip.poki{background:rgba(37,99,235,.1);color:var(--blue)}
+.scope{font-size:10px;font-weight:800;letter-spacing:.03em;text-transform:uppercase;background:#fff;border:1px solid var(--line);border-radius:5px;padding:1px 5px;color:var(--ink2);cursor:help}
+.wname{white-space:nowrap}
+.wname i{font-style:normal;font-weight:800;font-size:11px;color:var(--green);background:var(--gratcol);border-radius:5px;padding:0 5px}
+.sub2{font-weight:600;font-size:11.5px;color:var(--ink3)}
+.mark{font-size:11px;font-weight:800;color:var(--green);background:var(--gratcol);border-radius:5px;padding:1px 5px}
+tr.exp{cursor:pointer}
+tr.exp:hover td{background:#fafafa}
+tr.exp.open td{background:#f6f7f8}
+.tw{width:26px}
+.tri{color:var(--ink3);font-size:11px}
+tr.det td{background:#f6f7f8;padding:0 11px 16px}
+.detgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px}
+.dcard{background:#fff;border:1px solid var(--line);border-radius:13px;padding:13px}
+.hair2{height:1px;background:var(--hair);margin:11px 0}
+table.mini2{width:100%;border-collapse:collapse;font-size:12.5px;margin-top:7px}
+table.mini2 td{padding:4px 0;border-bottom:1px solid var(--hair)}
+table.mini2 tr.tt td{border-bottom:0;border-top:1px solid var(--line);font-weight:800;padding-top:6px}
+.ntext{font-size:12.5px;color:var(--ink2);line-height:1.5;margin-top:7px}
+.daycard{background:#fff;border:1px solid var(--line);border-radius:16px;padding:16px 18px}
+.daycard.slim{opacity:.92}
+.dchead{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.dchead b{font-size:16px}
+.dtot{margin-left:auto;font-size:19px;font-weight:800;font-variant-numeric:tabular-nums}
+.dtot i{font-style:normal;font-size:11px;font-weight:600;color:var(--ink3);text-transform:uppercase;letter-spacing:.05em;margin-left:5px}
+.recon{font-size:11px;font-weight:800;border-radius:6px;padding:2px 8px}
+.recon.ok{background:rgba(31,122,77,.1);color:var(--green)}
+.recon.warn{background:var(--tint);color:var(--alert)}
+.dcbar{display:flex;height:26px;border-radius:8px;overflow:hidden;margin-top:13px}
+.dcbar span{display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:800;color:#fff}
+.dcbar .sl{background:var(--ink3)}
+.dcbar .sd{background:var(--accent)}
+.dcbar .sm2{background:var(--amber)}
+.dcgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:18px;margin-top:16px}
+.dcol .big{font-size:24px;font-weight:800;letter-spacing:-.02em;margin:5px 0 3px;font-variant-numeric:tabular-nums}
+.dcol .big i{font-style:normal;font-size:11px;font-weight:600;color:var(--ink3);text-transform:uppercase;letter-spacing:.05em;margin-left:4px}
+.dcol .mini{color:var(--ink2);font-size:12.5px}
+.notecol{border-left:1px solid var(--hair);padding-left:18px}
+.splitpane{display:grid;grid-template-columns:minmax(240px,340px) 1fr;min-height:430px}
+.lpane{border-right:1px solid var(--line);padding:12px;display:grid;gap:8px;align-content:start}
+.lsearch{background:var(--well);border-radius:9px;padding:8px 11px;font-size:12.5px;color:var(--ink3)}
+.litem{border:1px solid var(--line);border-radius:12px;padding:10px 11px;display:grid;gap:5px;cursor:pointer}
+.litem .mut{color:var(--ink3);font-size:12px}
+.litem.on{border-color:var(--accent);background:var(--tint)}
+.litem.flag{background:var(--flagtint);border-color:rgba(192,53,32,.25)}
+.litem.flag.on{border-color:var(--alert)}
+.lnote{font-size:11.5px;color:var(--ink3);font-style:italic;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.rpane{padding:18px 20px}
+.rpane h3{font-size:19px;letter-spacing:-.01em}
+.rpane .sup{color:var(--ink3);font-size:12.5px;margin-top:2px}
+.rpane .cols{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:14px;margin-top:16px}
+
+/* ---------- questions ---------- */
+.qgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(330px,1fr));gap:14px;max-width:1400px}
+.qcard{background:#fff;border:1px solid var(--line);border-radius:14px;padding:16px 17px;position:relative}
+.qcard .qn{position:absolute;top:16px;right:16px;font-size:11px;font-weight:800;color:var(--ink3)}
+.qcard h4{font-size:15px;padding-right:22px;margin-bottom:7px}
+.qcard p{font-size:13px;color:var(--ink2);margin-bottom:7px}
+.qcard p:last-child{margin-bottom:0}
+.qcard .qwhy{color:var(--accent);font-weight:600;font-size:12.5px}
+@media (max-width:820px){.splitpane{grid-template-columns:1fr}.notecol{border-left:0;padding-left:0}}
+</style>
+
+<script>
+/* ================== helpers ================== */
+const $=(s,r=document)=>r.querySelector(s);
+const $$=(s,r=document)=>[...r.querySelectorAll(s)];
+function M(n){
+  const neg=n<-0.0001, v=Math.abs(Math.round(n*100)/100).toFixed(2), p=v.split(".");
+  return (neg?"−$":"$")+p[0].replace(/\B(?=(\d{3})+(?!\d))/g,",")+"."+p[1];
+}
+const num=el=>{const v=parseFloat(String(el.value).replace(/[^0-9.]/g,""));return isFinite(v)?v:0};
+const LUNCH={cash:118,card:142,grat:0};
+const LUNCH_ALL=LUNCH.cash+LUNCH.card+LUNCH.grat;
+const POOL=205;
+const NAMES=["Ana","Marco","Priya","Dee","Kenji"];
+const COLS=["#e84d38","#2563eb","#1f7a4d","#b7791f","#6b5bd6"];
+/** Largest-remainder allocation so shares always sum to exactly the pool. */
+function allocate(poolCents,weights){
+  const total=weights.reduce((a,b)=>a+b,0);
+  if(total<=0)return weights.map(()=>0);
+  const raw=weights.map(w=>poolCents*w/total);
+  const base=raw.map(Math.floor);
+  let rest=poolCents-base.reduce((a,b)=>a+b,0);
+  const order=raw.map((v,i)=>[v-Math.floor(v),i]).sort((a,b)=>b[0]-a[0]);
+  for(let k=0;k<rest;k++)base[order[k%order.length][1]]++;
+  return base;
+}
+
+/* ================== tabs ================== */
+$$("#tabs button").forEach(b=>b.onclick=()=>{
+  $$("#tabs button").forEach(x=>x.setAttribute("aria-pressed",String(x===b)));
+  $$("section[data-tab]").forEach(s=>s.classList.toggle("live",s.dataset.tab===b.dataset.go));
+  window.scrollTo({top:0});
+});
+
+/* ================== A1 · three wells ================== */
+(function(){
+  const p=$('[data-opt="a1"]');if(!p)return;
+  const f=n=>$(`[data-f="${n}"]`,p),out=n=>$(`[data-out="${n}"]`,p);
+  let scope="day";
+  $$("[data-scope] button",p).forEach(b=>b.onclick=()=>{
+    scope=b.dataset.v;$$("[data-scope] button",p).forEach(x=>x.classList.toggle("on",x===b));render();
+  });
+  $$("input",p).forEach(i=>i.addEventListener("input",render));
+  function render(){
+    const cash=num(f("cash")),card=num(f("card")),grat=num(f("grat"));
+    const day=scope==="day";
+    const ent=cash+card+grat, lun=day?LUNCH_ALL:0;
+    out("ent").textContent=M(ent);
+    out("fin").textContent=M(ent-lun);
+    const subline=$(".ln.sub",p);
+    subline.hidden=!day;
+    out("lun").textContent="−"+M(lun);
+    $(".ln span",p).textContent=day?"Entered (whole day)":"Entered (dinner only)";
+    const pool=Math.max(0,cash-(day?LUNCH.cash:0));
+    out("each").textContent=M(allocate(Math.round(pool*100),[1,1,1,1])[0]/100);
+    $(".strip .of",p).textContent="cash pool "+M(pool);
+    $(".strip .of",p).style.color=cash-(day?LUNCH.cash:0)<0?"var(--alert)":"";
+  }
+  render();
+})();
+
+/* ================== A2 · receipt tape ================== */
+(function(){
+  const p=$('[data-opt="a2"]');if(!p)return;
+  const f=n=>$(`[data-f="${n}"]`,p),out=n=>$(`[data-out="${n}"]`,p);
+  $("[data-gratcalc]",p).onclick=()=>{const b=$("[data-gratcalcbox]",p);b.hidden=!b.hidden};
+  $("[data-usegrat]",p).onclick=()=>{f("grat").value=(num(f("sub"))*0.18).toFixed(2);render()};
+  $$("input",p).forEach(i=>i.addEventListener("input",render));
+  $$('input[type="checkbox"]',p).forEach(i=>i.addEventListener("change",render));
+  function render(){
+    const cash=num(f("cash")),card=num(f("card")),grat=num(f("grat"));
+    const inside=f("gratinside").checked, minus=f("minuslunch").checked;
+    out("gratcalc").textContent=M(num(f("sub"))*0.18);
+    const ent=cash+card+(inside?0:grat);
+    const lun=minus?LUNCH_ALL:0;
+    out("lunchamt").textContent="−"+M(lun);
+    $("[data-lunchline]",p).style.opacity=minus?"1":".45";
+    out("fin").textContent=M(ent-lun);
+    const pool=Math.max(0,cash-(minus?LUNCH.cash:0));
+    out("each").textContent=M(allocate(Math.round(pool*100),[1,1,1,1])[0]/100);
+    $(".strip .of",p).textContent="cash pool "+M(pool);
+  }
+  render();
+})();
+
+/* ================== A3 · day bar ================== */
+(function(){
+  const p=$('[data-opt="a3"]');if(!p)return;
+  const f=n=>$(`[data-f="${n}"]`,p),out=n=>$(`[data-out="${n}"]`,p);
+  let annotated=false;
+  $("[data-splitday]",p).onclick=e=>{
+    annotated=!annotated;
+    e.target.previousSibling.textContent=annotated?"cash and card would be two fields here — same bar, same math · ":"cash $323.00 + card $777.00 · ";
+  };
+  $$("input",p).forEach(i=>i.addEventListener("input",render));
+  function render(){
+    const day=num(f("daytotal")),grat=Math.min(num(f("grat")),day);
+    const lunch=Math.min(LUNCH_ALL,day), dinner=Math.max(0,day-lunch);
+    const gratIn=Math.min(grat,dinner), rest=Math.max(0,dinner-gratIn);
+    const pc=v=>day>0?(v/day*100):0;
+    out("bar").innerHTML=
+      `<span class="s-lunch" style="width:${pc(lunch)}%">${pc(lunch)>16?"Lunch "+M(lunch):""}</span>`+
+      `<span class="s-grat" style="width:${pc(gratIn)}%">${pc(gratIn)>14?"grat":""}</span>`+
+      `<span class="s-dinner" style="width:${pc(rest)}%">${pc(rest)>18?"Dinner "+M(dinner):""}</span>`;
+    out("legend").innerHTML=
+      `<b><i style="background:var(--ink3)"></i>Lunch banked ${M(lunch)}</b>`+
+      `<b><i style="background:var(--green)"></i>Auto-grat ${M(gratIn)}</b>`+
+      `<b><i style="background:var(--accent)"></i>Dinner ${M(dinner)}</b>`;
+    out("fin").textContent=M(dinner);
+    const line=out("fin").closest(".c").querySelector(".mini");
+    const short=day<LUNCH_ALL;
+    line.innerHTML=`day ${M(day)} − lunch ${M(lunch)} · `+
+      (short?`<b style="color:var(--alert)">day total is under what lunch already banked</b>`:`<b class="ok">reconciles</b>`);
+  }
+  render();
+})();
+
+/* ================== A4 · guided ================== */
+(function(){
+  const p=$('[data-opt="a4"]');if(!p)return;
+  const f=n=>$(`[data-f="${n}"]`,p),out=n=>$(`[data-out="${n}"]`,p);
+  let step=0,scope="day",hasGrat=true;
+  $$("[data-scope] .pick",p).forEach(b=>b.onclick=()=>{
+    scope=b.dataset.v;$$("[data-scope] .pick",p).forEach(x=>x.classList.toggle("on",x===b));render();
+  });
+  $$("[data-gyn] button",p).forEach(b=>b.onclick=()=>{
+    hasGrat=b.dataset.v==="y";$$("[data-gyn] button",p).forEach(x=>x.classList.toggle("on",x===b));
+    $("[data-gbox]",p).hidden=!hasGrat;render();
+  });
+  $("[data-usegrat]",p).onclick=()=>{f("grat").value=(num(f("sub"))*0.18).toFixed(2);render()};
+  $("[data-next]",p).onclick=()=>{step=Math.min(2,step+1);render()};
+  $("[data-back]",p).onclick=()=>{step=Math.max(0,step-1);render()};
+  $$("input",p).forEach(i=>i.addEventListener("input",render));
+  $$('input[type="checkbox"]',p).forEach(i=>i.addEventListener("change",render));
+  function render(){
+    $$("[data-step]",p).forEach(s=>s.hidden=Number(s.dataset.step)!==step);
+    $$("[data-dots] i",p).forEach((d,i)=>d.classList.toggle("on",i===step));
+    $("[data-next]",p).textContent=step===2?"Review & save":"Next";
+    const cash=num(f("cash")),card=num(f("card")),ent=cash+card;
+    const grat=hasGrat?num(f("grat")):0, inside=f("gratinside").checked;
+    out("prevday").textContent=M(Math.max(0,ent-LUNCH_ALL));
+    out("prevshift").textContent=M(ent);
+    out("gratcalc").textContent=M(num(f("sub"))*0.18);
+    const lun=scope==="day"?LUNCH_ALL:0;
+    const fin=ent-lun+(inside?0:grat);
+    out("ent").textContent=M(ent+(inside?0:grat));
+    out("lun").textContent="−"+M(lun);
+    out("lun").closest(".ln").hidden=scope!=="day";
+    out("gratline").textContent=hasGrat?M(grat)+(inside?" (inside card)":" (added)"):"none";
+    out("fin").textContent=M(fin);
+  }
+  render();
+})();
+
+/* ================== B1 · badge on the chip ================== */
+(function(){
+  const p=$('[data-opt="b1"]');if(!p)return;
+  const CYCLE=[1,.75,.5,.25];
+  const people=NAMES.map((n,i)=>({n,on:true,w:i===4?.5:1}));
+  const roster=$("[data-roster]",p),payout=$("[data-payout]",p);
+  function render(){
+    roster.innerHTML=people.map((x,i)=>
+      `<span class="chip${x.on?" on":""}" data-i="${i}">${x.n}${x.on?`<b class="pct" data-b="${i}">${Math.round(x.w*100)}%</b>`:""}</span>`).join("");
+    $$("[data-i]",roster).forEach(c=>c.onclick=e=>{
+      if(e.target.dataset.b!==undefined){
+        const i=+e.target.dataset.b;
+        people[i].w=CYCLE[(CYCLE.indexOf(people[i].w)+1)%CYCLE.length];
+      }else{const i=+c.dataset.i;people[i].on=!people[i].on}
+      render();
+    });
+    const live=people.filter(x=>x.on);
+    const cents=allocate(POOL*100,live.map(x=>x.w));
+    // The per-person list is only worth screen space once a share is uneven —
+    // an all-100% split is fully described by "$X each" in the strip below.
+    const uneven=live.some(x=>x.w<1);
+    payout.closest(".c").hidden=!uneven;
+    payout.innerHTML=!uneven?"":live.map((x,i)=>
+      `<div class="prow"><span class="nm">${x.n}</span>${x.w<1?`<span class="sub">${Math.round(x.w*100)}% share</span>`:""}<span class="amtv">${M(cents[i]/100)}</span></div>`).join("");
+    const totalW=live.reduce((a,b)=>a+b.w,0);
+    $('[data-out="full"]',p).textContent=totalW?M(POOL/totalW):"$0.00";
+    $(".strip .slabel",p).textContent=uneven?"Full share":`Split ${live.length} ways`;
+    const partial=live.filter(x=>x.w<1).map(x=>x.n);
+    $("[data-tip]",p).innerHTML=partial.length
+      ? `<b>${partial.join(", ")}</b> ${partial.length>1?"are":"is"} on a reduced share — the pool is spread across ${totalW.toFixed(2).replace(/\.00$/,"")} shares, so everyone else goes up.`
+      : "Everyone is on a full share. Tap a badge to give somebody less.";
+  }
+  render();
+})();
+
+/* ================== B2 · hours ================== */
+(function(){
+  const p=$('[data-opt="b2"]');if(!p)return;
+  const hrs=[4,4,4,4,2],box=$("[data-hours]",p);
+  $("[data-allfull]",p).onclick=()=>{hrs.fill(4);render()};
+  function render(){
+    const total=hrs.reduce((a,b)=>a+b,0);
+    const cents=allocate(POOL*100,hrs);
+    box.innerHTML=NAMES.map((n,i)=>
+      `<div class="prow"><span class="nm">${n}</span>
+        <span class="step2"><button data-m="${i}">−</button><span class="v">${hrs[i].toFixed(1)} h</span><button data-pl="${i}">+</button></span>
+        <span class="amtv" style="min-width:64px;text-align:right">${M(cents[i]/100)}</span></div>`).join("");
+    $$("[data-m]",box).forEach(b=>b.onclick=()=>{const i=+b.dataset.m;hrs[i]=Math.max(0,hrs[i]-.5);render()});
+    $$("[data-pl]",box).forEach(b=>b.onclick=()=>{const i=+b.dataset.pl;hrs[i]=Math.min(12,hrs[i]+.5);render()});
+    $('[data-out="th"]',p).textContent=total.toFixed(1)+" h";
+    $('[data-out="ph"]',p).textContent=total?M(POOL/total)+" / h":"—";
+  }
+  render();
+})();
+
+/* ================== B3 · drag the pool ================== */
+(function(){
+  const p=$('[data-opt="b3"]');if(!p)return;
+  const bar=$("[data-bar]",p),leg=$("[data-legend]",p);
+  let w=[22.5,22.5,22.5,22.5,10];
+  const segs=[],handles=[];
+  NAMES.forEach((n,i)=>{
+    const s=document.createElement("span");s.className="wseg";s.style.background=COLS[i];
+    s.innerHTML=`<span>${n}</span><span class="wv"></span>`;bar.appendChild(s);segs.push(s);
+  });
+  for(let i=0;i<NAMES.length-1;i++){
+    const h=document.createElement("span");h.className="whandle";h.dataset.h=i;bar.appendChild(h);handles.push(h);
+    h.addEventListener("pointerdown",e=>{
+      h.setPointerCapture(e.pointerId);
+      const startX=e.clientX,a=w[i],b=w[i+1],W=bar.getBoundingClientRect().width;
+      const move=ev=>{
+        let d=(ev.clientX-startX)/W*100;
+        d=Math.max(-(a-4),Math.min(b-4,d));
+        w[i]=a+d;w[i+1]=b-d;layout();
+      };
+      const up=()=>{h.removeEventListener("pointermove",move);h.removeEventListener("pointerup",up)};
+      h.addEventListener("pointermove",move);h.addEventListener("pointerup",up);
+    });
+  }
+  $("[data-even]",p).onclick=()=>{w=NAMES.map(()=>100/NAMES.length);layout()};
+  function layout(){
+    const cents=allocate(POOL*100,w);
+    let acc=0;
+    segs.forEach((s,i)=>{
+      s.style.width=w[i]+"%";
+      s.querySelector(".wv").textContent=w[i]>9?M(cents[i]/100):"";
+      s.firstChild.style.display=w[i]>12?"":"none";
+    });
+    handles.forEach((h,i)=>{acc+=w[i];h.style.left=acc+"%"});
+    leg.innerHTML=NAMES.map((n,i)=>
+      `<div class="wl" data-d="${i}"><i style="background:${COLS[i]}"></i>${n}<span class="pc">${w[i].toFixed(0)}%</span><b>${M(cents[i]/100)}</b></div>`).join("");
+    $$("[data-d]",leg).forEach(r=>r.ondblclick=()=>{
+      const i=+r.dataset.d,give=w[i]/2;w[i]-=give;
+      const others=w.length-1;w.forEach((_,j)=>{if(j!==i)w[j]+=give/others});layout();
+    });
+    $('[data-out="sum"]',p).textContent=M(cents.reduce((a,b)=>a+b,0)/100);
+  }
+  layout();
+})();
+
+/* ================== B4 · full / helper ================== */
+(function(){
+  const p=$('[data-opt="b4"]');if(!p)return;
+  const people=NAMES.map((n,i)=>({n,w:i===4?.5:1}));
+  let policy="reflow";
+  const list=$("[data-list]",p);
+  $$("[data-policy] button",p).forEach(b=>b.onclick=()=>{
+    policy=b.dataset.v;$$("[data-policy] button",p).forEach(x=>x.classList.toggle("on",x===b));render();
+  });
+  function shares(){
+    const n=people.length,sumW=people.reduce((a,b)=>a+b.w,0);
+    if(policy==="reflow"){
+      const cents=allocate(POOL*100,people.map(x=>x.w));
+      return{cents,full:POOL/sumW,left:0};
+    }
+    const full=POOL/n;
+    const cents=people.map(x=>Math.round(full*x.w*100));
+    return{cents,full,left:POOL-cents.reduce((a,b)=>a+b,0)/100};
+  }
+  function render(){
+    const{cents,full,left}=shares();
+    list.innerHTML=people.map((x,i)=>`
+      <div class="prow">
+        <div class="top"><span class="nm">${x.n}</span>
+          <span class="amtv" style="margin-left:12px">${M(cents[i]/100)}</span>
+          <span class="seg sm" data-r="${i}"><button data-w="1" class="${x.w===1?"on":""}">Full</button><button data-w="h" class="${x.w<1?"on":""}">Helper</button></span>
+        </div>
+        ${x.w<1?`<div class="presets" data-pr="${i}">
+          <button data-v=".25" class="${x.w===.25?"on":""}">¼ share</button>
+          <button data-v=".5" class="${x.w===.5?"on":""}">½ share</button>
+          <button data-v=".75" class="${x.w===.75?"on":""}">¾ share</button>
+          <button data-v="0" class="">custom</button></div>`:""}
+      </div>`).join("");
+    $$("[data-r] button",list).forEach(b=>b.onclick=()=>{
+      const i=+b.closest("[data-r]").dataset.r;
+      people[i].w=b.dataset.w==="1"?1:.5;render();
+    });
+    $$("[data-pr] button",list).forEach(b=>b.onclick=()=>{
+      const i=+b.closest("[data-pr]").dataset.pr,v=parseFloat(b.dataset.v);
+      people[i].w=v>0?v:.6;render();
+    });
+    const freed=POOL-(POOL/people.length)*people.reduce((a,b)=>a+b.w,0);
+    $("[data-policy]",p).previousElementSibling.textContent="The other "+M(freed);
+    $('[data-out="full"]',p).textContent=M(full);
+    const helper=people.find(x=>x.w<1);
+    $('[data-out="half"]',p).textContent=helper?M(cents[people.indexOf(helper)]/100):"—";
+    $('[data-out="half"]',p).closest(".ln").firstElementChild.textContent=helper?`${helper.n} (${Math.round(helper.w*100)}%)`:"No partial shares";
+    $('[data-out="left"]',p).textContent=M(left);
+  }
+  render();
+})();
+
+/* ================== C1 · quiet line ================== */
+(function(){
+  const p=$('[data-opt="c1"]');if(!p)return;
+  const closed=$("[data-noteclosed]",p),open=$("[data-noteopen]",p),done=$("[data-notedone]",p),ta=$('[data-f="note"]',p);
+  const show=(a,b,c)=>{closed.hidden=!a;open.hidden=!b;done.hidden=!c};
+  $("[data-open]",p).onclick=()=>{show(0,1,0);ta.focus()};
+  $("[data-cancel]",p).onclick=()=>show(1,0,0);
+  $("[data-edit]",p).onclick=()=>{show(0,1,0);ta.focus()};
+  $("[data-save]",p).onclick=()=>{
+    if(!ta.value.trim())return show(1,0,0);
+    $('[data-out="preview"]',p).textContent=ta.value.trim();show(0,0,1);
+  };
+  ta.addEventListener("input",()=>$('[data-out="count"]',p).textContent=`${ta.value.length} / 280`);
+})();
+
+/* ================== C2 · reason chips ================== */
+(function(){
+  const p=$('[data-opt="c2"]');if(!p)return;
+  const REASONS=["Drawer short","Drawer over","Big party / one check","Comped tables","Square looked wrong","Staffing was odd","Other"];
+  const on=new Set(["Drawer short"]);
+  const box=$("[data-reasons]",p),ta=$('[data-f="note"]',p);
+  function render(){
+    box.innerHTML=REASONS.map(r=>`<span class="chip${on.has(r)?" on":""}" data-r="${r}">${r}</span>`).join("");
+    $$("[data-r]",box).forEach(c=>c.onclick=()=>{
+      const r=c.dataset.r;on.has(r)?on.delete(r):on.add(r);render();
+    });
+    const txt=ta.value.trim();
+    $('[data-out="preview"]',p).innerHTML=on.size||txt
+      ? `<div class="dp">${[...on].map(r=>`<span class="rchip on">${r}</span>`).join("")}${txt?`<span style="color:var(--ink2)">“${txt.slice(0,60)}${txt.length>60?"…":""}”</span>`:""}</div>`
+      : `<div class="dp"><span style="color:var(--ink3)">nothing — the row stays clean</span></div>`;
+  }
+  ta.addEventListener("input",render);
+  render();
+})();
+
+/* ================== C3 · note on a person ================== */
+(function(){
+  const p=$('[data-opt="c3"]');if(!p)return;
+  const people=NAMES.map((n,i)=>({n,share:i===4?"½ · $22.76":"full · $45.56",note:i===4?"came in 6–8 to cover Priya’s break":""}));
+  const box=$("[data-people]",p);
+  let openIdx=-1;
+  function render(){
+    box.innerHTML=people.map((x,i)=>`
+      <div class="prow" style="display:block">
+        <div class="top" style="display:flex;align-items:center;gap:9px">
+          <span class="nm">${x.n}</span><span class="sub">${x.share}</span>
+          <button class="nb" data-n="${i}">${x.note?"note ✓":"+ note"}</button>
+        </div>
+        ${openIdx===i?`<input class="plain noteline" data-in="${i}" placeholder="e.g. left at 8, covered the patio" value="${x.note.replace(/"/g,"&quot;")}">`:
+          x.note?`<div class="sub noteline" style="color:var(--blue)">“${x.note}”</div>`:""}
+      </div>`).join("");
+    $$("[data-n]",box).forEach(b=>b.onclick=()=>{openIdx=openIdx===+b.dataset.n?-1:+b.dataset.n;render();
+      const inp=$("[data-in]",box);if(inp){inp.focus();inp.setSelectionRange(inp.value.length,inp.value.length)}});
+    const inp=$("[data-in]",box);
+    if(inp)inp.addEventListener("input",()=>people[+inp.dataset.in].note=inp.value);
+  }
+  render();
+})();
+
+/* ================== C4 · raise it ================== */
+(function(){
+  const p=$('[data-opt="c4"]');if(!p)return;
+  const sheet=$("[data-sheet]",p),done=$("[data-done]",p),btn=$("[data-open]",p),ta=$('[data-f="note"]',p);
+  let sev="fyi";
+  btn.onclick=()=>{sheet.hidden=false;btn.hidden=true;ta.focus()};
+  $("[data-cancel]",p).onclick=()=>{sheet.hidden=true;btn.hidden=false};
+  $$("[data-sev] button",p).forEach(b=>b.onclick=()=>{
+    sev=b.dataset.v;$$("[data-sev] button",p).forEach(x=>x.classList.toggle("on",x===b));
+    $('[data-out="hint"]',p).textContent=sev==="fyi"
+      ?"Saves quietly with the entry — no alert."
+      :"Lands in Recorded tips tinted red with a Verify button, next to the amounts the anomaly rule already flags.";
+  });
+  $("[data-save]",p).onclick=()=>{
+    sheet.hidden=true;done.hidden=false;
+    done.classList.toggle("flagged",sev==="check");
+    $(".fchip",done).textContent=sev==="check"?"⚑ check":"note";
+    $('[data-out="preview"]',p).textContent=ta.value.trim()||"Drawer was $20 short. Recounted twice.";
+  };
+})();
+
+/* ================== D2 · expandable rows ================== */
+(function(){
+  const p=$('[data-opt="d2"]');if(!p)return;
+  $$("[data-exp]",p).forEach(row=>row.onclick=()=>{
+    const det=row.nextElementSibling;
+    const open=!det.hidden;
+    det.hidden=open;row.classList.toggle("open",!open);
+    row.querySelector(".tri").textContent=open?"▸":"▾";
+  });
+})();
+
+/* ================== D4 · list + inspector ================== */
+(function(){
+  const p=$('[data-opt="d4"]');if(!p)return;
+  const E=[
+    {t:"Wed, Aug 27 · Dinner",s:"Babytuna Sushi · entered by Dee, dictated 10:52 PM",
+     calc:[["Entered from Square (whole day)","$323.00"],["− lunch recorded 3:41 PM","−$118.00","sub"],["Dinner cash pool","$205.00","tot"]],
+     extra:[["Card → payroll","$635.00"],["of which auto-grat 18%","$216.00"]],
+     people:[["Ana","full","$45.56"],["Marco","full","$45.56"],["Priya","full","$45.56"],["Dee","full","$45.56"],["Kenji","½ · 2h","$22.76"]],
+     note:"Drawer $20 short — Marco recounted, still short. Kenji only came in 6–8 to cover Priya’s break.",flag:false},
+    {t:"Wed, Aug 27 · Lunch",s:"Babytuna Sushi · entered by Ana, typed 3:41 PM",
+     calc:[["Entered as lunch only","$118.00","tot"]],extra:[["Card → payroll","$142.00"],["Auto-grat","none"]],
+     people:[["Ana","full","$39.33"],["Priya","full","$39.33"],["Dee","full","$39.34"]],note:"",flag:false},
+    {t:"Tue, Aug 26 · Dinner",s:"Babytuna Poki & Pho · entered by Sam, typed 9:58 PM",
+     calc:[["Entered as dinner only","$612.00","tot"],["Lunch on record that day","none","sub"]],
+     extra:[["Card → payroll","$210.00"],["Auto-grat","none"]],
+     people:[["Sam","full","$489.60"],["Rey","¼ · 1.5h","$122.40"]],
+     note:"Party of 30 on the patio, one check.",flag:true}];
+  const pane=$("[data-out='insp']",p);
+  function draw(i){
+    const e=E[i];
+    pane.innerHTML=`
+      <div class="row"><div><h3>${e.t}</h3><div class="sup">${e.s}</div></div>
+        <div style="margin-left:auto;display:flex;gap:8px">${e.flag?`<span class="tbtn sm prim">Verify</span>`:""}<span class="tbtn sm">Fix entry</span></div></div>
+      <div class="cols">
+        <div class="dcard"><div class="slabel">How this number was reached</div><div class="calc" style="margin-top:8px">
+          ${e.calc.map(r=>`<div class="ln ${r[2]||""}"><span>${r[0]}</span><span>${r[1]}</span></div>`).join("")}</div>
+          <div class="hair2"></div><div class="calc">
+          ${e.extra.map(r=>`<div class="ln"><span>${r[0]}</span><span>${r[1]}</span></div>`).join("")}</div></div>
+        <div class="dcard"><div class="slabel">Who takes what</div><table class="mini2"><tbody>
+          ${e.people.map(r=>`<tr><td>${r[0]}</td><td class="r mut">${r[1]}</td><td class="r b">${r[2]}</td></tr>`).join("")}
+        </tbody></table></div>
+        <div class="dcard"><div class="slabel">Note</div>
+          <p class="ntext${e.note?"":" mut"}">${e.note||"No note on this entry."}</p></div>
+      </div>`;
+  }
+  $$("[data-e]",p).forEach(it=>it.onclick=()=>{
+    $$("[data-e]",p).forEach(x=>x.classList.toggle("on",x===it));draw(+it.dataset.e);
+  });
+  draw(0);
+})();
+</script>
+</body>
+</html>

--- a/supabase/functions/_shared/tips.ts
+++ b/supabase/functions/_shared/tips.ts
@@ -1,9 +1,11 @@
 // Shared helpers for the tip-entry edge functions.
 //
-// The pure logic here (business date, anomaly rule) MIRRORS the canonical,
-// unit-tested implementations in web/src/lib/tips/businessDate.ts and
-// web/src/lib/tips/anomaly.ts. Keep them in sync — edge functions cannot
-// import from web/ (separate deploy bundles) and vice versa.
+// The pure logic here (business date, anomaly rule, weighted allocation, day
+// scope) MIRRORS the canonical, unit-tested implementations in
+// web/src/lib/tips/businessDate.ts, web/src/lib/tips/anomaly.ts,
+// web/src/lib/tips/split.ts, and web/src/lib/tips/dayScope.ts. Keep them in
+// sync — edge functions cannot import from web/ (separate deploy bundles) and
+// vice versa.
 
 // deno-lint-ignore-file no-explicit-any
 
@@ -44,7 +46,7 @@ export function clientIdentifier(req: Request): string {
  */
 export async function validateTipSession(
   admin: any,
-  sessionToken: string | null | undefined,
+  sessionToken: unknown,
 ): Promise<TipSession | null> {
   if (typeof sessionToken !== 'string' || sessionToken.length < 16 || sessionToken.length > 128) {
     return null;
@@ -213,6 +215,121 @@ export function normalizeAmount(value: unknown): number | null {
   if (typeof num !== 'number' || !Number.isFinite(num)) return null;
   if (num < 0 || num >= 100000) return null;
   return Math.round(num * 100) / 100;
+}
+
+// Weighted allocation (Tips v3 partial shares). Unlike the legacy equal
+// split, the allocated shares must sum to the pool EXACTLY — nothing stays in
+// the drawer beyond what largest-remainder cannot avoid (which is nothing).
+// Half-up rounding is wrong here: it can pay out more than the pool.
+//
+// MIRROR of web/src/lib/tips/split.ts (canonical + unit tested there). Keep
+// both copies in sync.
+
+export function toCents(amount: number): number {
+  return Math.round(amount * 100);
+}
+
+export function fromCents(cents: number): number {
+  return cents / 100;
+}
+
+/**
+ * Split poolCents across weights by largest remainder.
+ *
+ * raw_i = poolCents * w_i / sum(w); everyone gets floor(raw_i); the leftover
+ * cents go one at a time to the largest fractional parts, ties broken by the
+ * person's position in the split (earlier wins). Returns integer cents,
+ * positional with weights, summing exactly to poolCents. A pool of 0 or an
+ * empty/zero weight list allocates all zeros.
+ */
+export function allocatePoolCents(
+  poolCents: number,
+  weights: number[],
+): number[] {
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+  if (!Number.isFinite(poolCents) || poolCents <= 0 || totalWeight <= 0) {
+    return weights.map(() => 0);
+  }
+  const raw = weights.map((w) => (poolCents * w) / totalWeight);
+  const base = raw.map(Math.floor);
+  const rest = poolCents - base.reduce((sum, c) => sum + c, 0);
+  const order = raw
+    .map((value, index) => [value - Math.floor(value), index] as const)
+    .sort((a, b) => b[0] - a[0]);
+  for (let k = 0; k < rest; k++) {
+    base[order[k % order.length][1]] += 1;
+  }
+  return base;
+}
+
+/**
+ * The "full share" a weight-1 person takes, in cents, for display: the strip,
+ * the ledger's Per person column, and the saved screen all print this.
+ * round(poolCents / sum(weights)), half-up — display only; the money that is
+ * actually assigned comes from allocatePoolCents.
+ */
+export function fullShareCents(poolCents: number, weights: number[]): number {
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+  if (!Number.isFinite(poolCents) || poolCents <= 0 || totalWeight <= 0) {
+    return 0;
+  }
+  return Math.round(poolCents / totalWeight);
+}
+
+// Day-scope subtraction (Tips v3). A dinner entered as "Whole day (Square)"
+// stores shift-only figures: what the closer typed minus what lunch already
+// recorded, field by field (cash−cash, card−card, gratuity−gratuity), against
+// today's lunch row at the same location. The server recomputes this on save
+// and is authoritative; the client copy only drives the live receipt and the
+// blocking negative warning.
+//
+// MIRROR of web/src/lib/tips/dayScope.ts (canonical + unit tested there). Keep
+// both copies in sync.
+
+export type EnteredScope = 'shift' | 'day';
+
+export interface MealAmounts {
+  cash: number;
+  card: number;
+  gratuity: number;
+}
+
+export interface DerivedAmounts {
+  /** Shift-only figures in dollars, cent-exact. May be negative. */
+  derived: MealAmounts;
+  /** True when a lunch row existed and was subtracted. */
+  subtracted: boolean;
+}
+
+/**
+ * Derive the shift-only amounts from what the closer typed.
+ *
+ * On scope "day" with a lunch row on record, each field is typed − lunch,
+ * computed in integer cents. On scope "shift", or on "day" with no lunch
+ * recorded (the flagged day_total_no_lunch case), the typed figures pass
+ * through unchanged and `subtracted` is false.
+ */
+export function deriveShiftAmounts(
+  typed: MealAmounts,
+  scope: EnteredScope,
+  lunch: MealAmounts | null,
+): DerivedAmounts {
+  if (scope !== 'day' || lunch === null) {
+    return { derived: { ...typed }, subtracted: false };
+  }
+  return {
+    derived: {
+      cash: fromCents(toCents(typed.cash) - toCents(lunch.cash)),
+      card: fromCents(toCents(typed.card) - toCents(lunch.card)),
+      gratuity: fromCents(toCents(typed.gratuity) - toCents(lunch.gratuity)),
+    },
+    subtracted: true,
+  };
+}
+
+/** True when any derived field is negative — the one blocking entry state. */
+export function hasNegativeAmount(amounts: MealAmounts): boolean {
+  return amounts.cash < 0 || amounts.card < 0 || amounts.gratuity < 0;
 }
 
 /**

--- a/supabase/functions/tip-entries/index.ts
+++ b/supabase/functions/tip-entries/index.ts
@@ -9,7 +9,10 @@ import { corsHeadersForRequest } from '../_shared/cors.ts';
 import {
   businessDateFor,
   checkAnomaly,
+  defaultMealPeriod,
+  deriveShiftAmounts,
   fetchScheduledIds,
+  hasNegativeAmount,
   normalizeAmount,
   validateTipSession,
 } from '../_shared/tips.ts';
@@ -46,19 +49,31 @@ function parseMeal(value: unknown): 'lunch' | 'dinner' | null {
 async function loadSlot(locationId: string, businessDate: string, meal: string) {
   const { data, error } = await supabaseAdmin
     .from('tip_entries')
-    .select('id, business_date, meal_period, cash_amount, card_amount, split_count, entry_method, voice_variant, corrections_count, entered_by, flagged_anomaly, updated_at, tip_entry_people(tip_employee_id)')
+    .select('id, business_date, meal_period, cash_amount, card_amount, gratuity_amount, entered_scope, raw_cash_amount, raw_card_amount, raw_gratuity_amount, note, split_count, entry_method, voice_variant, corrections_count, entered_by, flagged_anomaly, updated_at, tip_entry_people(tip_employee_id, share_weight)')
     .eq('location_id', locationId)
     .eq('business_date', businessDate)
     .eq('meal_period', meal)
     .maybeSingle();
   if (error) throw error;
   if (!data) return null;
+  const people: Array<{ id: string; weight: number }> = (data.tip_entry_people ?? []).map(
+    (row: { tip_employee_id: string; share_weight: unknown }) => ({
+      id: row.tip_employee_id,
+      weight: Number(row.share_weight),
+    }),
+  );
   return {
     id: data.id,
     businessDate: data.business_date,
     meal: data.meal_period,
     cash: Number(data.cash_amount),
     card: Number(data.card_amount),
+    gratuity: Number(data.gratuity_amount),
+    enteredScope: data.entered_scope === 'day' ? 'day' : 'shift',
+    rawCash: Number(data.raw_cash_amount ?? data.cash_amount),
+    rawCard: Number(data.raw_card_amount ?? data.card_amount),
+    rawGratuity: Number(data.raw_gratuity_amount ?? data.gratuity_amount),
+    note: data.note ?? null,
     splitCount: data.split_count,
     entryMethod: data.entry_method,
     voiceVariant: data.voice_variant,
@@ -66,9 +81,38 @@ async function loadSlot(locationId: string, businessDate: string, meal: string) 
     enteredBy: data.entered_by,
     flaggedAnomaly: data.flagged_anomaly,
     updatedAt: data.updated_at,
-    peopleIds: (data.tip_entry_people ?? []).map(
-      (row: { tip_employee_id: string }) => row.tip_employee_id,
-    ),
+    peopleIds: people.map((person) => person.id),
+    people,
+  };
+}
+
+async function fetchToday(locationId: string, businessDate: string, now: Date) {
+  const { data, error } = await supabaseAdmin
+    .from('tip_entries')
+    .select('meal_period, cash_amount, card_amount, gratuity_amount')
+    .eq('location_id', locationId)
+    .eq('business_date', businessDate);
+  if (error) throw error;
+  const rows = (data ?? []) as Array<{
+    meal_period: string;
+    cash_amount: unknown;
+    card_amount: unknown;
+    gratuity_amount: unknown;
+  }>;
+  const meals = new Set(rows.map((row) => row.meal_period));
+  const lunchRow = rows.find((row) => row.meal_period === 'lunch');
+  return {
+    businessDate,
+    lunchRecorded: meals.has('lunch'),
+    dinnerRecorded: meals.has('dinner'),
+    defaultMeal: defaultMealPeriod(now),
+    lunch: lunchRow
+      ? {
+        cash: Number(lunchRow.cash_amount),
+        card: Number(lunchRow.card_amount),
+        gratuity: Number(lunchRow.gratuity_amount),
+      }
+      : null,
   };
 }
 
@@ -125,18 +169,30 @@ Deno.serve(async (req) => {
     if (action === 'get_slot') {
       const meal = parseMeal(body.meal);
       if (!meal) return json(req, { ok: false, error: 'Invalid meal period' }, 400);
-      const businessDate = businessDateFor(new Date());
-      const [entry, scheduledIds] = await Promise.all([
+      const now = new Date();
+      const businessDate = businessDateFor(now);
+      const [entry, scheduledIds, today] = await Promise.all([
         loadSlot(session.location_id, businessDate, meal),
         scheduledRosterIds(session.location_id, businessDate, meal),
+        fetchToday(session.location_id, businessDate, now),
       ]);
-      return json(req, { ok: true, businessDate, entry, scheduledIds });
+      return json(req, { ok: true, businessDate, entry, scheduledIds, today });
     }
 
     if (action === 'save') {
       const meal = parseMeal(body.meal);
       const cash = normalizeAmount(body.cash);
       const card = normalizeAmount(body.card);
+      const gratuity = normalizeAmount(body.gratuity === undefined ? 0 : body.gratuity);
+      const enteredScope = body.enteredScope === undefined
+        ? 'shift'
+        : body.enteredScope === 'shift' || body.enteredScope === 'day'
+        ? body.enteredScope
+        : null;
+      const trimmedNote = typeof body.note === 'string'
+        ? body.note.trim().slice(0, 280).trim()
+        : '';
+      const note = trimmedNote || null;
       const confirmAnomaly = body.confirmAnomaly === true;
       const entryMethod = body.entryMethod === 'voice' ? 'voice' : 'typed';
       const voiceVariant =
@@ -151,14 +207,43 @@ Deno.serve(async (req) => {
           : 0;
 
       if (!meal) return json(req, { ok: false, error: 'Invalid meal period' }, 400);
-      if (cash === null || card === null) {
+      if (cash === null || card === null || gratuity === null) {
         return json(req, { ok: false, error: 'Amounts must be between $0 and $99,999.' }, 400);
       }
+      if (!enteredScope) {
+        return json(req, { ok: false, error: 'Invalid entered scope' }, 400);
+      }
 
-      const peopleIds = Array.isArray(body.peopleIds)
-        ? body.peopleIds.filter((id): id is string => typeof id === 'string' && UUID_PATTERN.test(id))
-        : [];
-      const uniquePeople = [...new Set(peopleIds)];
+      const rawPeopleIds = Array.isArray(body.peopleIds) ? body.peopleIds : [];
+      const rawWeights = body.weights === undefined
+        ? rawPeopleIds.map(() => 1)
+        : body.weights;
+      if (
+        !Array.isArray(rawWeights) ||
+        rawWeights.length !== rawPeopleIds.length ||
+        !rawWeights.every(
+          (weight) =>
+            typeof weight === 'number' && Number.isFinite(weight) && weight > 0 && weight <= 1,
+        )
+      ) {
+        return json(req, {
+          ok: false,
+          code: 'bad_weights',
+          error: 'Each selected person needs a share greater than 0% and no more than 100%.',
+        }, 400);
+      }
+
+      // Filter invalid ids and dedupe in lockstep with their positional
+      // weights. The first occurrence wins, matching Set's prior behavior.
+      const uniquePeople: string[] = [];
+      const uniqueWeights: number[] = [];
+      const seenPeople = new Set<string>();
+      rawPeopleIds.forEach((id, index) => {
+        if (typeof id !== 'string' || !UUID_PATTERN.test(id) || seenPeople.has(id)) return;
+        seenPeople.add(id);
+        uniquePeople.push(id);
+        uniqueWeights.push(rawWeights[index] as number);
+      });
       if (uniquePeople.length < 1 || uniquePeople.length > 30) {
         return json(req, { ok: false, code: 'no_people', error: 'Pick at least one person splitting these tips.' }, 400);
       }
@@ -176,11 +261,38 @@ Deno.serve(async (req) => {
       }
 
       const businessDate = businessDateFor(new Date());
+      let lunch: { cash: number; card: number; gratuity: number } | null = null;
+      if (enteredScope === 'day') {
+        const { data: lunchRow, error: lunchError } = await supabaseAdmin
+          .from('tip_entries')
+          .select('cash_amount, card_amount, gratuity_amount')
+          .eq('location_id', session.location_id)
+          .eq('business_date', businessDate)
+          .eq('meal_period', 'lunch')
+          .maybeSingle();
+        if (lunchError) throw lunchError;
+        if (lunchRow) {
+          lunch = {
+            cash: Number(lunchRow.cash_amount),
+            card: Number(lunchRow.card_amount),
+            gratuity: Number(lunchRow.gratuity_amount),
+          };
+        }
+      }
+
+      const typedAmounts = { cash, card, gratuity };
+      const { derived } = deriveShiftAmounts(typedAmounts, enteredScope, lunch);
+      if (hasNegativeAmount(derived)) {
+        return json(req, {
+          ok: false,
+          code: 'negative_after_lunch',
+          error: 'Lunch already recorded more than this. Check the Square report.',
+        }, 400);
+      }
+      const missingLunch = enteredScope === 'day' && lunch === null;
 
       // Phase 2: anomaly check against trailing history for this slot,
       // excluding today's row (it's the one being edited).
-      let anomalyReason: string | null = null;
-      let flaggedAnomaly = false;
       const { data: historyRows, error: historyError } = await supabaseAdmin
         .from('tip_entries')
         .select('cash_amount, card_amount')
@@ -196,16 +308,21 @@ Deno.serve(async (req) => {
           card: Number(row.card_amount),
         }),
       );
-      const anomaly = checkAnomaly(history, cash, card);
+      const anomaly = checkAnomaly(history, derived.cash, derived.card);
+      let statisticalReason: string | null = null;
       if (anomaly.flagged) {
         if (!confirmAnomaly) {
           return json(req, { ok: false, needsConfirm: true, anomaly });
         }
-        flaggedAnomaly = true;
-        anomalyReason = anomaly.fields
+        statisticalReason = anomaly.fields
           .map((f) => `${f.field} $${f.value.toFixed(2)} vs typical $${f.typicalLow}-$${f.typicalHigh} (max ever $${f.maxEver.toFixed(0)})`)
           .join('; ');
       }
+      const flaggedAnomaly = missingLunch || anomaly.flagged;
+      const anomalyReason = [
+        missingLunch ? 'day_total_no_lunch' : null,
+        statisticalReason,
+      ].filter((reason): reason is string => reason !== null).join('; ') || null;
 
       // Atomic upsert + people replacement (single transaction in SQL) so a
       // failed people insert or two concurrent saves can't leave a slot with
@@ -214,9 +331,16 @@ Deno.serve(async (req) => {
         p_business_date: businessDate,
         p_location_id: session.location_id,
         p_meal_period: meal,
-        p_cash: cash,
-        p_card: card,
+        p_cash: derived.cash,
+        p_card: derived.card,
+        p_gratuity: derived.gratuity,
+        p_entered_scope: enteredScope,
+        p_raw_cash: cash,
+        p_raw_card: card,
+        p_raw_gratuity: gratuity,
         p_people: uniquePeople,
+        p_weights: uniqueWeights,
+        p_note: note,
         p_entry_method: entryMethod,
         p_voice_variant: entryMethod === 'voice' ? voiceVariant : null,
         p_corrections: correctionsCount,

--- a/supabase/functions/tip-entry-auth/index.ts
+++ b/supabase/functions/tip-entry-auth/index.ts
@@ -66,16 +66,30 @@ async function fetchToday(locationId: string, now: Date = new Date()) {
   const businessDate = businessDateFor(now);
   const { data, error } = await supabaseAdmin
     .from('tip_entries')
-    .select('meal_period')
+    .select('meal_period, cash_amount, card_amount, gratuity_amount')
     .eq('location_id', locationId)
     .eq('business_date', businessDate);
   if (error) console.warn('[tip-entry-auth] today fetch failed', error);
-  const meals = new Set((data ?? []).map((row: { meal_period: string }) => row.meal_period));
+  const rows = (data ?? []) as Array<{
+    meal_period: string;
+    cash_amount: unknown;
+    card_amount: unknown;
+    gratuity_amount: unknown;
+  }>;
+  const meals = new Set(rows.map((row) => row.meal_period));
+  const lunchRow = rows.find((row) => row.meal_period === 'lunch');
   return {
     businessDate,
     lunchRecorded: meals.has('lunch'),
     dinnerRecorded: meals.has('dinner'),
     defaultMeal: defaultMealPeriod(now),
+    lunch: lunchRow
+      ? {
+        cash: Number(lunchRow.cash_amount),
+        card: Number(lunchRow.card_amount),
+        gratuity: Number(lunchRow.gratuity_amount),
+      }
+      : null,
   };
 }
 

--- a/supabase/migrations/20260828100000_tips_v3_grat_scope_weights_notes.sql
+++ b/supabase/migrations/20260828100000_tips_v3_grat_scope_weights_notes.sql
@@ -1,0 +1,196 @@
+alter table public.tip_entries
+  add column gratuity_amount   numeric(10,2) not null default 0,
+  add column entered_scope      text not null default 'shift'
+      check (entered_scope in ('shift','day')),
+  add column raw_cash_amount    numeric(10,2),
+  add column raw_card_amount    numeric(10,2),
+  add column raw_gratuity_amount numeric(10,2),
+  add column note               text,
+  add column note_at            timestamptz;
+
+alter table public.tip_entry_people
+  add column share_weight numeric(4,3) not null default 1
+      check (share_weight > 0 and share_weight <= 1);
+
+alter table public.tip_entries
+  add constraint tip_entries_gratuity_amount_check
+    check (gratuity_amount >= 0),
+  add constraint tip_entries_note_check
+    check (
+      note is null
+      or (note = btrim(note) and char_length(note) between 1 and 280)
+    );
+
+-- Replace the session-guarded save RPC with the Tips v3 signature. The
+-- 13-argument signature is recreated below as a deploy-window wrapper.
+drop function public.tip_save_entry(
+  date, uuid, text, numeric, numeric, uuid[], text, text, integer, uuid, boolean, text, uuid
+);
+
+create function public.tip_save_entry(
+  p_business_date date,
+  p_location_id uuid,
+  p_meal_period text,
+  p_cash numeric,
+  p_card numeric,
+  p_gratuity numeric,
+  p_entered_scope text,
+  p_raw_cash numeric,
+  p_raw_card numeric,
+  p_raw_gratuity numeric,
+  p_people uuid[],
+  p_weights numeric[],
+  p_note text,
+  p_entry_method text,
+  p_voice_variant text,
+  p_corrections integer,
+  p_entered_by uuid,
+  p_flagged boolean,
+  p_anomaly_reason text,
+  p_session_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_entry_id uuid;
+begin
+  if array_length(p_people, 1) is null or array_length(p_people, 1) < 1 then
+    raise exception 'At least one person must split the entry';
+  end if;
+
+  if coalesce(array_length(p_weights, 1), 0) <> array_length(p_people, 1) then
+    raise exception using errcode = '22023', message = 'Weights must match people';
+  end if;
+
+  -- The conflict update locks the existing slot before its session identity is
+  -- checked, so concurrent saves from different devices cannot race past this
+  -- guard. A false WHERE clause returns no row, which maps to the explicit
+  -- already-recorded response below.
+  insert into public.tip_entries (
+    business_date, location_id, meal_period, cash_amount, card_amount,
+    gratuity_amount, entered_scope, raw_cash_amount, raw_card_amount,
+    raw_gratuity_amount, note, note_at, split_count, entry_method,
+    voice_variant, corrections_count, entered_by, flagged_anomaly,
+    anomaly_reason, entry_session_id
+  ) values (
+    p_business_date, p_location_id, p_meal_period, p_cash, p_card,
+    p_gratuity, p_entered_scope, p_raw_cash, p_raw_card, p_raw_gratuity,
+    p_note, case when p_note is null then null else now() end,
+    array_length(p_people, 1), p_entry_method,
+    case when p_entry_method = 'voice' then p_voice_variant else null end,
+    p_corrections, p_entered_by, p_flagged, p_anomaly_reason, p_session_id
+  )
+  on conflict (business_date, location_id, meal_period) do update
+    set cash_amount = excluded.cash_amount,
+        card_amount = excluded.card_amount,
+        gratuity_amount = excluded.gratuity_amount,
+        entered_scope = excluded.entered_scope,
+        raw_cash_amount = excluded.raw_cash_amount,
+        raw_card_amount = excluded.raw_card_amount,
+        raw_gratuity_amount = excluded.raw_gratuity_amount,
+        note_at = case
+          when public.tip_entries.note is distinct from excluded.note then now()
+          else public.tip_entries.note_at
+        end,
+        note = excluded.note,
+        split_count = excluded.split_count,
+        entry_method = excluded.entry_method,
+        voice_variant = coalesce(excluded.voice_variant, public.tip_entries.voice_variant),
+        corrections_count = case
+          when excluded.entry_method = 'voice' then excluded.corrections_count
+          else public.tip_entries.corrections_count
+        end,
+        entered_by = excluded.entered_by,
+        flagged_anomaly = excluded.flagged_anomaly,
+        anomaly_reason = excluded.anomaly_reason,
+        entry_session_id = excluded.entry_session_id
+    where public.tip_entries.entry_session_id is not distinct from p_session_id
+  returning id into v_entry_id;
+
+  if v_entry_id is null then
+    raise exception using errcode = 'P0001', message = 'already_recorded';
+  end if;
+
+  delete from public.tip_entry_people where tip_entry_id = v_entry_id;
+  insert into public.tip_entry_people (tip_entry_id, tip_employee_id, share_weight)
+  select v_entry_id, person.person_id, p_weights[person.position::integer]
+  from unnest(p_people) with ordinality as person(person_id, position);
+
+  return v_entry_id;
+end;
+$$;
+
+comment on function public.tip_save_entry(
+  date, uuid, text, numeric, numeric, numeric, text, numeric, numeric, numeric,
+  uuid[], numeric[], text, text, text, integer, uuid, boolean, text, uuid
+) is
+  'Tips v3 save: p_cash/p_card/p_gratuity are server-derived shift amounts; p_raw_cash/p_raw_card/p_raw_gratuity are the closer-typed amounts. Day-scope derivation lives in the edge function, not SQL.';
+
+-- Compatibility signature for the old deployed edge function. Its inputs
+-- already represent shift-only amounts, so raw values match derived values.
+create function public.tip_save_entry(
+  p_business_date date,
+  p_location_id uuid,
+  p_meal_period text,
+  p_cash numeric,
+  p_card numeric,
+  p_people uuid[],
+  p_entry_method text,
+  p_voice_variant text,
+  p_corrections integer,
+  p_entered_by uuid,
+  p_flagged boolean,
+  p_anomaly_reason text,
+  p_session_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  return public.tip_save_entry(
+    p_business_date,
+    p_location_id,
+    p_meal_period,
+    p_cash,
+    p_card,
+    0,
+    'shift',
+    p_cash,
+    p_card,
+    0,
+    p_people,
+    array_fill(1::numeric, array[coalesce(array_length(p_people, 1), 0)]),
+    null,
+    p_entry_method,
+    p_voice_variant,
+    p_corrections,
+    p_entered_by,
+    p_flagged,
+    p_anomaly_reason,
+    p_session_id
+  );
+end;
+$$;
+
+revoke all on function public.tip_save_entry(
+  date, uuid, text, numeric, numeric, numeric, text, numeric, numeric, numeric,
+  uuid[], numeric[], text, text, text, integer, uuid, boolean, text, uuid
+) from public, anon, authenticated;
+
+grant execute on function public.tip_save_entry(
+  date, uuid, text, numeric, numeric, numeric, text, numeric, numeric, numeric,
+  uuid[], numeric[], text, text, text, integer, uuid, boolean, text, uuid
+) to service_role;
+
+revoke all on function public.tip_save_entry(
+  date, uuid, text, numeric, numeric, uuid[], text, text, integer, uuid, boolean, text, uuid
+) from public, anon, authenticated;
+
+grant execute on function public.tip_save_entry(
+  date, uuid, text, numeric, numeric, uuid[], text, text, integer, uuid, boolean, text, uuid
+) to service_role;

--- a/web/e2e/entry.spec.ts
+++ b/web/e2e/entry.spec.ts
@@ -50,12 +50,39 @@ async function clearChips(page: Page): Promise<void> {
   }
 }
 
-/** Wait for a save round-trip triggered by clicking "Save →". */
-async function save(page: Page): Promise<void> {
-  await Promise.all([
-    page.waitForResponse((response) => response.url().includes("tip-entries")),
+/** The server's stored row, as the save response reports it. */
+interface SavedEntry {
+  cash: number;
+  card: number;
+  gratuity: number;
+  enteredScope: string;
+  rawCash: number;
+  rawCard: number;
+  rawGratuity: number;
+  note: string | null;
+  people: Array<{ id: string; weight: number }>;
+  flaggedAnomaly: boolean;
+}
+
+/**
+ * Wait for a save round-trip triggered by clicking "Save →" and return what
+ * the SERVER stored — the persistence assertions must never trust the
+ * client's own rendering of its payload.
+ */
+async function save(page: Page): Promise<SavedEntry> {
+  const [response] = await Promise.all([
+    // Match the SAVE response specifically — get_slot also hits tip-entries
+    // and its response carries entry: null for an empty slot.
+    page.waitForResponse(
+      (r) =>
+        r.url().includes("tip-entries") &&
+        (r.request().postDataJSON() as { action?: string } | null)?.action === "save",
+    ),
     page.getByRole("button", { name: "Save →" }).click(),
   ]);
+  const json = (await response.json()) as { entry?: SavedEntry };
+  expect(json.entry).toBeTruthy();
+  return json.entry as SavedEntry;
 }
 
 test.describe("typed entry", () => {
@@ -98,7 +125,15 @@ test.describe("typed entry", () => {
       page.getByText("Drawer was $20 short — recounted."),
     ).toBeVisible();
 
-    await save(page);
+    const saved = await save(page);
+    // The server stored what was typed — shift scope, note included.
+    expect(saved.cash).toBe(120.5);
+    expect(saved.card).toBe(340.25);
+    expect(saved.gratuity).toBe(0);
+    expect(saved.enteredScope).toBe("shift");
+    expect(saved.rawCash).toBe(120.5);
+    expect(saved.note).toBe("Drawer was $20 short — recounted.");
+    expect(saved.people.map((p) => p.weight)).toEqual([1, 1]);
 
     // Full-screen confirmation: read-only wells, the note, and a countdown
     // that hands the phone back to the scan gate without a tap.
@@ -191,7 +226,17 @@ test.describe("typed entry", () => {
     await badge(page, "Jose", 100).click(); // → 75
     await badge(page, "Jose", 75).click(); // → 50
 
-    await save(page);
+    const saved = await save(page);
+    // The server stored the DERIVED shift figures and kept the raw ones.
+    expect(saved.cash).toBe(230);
+    expect(saved.card).toBe(60);
+    expect(saved.gratuity).toBe(50);
+    expect(saved.enteredScope).toBe("day");
+    expect(saved.rawCash).toBe(350.5);
+    expect(saved.rawCard).toBe(400.25);
+    expect(saved.rawGratuity).toBe(50);
+    expect(saved.flaggedAnomaly).toBe(false);
+    expect(saved.people.map((p) => p.weight).sort()).toEqual([0.5, 1]);
 
     // The saved screen shows the DERIVED shift figures, not what was typed:
     // cash 230.00, card 400.25 − 340.25 = 60.00, gratuity 50.00 − 0 = 50.00.

--- a/web/e2e/entry.spec.ts
+++ b/web/e2e/entry.spec.ts
@@ -1,19 +1,23 @@
-// The entry form: split math, the zero-people guard, the save confirmation
-// that signs the phone out, and the duplicate-slot lockout on the next
-// session. Sessions are minted via the edge function directly (the sign-in
-// UI is covered in landing.spec.ts).
+// The entry form: cash-pool split math, the day-scope receipt, partial-share
+// badges, notes, the zero-people guard, the 10s save confirmation that signs
+// the phone out, and the duplicate-slot lockout on the next session. Sessions
+// are minted via the edge function directly (the sign-in UI is covered in
+// landing.spec.ts).
 //
 // These tests write real tip_entries rows for today's Sushi lunch + dinner
 // slots on the live backend; run e2e/cleanup.sql BEFORE and after a run —
 // entry devices can no longer overwrite recorded slots, so leftovers from a
 // previous run would leave these specs starting on the "All set" screen.
+//
+// Order matters: lunch records first so the whole-day dinner test has a
+// lunch to subtract.
 
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import { fixtures, signInAs } from "./helpers";
 
 async function fillAmount(
   page: Page,
-  label: "Cash" | "Card",
+  label: "Cash" | "Card" | "Gratuity",
   value: string,
 ): Promise<void> {
   await page.getByLabel(`${label} amount`).fill(value);
@@ -21,15 +25,29 @@ async function fillAmount(
 
 /**
  * A roster split chip. Chips are the only buttons carrying aria-pressed,
- * which disambiguates them from the header's closer button of the same name.
+ * which disambiguates them from the header's closer button of the same name
+ * (the % badges carry aria-labels, not aria-pressed).
  */
 function chip(page: Page, name: string): Locator {
   return page.locator("button[aria-pressed]").filter({ hasText: name });
 }
 
+/** A selected chip's share badge, addressed by its accessible name. */
+function badge(page: Page, name: string, percent: number): Locator {
+  return page.getByRole("button", { name: `${name} share ${percent}%` });
+}
+
 /** The Lunch|Dinner segmented control renders as tabs. */
 function mealTab(page: Page, name: "Lunch" | "Dinner"): Locator {
   return page.getByRole("tab", { name, exact: true });
+}
+
+/** Clear the schedule's pre-selected chips so the math is deterministic. */
+async function clearChips(page: Page): Promise<void> {
+  const pressed = page.locator('button[aria-pressed="true"]');
+  while ((await pressed.count()) > 0) {
+    await pressed.first().click();
+  }
 }
 
 /** Wait for a save round-trip triggered by clicking "Save →". */
@@ -41,7 +59,7 @@ async function save(page: Page): Promise<void> {
 }
 
 test.describe("typed entry", () => {
-  test("split math, save → confirmation signs the phone out", async ({
+  test("lunch: cash-pool split, note, 10s countdown returns to the scan gate", async ({
     page,
   }) => {
     const { sushiToken } = fixtures();
@@ -49,20 +67,14 @@ test.describe("typed entry", () => {
     await page.goto("/entry");
     await expect(page.getByRole("heading", { name: "Tips" })).toBeVisible();
 
-    // Pin the test to the dinner slot regardless of wall-clock default.
-    await mealTab(page, "Dinner").click();
-
-    // The manager's weekly schedule pre-selects today's crew; clear any
-    // pre-selected chips so the split-math scenario stays deterministic.
-    // (Chips are the only buttons carrying aria-pressed.) Re-query after
-    // every click — the chip list re-renders.
-    const pressed = page.locator('button[aria-pressed="true"]');
-    while ((await pressed.count()) > 0) {
-      await pressed.first().click();
-    }
+    await mealTab(page, "Lunch").click();
+    // Lunch has no scope switch — always records what was typed.
+    await expect(page.getByText("Whole day (Square)")).toBeHidden();
+    await clearChips(page);
 
     await fillAmount(page, "Cash", "120.50");
     await fillAmount(page, "Card", "340.25");
+    // Gratuity stays blank — blank is legal and means $0.
 
     // No people picked → strip prompts instead of computing.
     await expect(page.getByText(/Pick who.s splitting/)).toBeVisible();
@@ -70,50 +82,46 @@ test.describe("typed entry", () => {
     await chip(page, "Maria").click();
     await chip(page, "Jose").click();
 
-    // (120.50 + 340.25) / 2 = 230.375 → 230.38 (half-up, in cents).
+    // The strip reads on the CASH pool only: 120.50 / 2 = 60.25.
     await expect(page.getByText("Split 2 ways")).toBeVisible();
-    await expect(page.getByText("$230.38 each")).toBeVisible();
-    await expect(page.getByText("of $460.75")).toBeVisible();
+    await expect(page.getByText("$60.25 each")).toBeVisible();
+    await expect(page.getByText("of $120.50 cash")).toBeVisible();
+    // All-full split → no per-person card.
+    await expect(page.getByText("What each person takes")).toBeHidden();
+
+    // Attach a note, then reopen the editor to prove it round-trips.
+    await page.getByRole("button", { name: "+ Add a note" }).click();
+    await page.getByLabel("Note").fill("Drawer was $20 short — recounted.");
+    await expect(page.getByText("33 / 280")).toBeVisible();
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(
+      page.getByText("Drawer was $20 short — recounted."),
+    ).toBeVisible();
 
     await save(page);
 
-    // Full-screen confirmation with the numbers, then back to the scan gate.
+    // Full-screen confirmation: read-only wells, the note, and a countdown
+    // that hands the phone back to the scan gate without a tap.
     await expect(page.getByRole("heading", { name: "Saved" })).toBeVisible();
     await expect(page.getByText("$120.50")).toBeVisible();
     await expect(page.getByText("$340.25")).toBeVisible();
-    await expect(page.getByText("2 people · $230.38 each")).toBeVisible();
-    await page.getByRole("button", { name: "Done" }).click();
+    await expect(page.getByText("2 people · $60.25 each")).toBeVisible();
+    await expect(
+      page.getByText("Drawer was $20 short — recounted."),
+    ).toBeVisible();
+    await expect(page.getByText(/Back to the scan screen in/)).toBeVisible();
 
+    // Hold ~10s: the countdown expires and the session ends on its own.
     await expect(
       page.getByRole("heading", { name: "Scan to enter" }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
     const stored = await page.evaluate(() =>
       window.localStorage.getItem("bt_tips_session"),
     );
     expect(stored).toBeNull();
   });
 
-  test("recorded shift is locked out for the next session", async ({
-    page,
-  }) => {
-    // Runs after the dinner save above (Playwright config is serial).
-    const { sushiToken } = fixtures();
-    await signInAs(page, sushiToken, "Maria");
-    await page.goto("/entry");
-    await expect(page.getByRole("heading", { name: "Tips" })).toBeVisible();
-
-    await expect(mealTab(page, "Dinner")).toBeDisabled();
-    await expect(
-      page.getByText(/Dinner is already recorded today/),
-    ).toBeVisible();
-    // The preset lands on the remaining shift.
-    await expect(mealTab(page, "Lunch")).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-  });
-
-  test("zero-people guard blocks, $0 amounts are legal; then all-done", async ({
+  test("dinner as whole day: receipt subtraction, negative guard, badges, derived save", async ({
     page,
   }) => {
     const { sushiToken } = fixtures();
@@ -121,23 +129,91 @@ test.describe("typed entry", () => {
     await page.goto("/entry");
     await expect(page.getByRole("heading", { name: "Tips" })).toBeVisible();
 
-    // Lunch is the remaining slot after the dinner test.
-    await fillAmount(page, "Cash", "0");
-    await fillAmount(page, "Card", "0");
+    await mealTab(page, "Dinner").click();
+    await clearChips(page);
 
-    // Amounts valid but nobody picked → warning, no save.
+    // Zero-people guard: amounts alone don't save.
+    await fillAmount(page, "Cash", "350.50");
+    await fillAmount(page, "Card", "400.25");
+    await fillAmount(page, "Gratuity", "50.00");
     await page.getByRole("button", { name: "Save →" }).click();
     await expect(page.getByText("Pick at least one person")).toBeVisible();
-
-    // Picking someone clears the warning; $0/$0 saves fine.
-    await chip(page, "Ken").click();
+    await chip(page, "Maria").click();
+    await chip(page, "Jose").click();
     await expect(page.getByText("Pick at least one person")).toBeHidden();
-    await expect(page.getByText("$0.00 each")).toBeVisible();
-    await save(page);
-    await expect(page.getByRole("heading", { name: "Saved" })).toBeVisible();
-    await page.getByRole("button", { name: "Done" }).click();
 
-    // Both slots recorded → the next session gets the all-done screen.
+    // Whole day is the default: the receipt shows its work against the
+    // recorded lunch (cash 120.50 + card 340.25 + gratuity 0 = 460.75).
+    await expect(page.getByText("Entered (whole day)")).toBeVisible();
+    await expect(page.getByText("$800.75")).toBeVisible();
+    await expect(page.getByText("− Lunch already recorded")).toBeVisible();
+    await expect(page.getByText("−$460.75")).toBeVisible();
+    await expect(page.getByText("Dinner records")).toBeVisible();
+    await expect(page.getByText("$340.00")).toBeVisible();
+
+    // The one blocking warning: typed cash below the recorded lunch cash.
+    await fillAmount(page, "Cash", "50");
+    await expect(
+      page.getByText(/Lunch already recorded more than this/),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save →" })).toBeDisabled();
+    await fillAmount(page, "Cash", "350.50");
+    await expect(
+      page.getByText(/Lunch already recorded more than this/),
+    ).toBeHidden();
+
+    // Dinner-only scope hides the lunch line and relabels the receipt.
+    await page.getByRole("tab", { name: "Dinner only" }).click();
+    await expect(page.getByText("Entered (dinner only)")).toBeVisible();
+    await expect(page.getByText("− Lunch already recorded")).toBeHidden();
+    await page.getByRole("tab", { name: "Whole day (Square)" }).click();
+
+    // Derived cash pool: 350.50 − 120.50 = 230.00. Badge cycling reshapes
+    // the shares: Jose at 50% raises Maria's full share.
+    await expect(page.getByText("of $230.00 cash")).toBeVisible();
+    await expect(page.getByText("Split 2 ways")).toBeVisible();
+    await badge(page, "Jose", 100).click(); // → 75
+    await badge(page, "Jose", 75).click(); // → 50
+    await expect(page.getByText("Full share")).toBeVisible();
+    // The full share shows in the strip and in Maria's payout row.
+    await expect(page.getByText("$153.33").first()).toBeVisible();
+    await expect(page.getByText("What each person takes")).toBeVisible();
+    await expect(page.getByText("50% share")).toBeVisible();
+    await expect(page.getByText("$76.67")).toBeVisible();
+    // Cycling badges never deselects the person.
+    await expect(chip(page, "Jose")).toHaveAttribute("aria-pressed", "true");
+
+    // Back to 100% removes the per-person card; then settle on 50%.
+    await badge(page, "Jose", 50).click(); // → 25
+    await badge(page, "Jose", 25).click(); // → 100
+    await expect(page.getByText("What each person takes")).toBeHidden();
+    await expect(page.getByText("Split 2 ways")).toBeVisible();
+    await badge(page, "Jose", 100).click(); // → 75
+    await badge(page, "Jose", 75).click(); // → 50
+
+    await save(page);
+
+    // The saved screen shows the DERIVED shift figures, not what was typed:
+    // cash 230.00, card 400.25 − 340.25 = 60.00, gratuity 50.00 − 0 = 50.00.
+    await expect(page.getByRole("heading", { name: "Saved" })).toBeVisible();
+    await expect(page.getByText("$230.00")).toBeVisible();
+    await expect(page.getByText("$60.00")).toBeVisible();
+    await expect(page.getByText("$50.00")).toBeVisible();
+    await expect(page.getByText(/full share/)).toBeVisible();
+    await expect(page.getByText(/\(50%\)/)).toBeVisible();
+
+    // Done short-circuits the countdown.
+    await page.getByRole("button", { name: "Done" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Scan to enter" }),
+    ).toBeVisible();
+  });
+
+  test("recorded shifts lock out the next session; both recorded → all done", async ({
+    page,
+  }) => {
+    // Runs after both saves above (Playwright config is serial).
+    const { sushiToken } = fixtures();
     await signInAs(page, sushiToken, "Maria");
     await page.goto("/entry");
     await expect(page.getByText("All set for today")).toBeVisible();

--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -40,7 +40,7 @@ test.describe("scan landing", () => {
       page.getByRole("heading", { name: "Scan to enter" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Scan the sticker" }),
+      page.getByRole("button", { name: "Scan the QR code" }),
     ).toBeVisible();
     await expect(
       page.getByText("Use your camera app or scan it here."),

--- a/web/e2e/tips-v3.spec.ts
+++ b/web/e2e/tips-v3.spec.ts
@@ -1,0 +1,62 @@
+// Tips v3 edge case: a whole-day dinner with NO lunch on record saves
+// flagged for the manager — with nothing shown to the closer. The entry
+// screen shows no banner, the save succeeds with the ordinary confirmation,
+// and the stored row carries flagged_anomaly (asserted from the save
+// response, since the manager dashboard is auth-gated).
+//
+// Uses the Poki slot: entry.spec.ts records today's Sushi lunch, so Sushi
+// always HAS a lunch by the time these run. Poki's dinner is free —
+// voice-sheet.spec.ts only smoke-tests the sheet and never saves.
+
+import { expect, test } from "@playwright/test";
+import { fixtures, signInAs } from "./helpers";
+
+test("no-lunch whole-day dinner saves flagged with nothing shown to the closer", async ({
+  page,
+}) => {
+  const { pokiToken } = fixtures();
+  await signInAs(page, pokiToken, "Lena");
+  await page.goto("/entry");
+  await expect(page.getByRole("heading", { name: "Tips" })).toBeVisible();
+
+  await page.getByRole("tab", { name: "Dinner", exact: true }).click();
+
+  // Whole day is the default. With no lunch on record the receipt subtracts
+  // zero and no warning of any kind appears.
+  await expect(
+    page.getByRole("tab", { name: "Whole day (Square)" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await page.getByLabel("Cash amount").fill("200.00");
+  await page.getByLabel("Card amount").fill("100.00");
+  await expect(page.getByText("− Lunch already recorded")).toBeVisible();
+  await expect(page.getByText("−$0.00")).toBeVisible();
+  await expect(
+    page.getByText(/Lunch already recorded more than this/),
+  ).toBeHidden();
+
+  const pressed = page.locator('button[aria-pressed="true"]');
+  while ((await pressed.count()) > 0) {
+    await pressed.first().click();
+  }
+  await page
+    .locator("button[aria-pressed]")
+    .filter({ hasText: "Lena" })
+    .click();
+
+  // Save succeeds normally; the stored row is flagged day_total_no_lunch.
+  const [response] = await Promise.all([
+    page.waitForResponse((r) => r.url().includes("tip-entries")),
+    page.getByRole("button", { name: "Save →" }).click(),
+  ]);
+  const json = (await response.json()) as {
+    entry?: { flaggedAnomaly?: boolean; enteredScope?: string };
+  };
+  expect(json.entry?.flaggedAnomaly).toBe(true);
+  expect(json.entry?.enteredScope).toBe("day");
+
+  // The closer sees the ordinary confirmation — no flag, no warning.
+  await expect(page.getByRole("heading", { name: "Saved" })).toBeVisible();
+  await expect(page.getByText(/Back to the scan screen in/)).toBeVisible();
+  await page.getByRole("button", { name: "Done" }).click();
+  await expect(page.getByRole("heading", { name: "Scan to enter" })).toBeVisible();
+});

--- a/web/src/components/entry/AmountWell.tsx
+++ b/web/src/components/entry/AmountWell.tsx
@@ -36,6 +36,7 @@ export function AmountWell({
   onChange,
   autoFocus = false,
   onCommit,
+  compact = false,
 }: {
   label: string;
   value: string;
@@ -43,15 +44,17 @@ export function AmountWell({
   autoFocus?: boolean;
   /** Called on blur / Enter with the current (sanitized) value. */
   onCommit?: (value: string) => void;
+  /** Smaller type for the three-up Cash·Card·Gratuity grid. */
+  compact?: boolean;
 }) {
   return (
-    <div className="bg-well rounded-well p-4">
+    <div className={`bg-well rounded-well ${compact ? "p-2.5" : "p-4"}`}>
       <div className="section-label">{label}</div>
       {/* The bottom rule is the only cue that the amount is typeable — it is
           not decoration. Read-only wells (the saved screen) render their own
           markup without it. */}
       <div className="mt-1 flex items-baseline gap-1 border-b-[1.5px] border-disabled pb-1 focus-within:border-accent">
-        <span className="text-ink2 text-2xl font-bold">$</span>
+        <span className={`text-ink2 font-bold ${compact ? "text-sm" : "text-2xl"}`}>$</span>
         <input
           type="text"
           inputMode="decimal"
@@ -60,7 +63,9 @@ export function AmountWell({
           value={value}
           placeholder="0.00"
           aria-label={`${label} amount`}
-          className="w-full bg-transparent text-2xl font-bold text-ink caret-accent placeholder:text-ink3 outline-none"
+          className={`w-full bg-transparent font-bold text-ink caret-accent placeholder:text-ink3 outline-none tabular-nums ${
+            compact ? "text-base" : "text-2xl"
+          }`}
           onChange={(event) => onChange(sanitizeAmount(event.target.value))}
           onBlur={() => onCommit?.(value)}
           onKeyDown={(event) => {

--- a/web/src/components/entry/AmountWell.tsx
+++ b/web/src/components/entry/AmountWell.tsx
@@ -47,7 +47,10 @@ export function AmountWell({
   return (
     <div className="bg-well rounded-well p-4">
       <div className="section-label">{label}</div>
-      <div className="mt-1 flex items-baseline gap-1">
+      {/* The bottom rule is the only cue that the amount is typeable — it is
+          not decoration. Read-only wells (the saved screen) render their own
+          markup without it. */}
+      <div className="mt-1 flex items-baseline gap-1 border-b-[1.5px] border-disabled pb-1 focus-within:border-accent">
         <span className="text-ink2 text-2xl font-bold">$</span>
         <input
           type="text"
@@ -57,7 +60,7 @@ export function AmountWell({
           value={value}
           placeholder="0.00"
           aria-label={`${label} amount`}
-          className="w-full bg-transparent text-2xl font-bold text-ink placeholder:text-ink3 outline-none"
+          className="w-full bg-transparent text-2xl font-bold text-ink caret-accent placeholder:text-ink3 outline-none"
           onChange={(event) => onChange(sanitizeAmount(event.target.value))}
           onBlur={() => onCommit?.(value)}
           onKeyDown={(event) => {

--- a/web/src/components/entry/EntryForm.tsx
+++ b/web/src/components/entry/EntryForm.tsx
@@ -906,13 +906,14 @@ export function EntryForm() {
               <ScopeSwitch value={scope} onChange={setScope} disabled={saving} />
             </div>
           )}
-          <div className="grid grid-cols-3 gap-3">
-            <AmountWell label="Cash" value={cash} onChange={handleCashChange} />
-            <AmountWell label="Card" value={card} onChange={handleCardChange} />
+          <div className="grid grid-cols-3 gap-2">
+            <AmountWell label="Cash" value={cash} onChange={handleCashChange} compact />
+            <AmountWell label="Card" value={card} onChange={handleCardChange} compact />
             <AmountWell
               label="Gratuity"
               value={gratuity}
               onChange={handleGratuityChange}
+              compact
             />
           </div>
           <p className="mt-2 text-sm text-ink3">

--- a/web/src/components/entry/EntryForm.tsx
+++ b/web/src/components/entry/EntryForm.tsx
@@ -639,7 +639,17 @@ export function EntryForm() {
   const negativeAfterLunch = hasNegativeAmount(derivedAmounts);
 
   const poolCents = Math.max(0, toCents(derivedAmounts.cash));
-  const selectedWeights = selectedIds.map((id) => weightById[id] ?? 1);
+  // Allocation order is the ROSTER order (sort_order, name — the same rule
+  // the dashboard ranks by), not tap order: largest-remainder ties break by
+  // position, so every surface must order the split identically or the odd
+  // cent lands on different people on different screens.
+  const orderedSelectedIds = useMemo(() => {
+    const selected = new Set(selectedIds);
+    return state
+      ? state.roster.filter((person) => selected.has(person.id)).map((person) => person.id)
+      : selectedIds;
+  }, [state, selectedIds]);
+  const selectedWeights = orderedSelectedIds.map((id) => weightById[id] ?? 1);
   const canSave =
     amountsValid && !negativeAfterLunch && selectedIds.length > 0 && !saving;
 
@@ -656,15 +666,24 @@ export function EntryForm() {
       | "voiceVariant"
       | "correctionsCount"
     >,
-  ): SavePayload => ({
-    ...base,
-    // All three amounts go AS TYPED — the server does the subtraction.
-    gratuity: isValidAmount(gratuity) ? Number(gratuity) : 0,
-    enteredScope: base.meal === "dinner" ? scope : "shift",
-    weights: base.peopleIds.map((id) => weightById[id] ?? 1),
-    note,
-    confirmAnomaly: false,
-  });
+  ): SavePayload => {
+    // Same canonical roster ordering as the live allocation above, so the
+    // saved screen, the server, and the dashboard all see one split order.
+    const picked = new Set(base.peopleIds);
+    const peopleIds = state
+      ? state.roster.filter((person) => picked.has(person.id)).map((person) => person.id)
+      : base.peopleIds;
+    return {
+      ...base,
+      peopleIds,
+      // All three amounts go AS TYPED — the server does the subtraction.
+      gratuity: isValidAmount(gratuity) ? Number(gratuity) : 0,
+      enteredScope: base.meal === "dinner" ? scope : "shift",
+      weights: peopleIds.map((id) => weightById[id] ?? 1),
+      note,
+      confirmAnomaly: false,
+    };
+  };
 
   const handleSaveClick = () => {
     if (selectedIds.length === 0) {
@@ -963,7 +982,7 @@ export function EntryForm() {
 
         {/* Renders only when at least one share is under 100%. */}
         <PayoutList
-          people={selectedIds.map((id, index) => ({
+          people={orderedSelectedIds.map((id, index) => ({
             id,
             name:
               displayRoster.find((person) => person.id === id)?.name ?? "?",

--- a/web/src/components/entry/EntryForm.tsx
+++ b/web/src/components/entry/EntryForm.tsx
@@ -19,11 +19,21 @@ import {
   isSessionInvalid,
   saveEntry,
   TipApiError,
+  type LunchAmounts,
   type SavePayload,
   type SessionState,
+  type SlotEntry,
 } from "@/lib/tips/api";
 import { anomalyMessage, type AnomalyResult } from "@/lib/tips/anomaly";
 import { formatBusinessDate } from "@/lib/tips/businessDate";
+import {
+  deriveShiftAmounts,
+  enteredTotal,
+  hasNegativeAmount,
+  type EnteredScope,
+  type MealAmounts,
+} from "@/lib/tips/dayScope";
+import { moneyFromCents } from "@/lib/tips/dashboardDerive";
 import { formatMoney } from "@/lib/tips/format";
 import { mealPreset } from "@/lib/tips/mealPreset";
 import {
@@ -31,10 +41,14 @@ import {
   loadSession,
   type StoredSession,
 } from "@/lib/tips/session";
+import { allocatePoolCents, fullShareCents, toCents } from "@/lib/tips/split";
 import type { MealPeriod, VoiceVariant } from "@/types/database";
 import { AmountWell, isValidAmount } from "./AmountWell";
 import { ConfirmDialog } from "./ConfirmDialog";
-import { RosterChips } from "./RosterChips";
+import { NoteField } from "./NoteField";
+import { PayoutList } from "./PayoutList";
+import { RosterChips, nextWeight } from "./RosterChips";
+import { ScopeSwitch } from "./ScopeSwitch";
 import { Segmented } from "./Segmented";
 import { SplitStrip } from "./SplitStrip";
 import { VoiceSheet, type VoiceApplyResult } from "./VoiceSheet";
@@ -45,7 +59,7 @@ const MEAL_OPTIONS = [
 ] as const;
 
 /** How long the saved confirmation lingers before returning to the scan gate. */
-const SAVED_SCREEN_MS = 4000;
+const SAVED_SCREEN_MS = 10000;
 
 interface VoiceMeta {
   variant: VoiceVariant;
@@ -109,30 +123,67 @@ function CheckIcon({ size = 14 }: { size?: number }) {
 }
 
 /**
- * Full-screen post-save confirmation. Lingers a few seconds, then ends the
- * session and sends the phone back to the scan gate; "Done" skips the wait.
+ * Full-screen post-save confirmation. Holds SAVED_SCREEN_MS with a visible
+ * countdown over a draining progress bar, then ends the session and sends
+ * the phone back to the scan gate; "Done" skips the wait. The three wells
+ * mirror the entry form's grid but are read-only — no editable underline.
  */
 function SavedScreen({
   payload,
+  entry,
+  lunch,
   locationName,
   businessDate,
   splitNames,
   onFinished,
 }: {
   payload: SavePayload;
+  /** The saved row from the server — its derived figures are authoritative. */
+  entry: SlotEntry | null;
+  /** The lunch figures in scope at save time (client-side fallback only). */
+  lunch: LunchAmounts | null;
   locationName: string;
   businessDate: string;
   splitNames: string[];
   onFinished: () => void;
 }) {
+  const totalSeconds = Math.round(SAVED_SCREEN_MS / 1000);
+  const [secondsLeft, setSecondsLeft] = useState(totalSeconds);
+
   useEffect(() => {
     const timer = setTimeout(onFinished, SAVED_SCREEN_MS);
-    return () => clearTimeout(timer);
+    const ticker = setInterval(
+      () => setSecondsLeft((current) => Math.max(0, current - 1)),
+      1000,
+    );
+    return () => {
+      clearTimeout(timer);
+      clearInterval(ticker);
+    };
   }, [onFinished]);
 
-  const total = payload.cash + payload.card;
+  // Prefer the server's stored (derived) figures; fall back to deriving
+  // client-side from what was typed when an older server omits them.
+  const amounts: MealAmounts = entry
+    ? { cash: entry.cash, card: entry.card, gratuity: entry.gratuity ?? 0 }
+    : deriveShiftAmounts(
+        { cash: payload.cash, card: payload.card, gratuity: payload.gratuity },
+        payload.enteredScope,
+        lunch,
+      ).derived;
+
   const count = payload.peopleIds.length;
-  const perPerson = count > 0 ? total / count : 0;
+  const poolCents = Math.max(0, toCents(amounts.cash));
+  const weights = payload.weights.length === count ? payload.weights : Array(count).fill(1);
+  const shares = allocatePoolCents(poolCents, weights);
+  const fullShare = fullShareCents(poolCents, weights);
+  const reduced = payload.peopleIds
+    .map((id, index) => ({
+      name: splitNames[index] ?? "",
+      weight: weights[index] ?? 1,
+      cents: shares[index] ?? 0,
+    }))
+    .filter((person) => person.weight < 1);
 
   return (
     <main className="mx-auto flex min-h-dvh w-full max-w-md flex-col px-5 pb-8 pt-20">
@@ -152,35 +203,69 @@ function SavedScreen({
           <span className="h-2 w-2 shrink-0 rounded-full bg-accent" />
           <p className="font-bold text-ink">{locationName}</p>
         </div>
-        <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="mt-4 grid grid-cols-3 gap-3">
           <div className="rounded-well bg-well p-3">
             <div className="section-label">Cash</div>
             <p className="mt-1 text-xl font-bold text-ink">
-              {formatMoney(payload.cash)}
+              {formatMoney(amounts.cash)}
             </p>
           </div>
           <div className="rounded-well bg-well p-3">
             <div className="section-label">Card</div>
             <p className="mt-1 text-xl font-bold text-ink">
-              {formatMoney(payload.card)}
+              {formatMoney(amounts.card)}
+            </p>
+          </div>
+          <div className="rounded-well bg-well p-3">
+            <div className="section-label">Gratuity</div>
+            <p className="mt-1 text-xl font-bold text-ink">
+              {formatMoney(amounts.gratuity)}
             </p>
           </div>
         </div>
         <p className="mt-4 text-ink2">
-          {count === 1
-            ? `${splitNames[0] ?? "1 person"} takes ${formatMoney(total)}`
-            : `${count} people · ${formatMoney(perPerson)} each`}
+          {count === 1 ? (
+            `${splitNames[0] ?? "1 person"} takes ${moneyFromCents(poolCents)}`
+          ) : reduced.length > 0 ? (
+            <>
+              {count} people · full share <b>{moneyFromCents(fullShare)}</b>
+              {reduced.map((person) => (
+                <span key={person.name}>
+                  , {person.name} <b>{moneyFromCents(person.cents)}</b> (
+                  {Math.round(person.weight * 100)}%)
+                </span>
+              ))}
+            </>
+          ) : (
+            `${count} people · ${moneyFromCents(fullShare)} each`
+          )}
         </p>
         {count > 1 && splitNames.length > 0 && (
           <p className="mt-1 text-sm text-ink3">{splitNames.join(", ")}</p>
+        )}
+        {payload.note && (
+          <div className="mt-3 flex items-center gap-2">
+            <span className="rounded-[5px] bg-poki/10 px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.06em] text-poki">
+              note
+            </span>
+            <span className="min-w-0 flex-1 truncate text-sm text-ink2">
+              {payload.note}
+            </span>
+          </div>
         )}
       </div>
 
       <div className="flex-1" />
 
       <p className="text-center text-sm text-ink3">
-        Signing this phone out&hellip; next entry starts with a scan
+        Back to the scan screen in <b className="text-ink2">{secondsLeft}</b>s
       </p>
+      <div className="mt-2 h-[3px] overflow-hidden rounded-[2px] bg-well">
+        <div
+          className="h-full bg-accent transition-[width] duration-1000 ease-linear"
+          style={{ width: `${(secondsLeft / totalSeconds) * 100}%` }}
+        />
+      </div>
       <button
         type="button"
         onClick={onFinished}
@@ -235,7 +320,15 @@ export function EntryForm() {
   const [allDone, setAllDone] = useState(false);
   const [cash, setCash] = useState("");
   const [card, setCard] = useState("");
+  const [gratuity, setGratuity] = useState("");
+  // Whole-day vs shift-only Square number. Dinner only — lunch always
+  // records what was typed. Defaults to whole day per the approved mockup.
+  const [scope, setScope] = useState<EnteredScope>("day");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  // Share weight per person id (1 | 0.75 | 0.5 | 0.25). Kept independent of
+  // selection so deselecting and reselecting someone keeps their badge.
+  const [weightById, setWeightById] = useState<Record<string, number>>({});
+  const [note, setNote] = useState<string | null>(null);
   // Who the manager's schedule says works each meal today. Seeds the chip
   // pre-selection and floats scheduled people to the top of the picker.
   const [scheduledByMeal, setScheduledByMeal] = useState<
@@ -261,6 +354,8 @@ export function EntryForm() {
     anomaly: AnomalyResult;
   } | null>(null);
   const [savedPayload, setSavedPayload] = useState<SavePayload | null>(null);
+  // The row the server stored — its derived figures drive the saved screen.
+  const [savedEntry, setSavedEntry] = useState<SlotEntry | null>(null);
   const [pickPersonWarning, setPickPersonWarning] = useState(false);
 
   const [showVoice, setShowVoice] = useState(false);
@@ -405,6 +500,12 @@ export function EntryForm() {
           );
           setMeal(meal);
         } else {
+          // A fresher today-status (with the recorded lunch figures) rides
+          // along on get_slot — keep the day-scope subtraction current.
+          if (slot.today) {
+            const freshToday = slot.today;
+            setState((prev) => (prev ? { ...prev, today: freshToday } : prev));
+          }
           setScheduledByMeal((prev) => ({ ...prev, [next]: slot.scheduledIds }));
           const saved = savedSelectionsRef.current[next];
           if (saved) {
@@ -490,6 +591,7 @@ export function EntryForm() {
         }
         setPendingAnomaly(null);
         setVoiceMeta(null);
+        setSavedEntry(result.entry);
         setSavedPayload(payload);
       } catch (error) {
         if (isSessionInvalid(error)) {
@@ -514,40 +616,90 @@ export function EntryForm() {
     [session, router, applyAlreadyRecorded],
   );
 
-  const amountsValid = isValidAmount(cash) && isValidAmount(card);
-  const canSave = amountsValid && selectedIds.length > 0 && !saving;
+  // Blank gratuity is legal and means $0 — only a half-typed "." is invalid.
+  const amountsValid =
+    isValidAmount(cash) &&
+    isValidAmount(card) &&
+    (gratuity === "" || isValidAmount(gratuity));
 
-  const handleSaveClick = useCallback(() => {
+  // Day-scope derivation drives the live receipt and the one blocking
+  // warning. The server recomputes all of this on save and is authoritative.
+  const typedAmounts: MealAmounts = {
+    cash: isValidAmount(cash) ? Number(cash) : 0,
+    card: isValidAmount(card) ? Number(card) : 0,
+    gratuity: isValidAmount(gratuity) ? Number(gratuity) : 0,
+  };
+  const lunchAmounts = state?.today.lunch ?? null;
+  const effectiveScope: EnteredScope = meal === "dinner" ? scope : "shift";
+  const { derived: derivedAmounts } = deriveShiftAmounts(
+    typedAmounts,
+    effectiveScope,
+    lunchAmounts,
+  );
+  const negativeAfterLunch = hasNegativeAmount(derivedAmounts);
+
+  const poolCents = Math.max(0, toCents(derivedAmounts.cash));
+  const selectedWeights = selectedIds.map((id) => weightById[id] ?? 1);
+  const canSave =
+    amountsValid && !negativeAfterLunch && selectedIds.length > 0 && !saving;
+
+  // Plain functions (no manual memoization) — the React Compiler handles
+  // these; nesting them in useCallback fights its dependency analysis.
+  const buildPayload = (
+    base: Pick<
+      SavePayload,
+      | "meal"
+      | "cash"
+      | "card"
+      | "peopleIds"
+      | "entryMethod"
+      | "voiceVariant"
+      | "correctionsCount"
+    >,
+  ): SavePayload => ({
+    ...base,
+    // All three amounts go AS TYPED — the server does the subtraction.
+    gratuity: isValidAmount(gratuity) ? Number(gratuity) : 0,
+    enteredScope: base.meal === "dinner" ? scope : "shift",
+    weights: base.peopleIds.map((id) => weightById[id] ?? 1),
+    note,
+    confirmAnomaly: false,
+  });
+
+  const handleSaveClick = () => {
     if (selectedIds.length === 0) {
       setPickPersonWarning(true);
       return;
     }
-    if (!amountsValid || saving) return;
-    void doSave({
-      meal,
-      cash: Number(cash),
-      card: Number(card),
-      peopleIds: selectedIds,
-      entryMethod: voiceMeta ? "voice" : "typed",
-      voiceVariant: voiceMeta?.variant ?? null,
-      correctionsCount: voiceMeta?.corrections ?? 0,
-      confirmAnomaly: false,
-    });
-  }, [selectedIds, amountsValid, saving, doSave, meal, cash, card, voiceMeta]);
+    if (!amountsValid || negativeAfterLunch || saving) return;
+    void doSave(
+      buildPayload({
+        meal,
+        cash: Number(cash),
+        card: Number(card),
+        peopleIds: selectedIds,
+        entryMethod: voiceMeta ? "voice" : "typed",
+        voiceVariant: voiceMeta?.variant ?? null,
+        correctionsCount: voiceMeta?.corrections ?? 0,
+      }),
+    );
+  };
 
-  const handleVoiceApply = useCallback(
-    (result: VoiceApplyResult) => {
-      setShowVoice(false);
-      setMeal(result.meal);
-      setCash(result.cash);
-      setCard(result.card);
-      setSelectedIds(result.peopleIds);
-      setPickPersonWarning(false);
-      setVoiceMeta({
-        variant: result.variant,
-        corrections: result.correctionsCount,
-      });
-      void doSave({
+  const handleVoiceApply = (result: VoiceApplyResult) => {
+    setShowVoice(false);
+    setMeal(result.meal);
+    setCash(result.cash);
+    setCard(result.card);
+    setSelectedIds(result.peopleIds);
+    setPickPersonWarning(false);
+    setVoiceMeta({
+      variant: result.variant,
+      corrections: result.correctionsCount,
+    });
+    // Voice still fills cash/card/people only — the typed gratuity, scope,
+    // weights and note ride along unchanged.
+    void doSave(
+      buildPayload({
         meal: result.meal,
         cash: Number(result.cash),
         card: Number(result.card),
@@ -555,11 +707,9 @@ export function EntryForm() {
         entryMethod: "voice",
         voiceVariant: result.variant,
         correctionsCount: result.correctionsCount,
-        confirmAnomaly: false,
-      });
-    },
-    [doSave],
-  );
+      }),
+    );
+  };
 
   const markTouched = useCallback((field: "cash" | "card" | "people") => {
     setTouchedFields((prev) =>
@@ -583,6 +733,10 @@ export function EntryForm() {
     [markTouched],
   );
 
+  const handleGratuityChange = useCallback((value: string) => {
+    setGratuity(value);
+  }, []);
+
   const togglePerson = useCallback(
     (id: string) => {
       setPickPersonWarning(false);
@@ -595,6 +749,11 @@ export function EntryForm() {
     },
     [markTouched],
   );
+
+  /** Cycle a selected person's share badge: 100 → 75 → 50 → 25 → 100. */
+  const cycleWeight = useCallback((id: string) => {
+    setWeightById((prev) => ({ ...prev, [id]: nextWeight(prev[id] ?? 1) }));
+  }, []);
 
   // Scheduled people sort first for the current meal; unscheduled staff sink
   // to the bottom. Stable sort keeps the server's sort_order/name order
@@ -642,6 +801,8 @@ export function EntryForm() {
     return (
       <SavedScreen
         payload={savedPayload}
+        entry={savedEntry}
+        lunch={lunchAmounts}
         locationName={state.location.name}
         businessDate={state.today.businessDate}
         splitNames={savedPayload.peopleIds
@@ -719,20 +880,80 @@ export function EntryForm() {
 
         {/* Amounts */}
         <div className="bg-card rounded-card p-4">
-          <div className="grid grid-cols-2 gap-3">
+          {/* Scope sits directly above the wells with no label over it —
+              dinner only. Lunch always records what was typed. */}
+          {meal === "dinner" && (
+            <div className="mb-3">
+              <ScopeSwitch value={scope} onChange={setScope} disabled={saving} />
+            </div>
+          )}
+          <div className="grid grid-cols-3 gap-3">
             <AmountWell label="Cash" value={cash} onChange={handleCashChange} />
             <AmountWell label="Card" value={card} onChange={handleCardChange} />
+            <AmountWell
+              label="Gratuity"
+              value={gratuity}
+              onChange={handleGratuityChange}
+            />
           </div>
+          <p className="mt-2 text-sm text-ink3">
+            Leave gratuity blank on a night with no large parties.
+          </p>
+          {meal === "dinner" && (
+            <div className="mt-3 grid gap-1 border-t border-dashed border-line pt-2.5 text-sm tabular-nums">
+              <div className="flex text-ink2">
+                <span>
+                  {scope === "day" ? "Entered (whole day)" : "Entered (dinner only)"}
+                </span>
+                <span className="ml-auto font-semibold text-ink">
+                  {formatMoney(enteredTotal(typedAmounts))}
+                </span>
+              </div>
+              {scope === "day" && (
+                <div className="flex text-ink2">
+                  <span>&minus; Lunch already recorded</span>
+                  <span className="ml-auto font-semibold text-alert">
+                    &minus;
+                    {formatMoney(
+                      lunchAmounts ? enteredTotal(lunchAmounts) : 0,
+                    )}
+                  </span>
+                </div>
+              )}
+              <div className="mt-0.5 flex border-t border-line pt-1.5 font-extrabold text-ink">
+                <span>Dinner records</span>
+                <span className="ml-auto text-base">
+                  {formatMoney(enteredTotal(derivedAmounts))}
+                </span>
+              </div>
+            </div>
+          )}
+          {/* The one warning the entry screen ever shows. A whole-day dinner
+              with no lunch on record says NOTHING here — it saves flagged
+              for the manager. */}
+          {negativeAfterLunch && (
+            <div className="mt-3 rounded-well bg-tint p-3 text-sm text-alert">
+              Lunch already recorded more than this. Check the Square report —{" "}
+              <b>Save is off until this is fixed.</b>
+            </div>
+          )}
         </div>
 
         {/* Roster */}
         <div className="bg-card rounded-card p-4">
-          <div className="section-label">Who&apos;s splitting</div>
+          <div className="flex items-baseline">
+            <div className="section-label">Who&apos;s splitting</div>
+            <span className="ml-auto text-sm text-ink3">
+              tap a badge to change a share
+            </span>
+          </div>
           <div className="mt-3">
             <RosterChips
               roster={displayRoster}
               selectedIds={selectedIds}
               onToggle={togglePerson}
+              weights={weightById}
+              onCycleWeight={cycleWeight}
             />
           </div>
           {pickPersonWarning && (
@@ -740,11 +961,20 @@ export function EntryForm() {
           )}
         </div>
 
-        <SplitStrip
-          cash={isValidAmount(cash) ? Number(cash) : 0}
-          card={isValidAmount(card) ? Number(card) : 0}
-          count={selectedIds.length}
+        {/* Renders only when at least one share is under 100%. */}
+        <PayoutList
+          people={selectedIds.map((id, index) => ({
+            id,
+            name:
+              displayRoster.find((person) => person.id === id)?.name ?? "?",
+            weight: selectedWeights[index] ?? 1,
+            cents: allocatePoolCents(poolCents, selectedWeights)[index] ?? 0,
+          }))}
         />
+
+        <SplitStrip poolCents={poolCents} weights={selectedWeights} />
+
+        <NoteField note={note} onChange={setNote} />
       </div>
 
       {/* Sticky bottom bar */}
@@ -780,7 +1010,7 @@ export function EntryForm() {
               silently doing nothing. */}
           <button
             type="button"
-            disabled={saving || !amountsValid}
+            disabled={saving || !amountsValid || negativeAfterLunch}
             onClick={handleSaveClick}
             className={`flex-1 rounded-full py-4 font-semibold ${
               canSave ? "bg-card text-ink" : "bg-disabled text-white"

--- a/web/src/components/entry/NoteField.tsx
+++ b/web/src/components/entry/NoteField.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+// One optional free-text note per entry (Tips v3). Three states: a dashed
+// "+ Add a note" button, the open editor (280 cap with a live counter,
+// Cancel / Save), and a one-line truncated preview with an edit affordance.
+// Saving empty text collapses back to the dashed button.
+
+import { useRef, useState } from "react";
+
+export const NOTE_MAX_LENGTH = 280;
+
+export function NoteField({
+  note,
+  onChange,
+}: {
+  /** The saved note, null when there is none. */
+  note: string | null;
+  /** Called with the trimmed note, or null when it was cleared. */
+  onChange: (note: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const startEditing = () => {
+    setDraft(note ?? "");
+    setOpen(true);
+  };
+
+  const save = () => {
+    const trimmed = draft.trim();
+    onChange(trimmed === "" ? null : trimmed);
+    setOpen(false);
+  };
+
+  if (open) {
+    return (
+      <div className="bg-card rounded-card p-4">
+        <div className="flex items-center">
+          <span className="section-label">Note</span>
+          <span className="ml-auto text-sm text-ink3">
+            {draft.length} / {NOTE_MAX_LENGTH}
+          </span>
+        </div>
+        <textarea
+          ref={textareaRef}
+          autoFocus
+          rows={3}
+          maxLength={NOTE_MAX_LENGTH}
+          value={draft}
+          onChange={(event) =>
+            setDraft(event.target.value.slice(0, NOTE_MAX_LENGTH))
+          }
+          placeholder="Drawer was $20 short — Marco recounted, still short."
+          aria-label="Note"
+          className="mt-2 w-full resize-none rounded-well bg-well p-3 text-ink outline-none placeholder:text-ink3"
+        />
+        <div className="mt-2.5 flex gap-2">
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="rounded-well border border-dashed border-line bg-card px-4 py-2 text-sm font-semibold text-ink2"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            className="rounded-well border border-accent bg-tint px-4 py-2 text-sm font-semibold text-alert"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (note !== null) {
+    return (
+      <div className="bg-card rounded-card flex items-center gap-2 px-4 py-3">
+        <span className="rounded-[5px] bg-poki/10 px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.06em] text-poki">
+          note
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm text-ink2">{note}</span>
+        <button
+          type="button"
+          onClick={startEditing}
+          className="shrink-0 font-bold text-accent"
+        >
+          edit
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      className="w-full rounded-well border border-dashed border-line bg-card p-3 text-center text-sm font-semibold text-ink2"
+    >
+      + Add a note
+    </button>
+  );
+}

--- a/web/src/components/entry/PayoutList.tsx
+++ b/web/src/components/entry/PayoutList.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+// "What each person takes" (Tips v3) — renders ONLY when at least one share
+// is under 100%. One row per selected person; reduced shares carry an
+// "NN% share" caption; dollars are right-aligned and tabular. The dollars
+// come from the canonical largest-remainder allocation, so the rows always
+// sum to the cash pool exactly.
+
+import { moneyFromCents } from "@/lib/tips/dashboardDerive";
+
+export interface PayoutPerson {
+  id: string;
+  name: string;
+  /** Share weight in (0,1]. */
+  weight: number;
+  /** Allocated cents from allocatePoolCents, positional with the split. */
+  cents: number;
+}
+
+export function PayoutList({ people }: { people: PayoutPerson[] }) {
+  if (people.length === 0 || people.every((person) => person.weight >= 1)) {
+    return null;
+  }
+  return (
+    <div className="bg-card rounded-card px-4 py-3">
+      <div className="section-label">What each person takes</div>
+      <div className="mt-2.5 grid gap-2">
+        {people.map((person) => (
+          <div
+            key={person.id}
+            className="flex items-center gap-2.5 rounded-well bg-well px-3 py-2.5"
+          >
+            <span className="text-sm font-semibold text-ink">{person.name}</span>
+            {person.weight < 1 && (
+              <span className="text-[11px] text-ink3">
+                {Math.round(person.weight * 100)}% share
+              </span>
+            )}
+            <span className="ml-auto font-extrabold tabular-nums text-ink">
+              {moneyFromCents(person.cents)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/entry/RosterChips.tsx
+++ b/web/src/components/entry/RosterChips.tsx
@@ -1,35 +1,69 @@
 "use client";
 
 // Toggleable name pills for "who's splitting". Selected = filled accent red.
+// Selected chips carry a % badge (Tips v3 partial shares): tapping the badge
+// cycles 100 → 75 → 50 → 25 → 100 without toggling the person; tapping the
+// chip body still toggles selection. The badge is its own hit target (≥28px)
+// even though it renders small.
 
 import type { RosterPerson } from "@/lib/tips/api";
+
+export const WEIGHT_CYCLE = [1, 0.75, 0.5, 0.25] as const;
+
+/** The next weight in the 100 → 75 → 50 → 25 cycle (wraps; unknown → 1). */
+export function nextWeight(weight: number): number {
+  const index = WEIGHT_CYCLE.indexOf(weight as (typeof WEIGHT_CYCLE)[number]);
+  return WEIGHT_CYCLE[(index + 1) % WEIGHT_CYCLE.length];
+}
 
 export function RosterChips({
   roster,
   selectedIds,
   onToggle,
+  weights,
+  onCycleWeight,
 }: {
   roster: RosterPerson[];
   selectedIds: string[];
   onToggle: (id: string) => void;
+  /** Share weight per person id; missing means a full share. */
+  weights?: Record<string, number>;
+  /** Cycle a selected person's share badge. Omit to hide the badges. */
+  onCycleWeight?: (id: string) => void;
 }) {
   const selected = new Set(selectedIds);
   return (
     <div className="flex flex-wrap gap-2">
       {roster.map((person) => {
         const isSelected = selected.has(person.id);
+        const weight = weights?.[person.id] ?? 1;
         return (
-          <button
-            key={person.id}
-            type="button"
-            aria-pressed={isSelected}
-            onClick={() => onToggle(person.id)}
-            className={`rounded-full px-4 py-2.5 font-medium ${
-              isSelected ? "bg-accent text-white" : "bg-well text-ink2"
-            }`}
-          >
-            {person.name}
-          </button>
+          <span key={person.id} className="inline-flex">
+            <button
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => onToggle(person.id)}
+              className={`rounded-full px-4 py-2.5 font-medium ${
+                isSelected
+                  ? `bg-accent text-white ${onCycleWeight ? "rounded-r-none pr-2" : ""}`
+                  : "bg-well text-ink2"
+              }`}
+            >
+              {person.name}
+            </button>
+            {isSelected && onCycleWeight && (
+              <button
+                type="button"
+                aria-label={`${person.name} share ${Math.round(weight * 100)}%`}
+                onClick={() => onCycleWeight(person.id)}
+                className="flex min-h-[28px] min-w-[28px] items-center rounded-full rounded-l-none bg-accent pl-1 pr-2.5 text-white"
+              >
+                <span className="rounded-full bg-white px-1.5 py-0.5 text-[10.5px] font-extrabold text-alert">
+                  {Math.round(weight * 100)}%
+                </span>
+              </button>
+            )}
+          </span>
         );
       })}
     </div>

--- a/web/src/components/entry/ScopeSwitch.tsx
+++ b/web/src/components/entry/ScopeSwitch.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+// Whole-day vs dinner-only scope for the amounts card (Tips v3). Dinner only —
+// lunch has no switch and always records what was typed. No label above it.
+
+import type { EnteredScope } from "@/lib/tips/dayScope";
+import { Segmented } from "./Segmented";
+
+const SCOPE_OPTIONS = [
+  { value: "day", label: "Whole day (Square)" },
+  { value: "shift", label: "Dinner only" },
+] as const;
+
+export function ScopeSwitch({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: EnteredScope;
+  onChange: (next: EnteredScope) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Segmented
+      options={SCOPE_OPTIONS}
+      value={value}
+      onChange={onChange}
+      compact
+      wellTrack
+      disabled={disabled}
+    />
+  );
+}

--- a/web/src/components/entry/SplitStrip.tsx
+++ b/web/src/components/entry/SplitStrip.tsx
@@ -1,20 +1,25 @@
 "use client";
 
 // Live per-person split readout. Derived only — never stored.
+//
+// Tips v3: the strip reads on the CASH pool only (card rides payroll and
+// weights never touch it). "Split N ways · $X each" when every share is
+// full; "Full share · $X" when any share is reduced. The right side is
+// always "of $Y cash".
 
-import { formatMoney } from "@/lib/tips/format";
-import { perPersonShare, totalTips } from "@/lib/tips/split";
+import { moneyFromCents } from "@/lib/tips/dashboardDerive";
+import { fullShareCents } from "@/lib/tips/split";
 
 export function SplitStrip({
-  cash,
-  card,
-  count,
+  poolCents,
+  weights,
 }: {
-  cash: number;
-  card: number;
-  count: number;
+  /** The cash pool being split, in cents (already net of lunch on day scope). */
+  poolCents: number;
+  /** Share weights of the selected people, positional. */
+  weights: number[];
 }) {
-  if (count < 1) {
+  if (weights.length < 1) {
     return (
       <div className="bg-card rounded-card px-4 py-3 flex items-baseline gap-2">
         <span className="section-label" style={{ color: "var(--color-ink3)" }}>
@@ -23,14 +28,18 @@ export function SplitStrip({
       </div>
     );
   }
+  const uneven = weights.some((weight) => weight < 1);
   return (
     <div className="bg-card rounded-card px-4 py-3 flex items-baseline gap-2">
-      <span className="section-label">Split {count} ways</span>
-      <span className="font-bold text-xl text-ink">
-        {formatMoney(perPersonShare(cash, card, count))} each
+      <span className="section-label">
+        {uneven ? "Full share" : `Split ${weights.length} ways`}
+      </span>
+      <span className="font-bold text-xl text-ink tabular-nums">
+        {moneyFromCents(fullShareCents(poolCents, weights))}
+        {uneven ? "" : " each"}
       </span>
       <span className="ml-auto text-ink3 text-sm">
-        of {formatMoney(totalTips(cash, card))}
+        of {moneyFromCents(Math.max(0, poolCents))} cash
       </span>
     </div>
   );

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -51,10 +51,15 @@ function timeLabel(iso: string): string {
   });
 }
 
-/** $ amount field value → cents, or null when invalid (0 .. $99,999.99). */
+/**
+ * $ amount field value → cents, or null when invalid (0 .. $99,999.99,
+ * at most two decimals — the UI must never show a figure the database
+ * would silently round).
+ */
 function parseAmountToCents(value: string): number | null {
   const stripped = value.replace(/[$,\s]/g, "");
   if (stripped === "") return null; // Number("") is 0 — a cleared field is invalid, not $0
+  if (!/^\d*(\.\d{0,2})?$/.test(stripped)) return null;
   const num = Number(stripped);
   if (!Number.isFinite(num) || num < 0 || num >= 100000) return null;
   return Math.round(num * 100);
@@ -66,17 +71,29 @@ const NOTE_MAX_LENGTH = 280;
 
 function FixDialog({
   entry,
+  lunchEntry,
   ctx,
   onClose,
 }: {
   entry: LedgerEntry;
+  /** The recorded lunch at the same location + business date, if any. */
+  lunchEntry: LedgerEntry | null;
   ctx: PageContext;
   onClose: () => void;
 }) {
   const toast = useToast();
-  const [cash, setCash] = useState((entry.cashCents / 100).toFixed(2));
-  const [card, setCard] = useState((entry.cardCents / 100).toFixed(2));
-  const [gratuity, setGratuity] = useState((entry.gratuityCents / 100).toFixed(2));
+  // The fields hold the AS-TYPED figures (same contract as the entry phone):
+  // on a whole-day row that's the raw Square number, and the dialog derives
+  // the stored shift figures against the recorded lunch before writing.
+  const [cash, setCash] = useState(
+    (((entry.enteredScope === "day" ? entry.rawCashCents : null) ?? entry.cashCents) / 100).toFixed(2),
+  );
+  const [card, setCard] = useState(
+    (((entry.enteredScope === "day" ? entry.rawCardCents : null) ?? entry.cardCents) / 100).toFixed(2),
+  );
+  const [gratuity, setGratuity] = useState(
+    (((entry.enteredScope === "day" ? entry.rawGratuityCents : null) ?? entry.gratuityCents) / 100).toFixed(2),
+  );
   const [scope, setScope] = useState<"shift" | "day">(entry.enteredScope);
   const [peopleIds, setPeopleIds] = useState<string[]>(entry.peopleIds);
   const [weightById, setWeightById] = useState<Record<string, number>>(() =>
@@ -103,14 +120,34 @@ function FixDialog({
   const cashCents = parseAmountToCents(cash);
   const cardCents = parseAmountToCents(card);
   const gratuityCents = parseAmountToCents(gratuity);
+
+  // Same derivation contract as the entry save: on day scope subtract the
+  // recorded lunch field by field; the stored figures are always shift-only
+  // and raw_* keeps what was typed. No lunch on record → nothing to subtract.
+  const lunchCents =
+    scope === "day" && lunchEntry
+      ? {
+          cash: lunchEntry.cashCents,
+          card: lunchEntry.cardCents,
+          gratuity: lunchEntry.gratuityCents,
+        }
+      : null;
+  const derivedCents =
+    cashCents !== null && cardCents !== null && gratuityCents !== null
+      ? {
+          cash: cashCents - (lunchCents?.cash ?? 0),
+          card: cardCents - (lunchCents?.card ?? 0),
+          gratuity: gratuityCents - (lunchCents?.gratuity ?? 0),
+        }
+      : null;
+  const negativeAfterLunch =
+    derivedCents !== null &&
+    (derivedCents.cash < 0 || derivedCents.card < 0 || derivedCents.gratuity < 0);
   const valid =
-    cashCents !== null &&
-    cardCents !== null &&
-    gratuityCents !== null &&
-    peopleIds.length >= 1;
+    derivedCents !== null && !negativeAfterLunch && peopleIds.length >= 1;
 
   async function save() {
-    if (!valid || busy || cashCents === null || cardCents === null || gratuityCents === null)
+    if (!valid || busy || derivedCents === null || cashCents === null || cardCents === null || gratuityCents === null)
       return;
     setBusy(true);
     setError(null);
@@ -150,10 +187,13 @@ function FixDialog({
       const { error: updateError } = await supabase
         .from("tip_entries")
         .update({
-          cash_amount: cashCents / 100,
-          card_amount: cardCents / 100,
-          gratuity_amount: gratuityCents / 100,
+          cash_amount: derivedCents.cash / 100,
+          card_amount: derivedCents.card / 100,
+          gratuity_amount: derivedCents.gratuity / 100,
           entered_scope: scope,
+          raw_cash_amount: cashCents / 100,
+          raw_card_amount: cardCents / 100,
+          raw_gratuity_amount: gratuityCents / 100,
           split_count: peopleIds.length,
           ...(noteChanged
             ? {
@@ -217,7 +257,9 @@ function FixDialog({
       )}
       <div className="mt-4 grid grid-cols-3 gap-3">
         <label className="flex flex-col gap-1">
-          <span className="section-label">Cash (split pool)</span>
+          <span className="section-label">
+            {scope === "day" ? "Cash (whole day)" : "Cash (split pool)"}
+          </span>
           <input
             value={cash}
             onChange={(event) => setCash(event.target.value)}
@@ -314,9 +356,23 @@ function FixDialog({
         />
       </label>
 
-      {cashCents !== null && peopleIds.length > 0 && (
+      {scope === "day" && derivedCents !== null && !negativeAfterLunch && (
+        <p className="mt-3 text-[12.5px] text-ink2 tabular-nums">
+          {lunchEntry
+            ? `− lunch ${moneyFromCents(lunchCents?.cash ?? 0)} cash / ${moneyFromCents(lunchCents?.card ?? 0)} card → records `
+            : "no lunch on record → records "}
+          <b className="text-ink">{moneyFromCents(derivedCents.cash)}</b> cash pool
+        </p>
+      )}
+      {negativeAfterLunch && (
+        <p className="mt-3 text-sm text-alert">
+          Lunch already recorded more than this — the whole-day figures can&apos;t
+          be below the recorded lunch.
+        </p>
+      )}
+      {derivedCents !== null && !negativeAfterLunch && peopleIds.length > 0 && (
         <p className="mt-3 text-[12.5px] text-ink2">
-          {moneyFromCents(poolFullShareCents(cashCents, previewWeights))} full share
+          {moneyFromCents(poolFullShareCents(derivedCents.cash, previewWeights))} full share
           {previewWeights.some((weight) => weight < 1) ? " (weighted)" : " each"}
         </p>
       )}
@@ -749,7 +805,16 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
         </table>
       </div>
 
-      {fixing && <FixDialog entry={fixing} ctx={ctx} onClose={() => setFixing(null)} />}
+      {fixing && (
+        <FixDialog
+          entry={fixing}
+          lunchEntry={
+            lunchByDayLocation.get(`${fixing.businessDate}|${fixing.locationId}`) ?? null
+          }
+          ctx={ctx}
+          onClose={() => setFixing(null)}
+        />
+      )}
     </section>
   );
 }

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -140,9 +140,7 @@ function FixDialog({
       if (upserts.length > 0) {
         const { error: upsertError } = await supabase
           .from("tip_entry_people")
-          // Cast dies once the regenerated database.ts (backend side of the
-          // v3 migration) knows share_weight.
-          .upsert(upserts as never, { onConflict: "tip_entry_id,tip_employee_id" });
+          .upsert(upserts, { onConflict: "tip_entry_id,tip_employee_id" });
         if (upsertError) throw new Error(upsertError.message);
       }
 
@@ -151,8 +149,6 @@ function FixDialog({
       const noteChanged = nextNote !== (entry.note ?? null);
       const { error: updateError } = await supabase
         .from("tip_entries")
-        // Cast dies once the regenerated database.ts (backend side of the
-        // v3 migration) knows the new columns.
         .update({
           cash_amount: cashCents / 100,
           card_amount: cardCents / 100,
@@ -165,7 +161,7 @@ function FixDialog({
                 note_at: nextNote === null ? null : new Date().toISOString(),
               }
             : {}),
-        } as never)
+        })
         .eq("id", entry.id);
       if (updateError) throw new Error(updateError.message);
 

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -354,7 +354,9 @@ function DetailPanel({
   verifying: boolean;
 }) {
   const shares = entryShareCents(entry);
-  const noLunchFlag = entry.anomalyReason === "day_total_no_lunch";
+  // Prefix match: when the save was ALSO a statistical outlier the reason is
+  // "day_total_no_lunch; <statistical reason>" (contract amendment 2).
+  const noLunchFlag = entry.anomalyReason?.startsWith("day_total_no_lunch") ?? false;
   // What was actually subtracted at save time — shown from the raw figures,
   // not the current lunch row (which a fix may have changed since).
   const subtractedCents =

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -1,19 +1,23 @@
 "use client";
 
-// Recorded tips — the dense ledger. Rows newest-first grouped by day with
-// day-total rows; tinted cash/card column groups; flagged rows get a red
-// tint, a "⚑ check" chip, and a Verify button. Fix opens a manager edit
-// dialog that updates the entry + its people directly under RLS (manager
-// edits do not go through tip_save_entry).
+// Recorded tips — the dense ledger (Tips v3, option D2). Rows newest-first
+// grouped by day with day-total rows; tinted cash/card column groups; flagged
+// rows get a red tint, a "⚑ check" chip, and a Verify button. Clicking a row
+// unfolds a three-card detail panel: how the number was reached (raw →
+// −lunch → recorded, then card and gratuity), who takes what (weighted), and
+// the note. Fix opens a manager edit dialog that updates the entry + its
+// people directly under RLS (manager edits do not go through tip_save_entry).
 
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
 import {
-  cashShareCents,
+  entryFullShareCents,
+  entryShareCents,
   moneyFromCents,
   type LedgerEntry,
 } from "@/lib/tips/dashboardDerive";
 import { shortDayLabel } from "@/lib/tips/dashboardRange";
+import { fullShareCents as poolFullShareCents } from "@/lib/tips/split";
 import {
   btn,
   btnPrim,
@@ -38,6 +42,15 @@ function mealLabel(meal: string): string {
   return meal.charAt(0).toUpperCase() + meal.slice(1);
 }
 
+/** "3:41 PM" in the restaurant's timezone. */
+function timeLabel(iso: string): string {
+  return new Date(iso).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "America/Los_Angeles",
+  });
+}
+
 /** $ amount field value → cents, or null when invalid (0 .. $99,999.99). */
 function parseAmountToCents(value: string): number | null {
   const stripped = value.replace(/[$,\s]/g, "");
@@ -46,6 +59,10 @@ function parseAmountToCents(value: string): number | null {
   if (!Number.isFinite(num) || num < 0 || num >= 100000) return null;
   return Math.round(num * 100);
 }
+
+const WEIGHT_OPTIONS = [1, 0.75, 0.5, 0.25] as const;
+
+const NOTE_MAX_LENGTH = 280;
 
 function FixDialog({
   entry,
@@ -59,7 +76,15 @@ function FixDialog({
   const toast = useToast();
   const [cash, setCash] = useState((entry.cashCents / 100).toFixed(2));
   const [card, setCard] = useState((entry.cardCents / 100).toFixed(2));
+  const [gratuity, setGratuity] = useState((entry.gratuityCents / 100).toFixed(2));
+  const [scope, setScope] = useState<"shift" | "day">(entry.enteredScope);
   const [peopleIds, setPeopleIds] = useState<string[]>(entry.peopleIds);
+  const [weightById, setWeightById] = useState<Record<string, number>>(() =>
+    Object.fromEntries(
+      entry.peopleIds.map((id, index) => [id, entry.weights[index] ?? 1]),
+    ),
+  );
+  const [note, setNote] = useState(entry.note ?? "");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -77,38 +102,70 @@ function FixDialog({
 
   const cashCents = parseAmountToCents(cash);
   const cardCents = parseAmountToCents(card);
-  const valid = cashCents !== null && cardCents !== null && peopleIds.length >= 1;
+  const gratuityCents = parseAmountToCents(gratuity);
+  const valid =
+    cashCents !== null &&
+    cardCents !== null &&
+    gratuityCents !== null &&
+    peopleIds.length >= 1;
 
   async function save() {
-    if (!valid || busy || cashCents === null || cardCents === null) return;
+    if (!valid || busy || cashCents === null || cardCents === null || gratuityCents === null)
+      return;
     setBusy(true);
     setError(null);
     const supabase = getSupabase();
     // PostgREST calls can't share a transaction, so order the steps to keep
-    // every intermediate state recoverable: add people first, update the
-    // amounts + split_count, remove people last. An amounts-only fix (the
-    // common case) is then a single atomic UPDATE, and the entry can never
-    // pass through a zero-people state.
+    // every intermediate state recoverable: upsert people (adds + weight
+    // changes) first, update the amounts + split_count, remove people last.
+    // An amounts-only fix (the common case) is then a single atomic UPDATE,
+    // and the entry can never pass through a zero-people state.
     try {
       const before = new Set(entry.peopleIds);
       const after = new Set(peopleIds);
-      const added = peopleIds.filter((id) => !before.has(id));
       const removed = entry.peopleIds.filter((id) => !after.has(id));
+      const beforeWeight = new Map(
+        entry.peopleIds.map((id, index) => [id, entry.weights[index] ?? 1]),
+      );
+      const upserts = peopleIds
+        .filter(
+          (id) => !before.has(id) || (weightById[id] ?? 1) !== beforeWeight.get(id),
+        )
+        .map((personId) => ({
+          tip_entry_id: entry.id,
+          tip_employee_id: personId,
+          share_weight: weightById[personId] ?? 1,
+        }));
 
-      if (added.length > 0) {
-        const { error: insertError } = await supabase.from("tip_entry_people").insert(
-          added.map((personId) => ({ tip_entry_id: entry.id, tip_employee_id: personId })),
-        );
-        if (insertError) throw new Error(insertError.message);
+      if (upserts.length > 0) {
+        const { error: upsertError } = await supabase
+          .from("tip_entry_people")
+          // Cast dies once the regenerated database.ts (backend side of the
+          // v3 migration) knows share_weight.
+          .upsert(upserts as never, { onConflict: "tip_entry_id,tip_employee_id" });
+        if (upsertError) throw new Error(upsertError.message);
       }
 
+      const trimmedNote = note.trim().slice(0, NOTE_MAX_LENGTH);
+      const nextNote = trimmedNote === "" ? null : trimmedNote;
+      const noteChanged = nextNote !== (entry.note ?? null);
       const { error: updateError } = await supabase
         .from("tip_entries")
+        // Cast dies once the regenerated database.ts (backend side of the
+        // v3 migration) knows the new columns.
         .update({
           cash_amount: cashCents / 100,
           card_amount: cardCents / 100,
+          gratuity_amount: gratuityCents / 100,
+          entered_scope: scope,
           split_count: peopleIds.length,
-        })
+          ...(noteChanged
+            ? {
+                note: nextNote,
+                note_at: nextNote === null ? null : new Date().toISOString(),
+              }
+            : {}),
+        } as never)
         .eq("id", entry.id);
       if (updateError) throw new Error(updateError.message);
 
@@ -132,6 +189,7 @@ function FixDialog({
   }
 
   const location = ctx.locationById.get(entry.locationId);
+  const previewWeights = peopleIds.map((id) => weightById[id] ?? 1);
 
   return (
     <ModalShell
@@ -139,7 +197,29 @@ function FixDialog({
       title={`Fix — ${shortDayLabel(entry.businessDate)} · ${location?.label ?? "?"} ${entry.meal}`}
       onClose={busy ? () => {} : onClose}
     >
-      <div className="mt-4 grid grid-cols-2 gap-3">
+      {entry.meal === "dinner" && (
+        <div className="mt-4 flex gap-1.5">
+          {(
+            [
+              { value: "day", label: "Whole day (Square)" },
+              { value: "shift", label: "Dinner only" },
+            ] as const
+          ).map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={scope === option.value}
+              onClick={() => setScope(option.value)}
+              className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-semibold ${
+                scope === option.value ? "bg-accent text-white" : "bg-well text-ink2"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="mt-4 grid grid-cols-3 gap-3">
         <label className="flex flex-col gap-1">
           <span className="section-label">Cash (split pool)</span>
           <input
@@ -158,6 +238,15 @@ function FixDialog({
             className="rounded-well bg-well px-3.5 py-2.5 text-ink outline-none"
           />
         </label>
+        <label className="flex flex-col gap-1">
+          <span className="section-label">Gratuity</span>
+          <input
+            value={gratuity}
+            onChange={(event) => setGratuity(event.target.value)}
+            inputMode="decimal"
+            className="rounded-well bg-well px-3.5 py-2.5 text-ink outline-none"
+          />
+        </label>
       </div>
 
       <div className="mt-4">
@@ -165,33 +254,74 @@ function FixDialog({
         <div className="mt-2 flex flex-wrap gap-2">
           {choosable.map((employee) => {
             const selected = peopleIds.includes(employee.id);
+            const weight = weightById[employee.id] ?? 1;
             return (
-              <button
-                key={employee.id}
-                type="button"
-                aria-pressed={selected}
-                onClick={() =>
-                  setPeopleIds((previous) =>
+              <span key={employee.id} className="inline-flex">
+                <button
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() =>
+                    setPeopleIds((previous) =>
+                      selected
+                        ? previous.filter((id) => id !== employee.id)
+                        : [...previous, employee.id],
+                    )
+                  }
+                  className={`rounded-full px-3.5 py-1.5 text-[13px] font-semibold ${
                     selected
-                      ? previous.filter((id) => id !== employee.id)
-                      : [...previous, employee.id],
-                  )
-                }
-                className={`rounded-full px-3.5 py-1.5 text-[13px] font-semibold ${
-                  selected ? "bg-accent text-white" : "bg-well text-ink2"
-                }`}
-              >
-                {employee.name}
-                {!employee.active && " (inactive)"}
-              </button>
+                      ? "rounded-r-none bg-accent pr-2 text-white"
+                      : "bg-well text-ink2"
+                  }`}
+                >
+                  {employee.name}
+                  {!employee.active && " (inactive)"}
+                </button>
+                {selected && (
+                  <button
+                    type="button"
+                    aria-label={`${employee.name} share ${Math.round(weight * 100)}%`}
+                    onClick={() =>
+                      setWeightById((previous) => {
+                        const index = WEIGHT_OPTIONS.indexOf(
+                          (previous[employee.id] ?? 1) as (typeof WEIGHT_OPTIONS)[number],
+                        );
+                        return {
+                          ...previous,
+                          [employee.id]:
+                            WEIGHT_OPTIONS[(index + 1) % WEIGHT_OPTIONS.length],
+                        };
+                      })
+                    }
+                    className="flex min-w-[28px] items-center rounded-full rounded-l-none bg-accent pl-0.5 pr-2 text-white"
+                  >
+                    <span className="rounded-full bg-white px-1.5 py-0.5 text-[10.5px] font-extrabold text-alert">
+                      {Math.round(weight * 100)}%
+                    </span>
+                  </button>
+                )}
+              </span>
             );
           })}
         </div>
       </div>
 
+      <label className="mt-4 flex flex-col gap-1">
+        <span className="section-label">
+          Note · {note.length} / {NOTE_MAX_LENGTH}
+        </span>
+        <textarea
+          value={note}
+          rows={2}
+          maxLength={NOTE_MAX_LENGTH}
+          onChange={(event) => setNote(event.target.value.slice(0, NOTE_MAX_LENGTH))}
+          className="resize-none rounded-well bg-well px-3.5 py-2.5 text-ink outline-none"
+        />
+      </label>
+
       {cashCents !== null && peopleIds.length > 0 && (
         <p className="mt-3 text-[12.5px] text-ink2">
-          {moneyFromCents(cashShareCents(cashCents, peopleIds.length))} cash each
+          {moneyFromCents(poolFullShareCents(cashCents, previewWeights))} full share
+          {previewWeights.some((weight) => weight < 1) ? " (weighted)" : " each"}
         </p>
       )}
       {error && <p className="mt-3 text-sm text-alert">{error}</p>}
@@ -208,10 +338,196 @@ function FixDialog({
   );
 }
 
+/** The unfolded three-card breakdown for one entry. */
+function DetailPanel({
+  entry,
+  lunchEntry,
+  onFix,
+  onVerify,
+  verifying,
+}: {
+  entry: LedgerEntry;
+  /** The recorded lunch row at the same location + business date, if shown. */
+  lunchEntry: LedgerEntry | null;
+  onFix: () => void;
+  onVerify: () => void;
+  verifying: boolean;
+}) {
+  const shares = entryShareCents(entry);
+  const noLunchFlag = entry.anomalyReason === "day_total_no_lunch";
+  // What was actually subtracted at save time — shown from the raw figures,
+  // not the current lunch row (which a fix may have changed since).
+  const subtractedCents =
+    entry.rawCashCents === null ? null : entry.rawCashCents - entry.cashCents;
+
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      <div className="rounded-[13px] border border-line bg-card p-3.5">
+        <div className="section-label">How this number was reached</div>
+        <div className="mt-2 grid gap-1 text-[12.5px] tabular-nums">
+          {entry.enteredScope === "day" ? (
+            <>
+              <div className="flex text-ink2">
+                <span>Entered from Square (whole day)</span>
+                <span className="ml-auto font-semibold text-ink">
+                  {moneyFromCents(entry.rawCashCents ?? entry.cashCents)}
+                </span>
+              </div>
+              <div className="flex text-ink2">
+                <span>
+                  &minus; lunch recorded
+                  {lunchEntry && !noLunchFlag ? ` ${timeLabel(lunchEntry.createdAt)}` : ""}
+                </span>
+                {noLunchFlag ? (
+                  <span className="ml-auto font-semibold text-alert">nothing on record</span>
+                ) : (
+                  <span className="ml-auto font-semibold text-alert">
+                    &minus;{moneyFromCents(subtractedCents ?? 0)}
+                  </span>
+                )}
+              </div>
+              <div className="mt-0.5 flex border-t border-line pt-1.5 font-extrabold text-ink">
+                <span>{mealLabel(entry.meal)} cash pool</span>
+                <span className="ml-auto">{moneyFromCents(entry.cashCents)}</span>
+              </div>
+            </>
+          ) : (
+            <div className="flex font-extrabold text-ink">
+              <span>Entered as {entry.meal} only</span>
+              <span className="ml-auto">{moneyFromCents(entry.cashCents)}</span>
+            </div>
+          )}
+        </div>
+        {noLunchFlag && (
+          <p className="mt-2 text-[12.5px] text-alert">
+            Flagged <code className="rounded bg-well px-1">day_total_no_lunch</code> — a
+            whole-day total was entered with no lunch to subtract.
+          </p>
+        )}
+        <div className="my-2.5 h-px bg-hairline" />
+        <div className="grid gap-1 text-[12.5px] tabular-nums">
+          <div className="flex text-ink2">
+            <span>Card → payroll</span>
+            <span className="ml-auto font-semibold text-ink">
+              {moneyFromCents(entry.cardCents)}
+            </span>
+          </div>
+          <div className="flex text-ink2">
+            <span>Gratuity</span>
+            <span className="ml-auto font-semibold text-ink">
+              {entry.gratuityCents > 0 ? moneyFromCents(entry.gratuityCents) : "none"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-[13px] border border-line bg-card p-3.5">
+        <div className="section-label">Who takes what</div>
+        <table className="mt-1.5 w-full border-collapse text-[12.5px]">
+          <tbody>
+            {entry.peopleIds.map((personId, index) => {
+              const weight = entry.weights[index] ?? 1;
+              return (
+                <tr key={personId}>
+                  <td className="border-b border-hairline py-1">
+                    {entry.peopleNames[index] ?? "?"}
+                  </td>
+                  <td className="border-b border-hairline py-1 text-right text-ink3">
+                    {weight < 1 ? `${Math.round(weight * 100)}%` : "full"}
+                  </td>
+                  <td className="border-b border-hairline py-1 text-right font-semibold tabular-nums">
+                    {moneyFromCents(shares[index] ?? 0)}
+                  </td>
+                </tr>
+              );
+            })}
+            <tr>
+              <td className="border-t border-line pt-1.5 font-extrabold">Pool</td>
+              <td className="border-t border-line" />
+              <td className="border-t border-line pt-1.5 text-right font-extrabold tabular-nums">
+                {moneyFromCents(entry.cashCents)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="rounded-[13px] border border-line bg-card p-3.5">
+        <div className="section-label">
+          Note
+          {entry.note && entry.enteredByName
+            ? ` · ${entry.enteredByName}${entry.noteAt ? `, ${timeLabel(entry.noteAt)}` : ""}`
+            : ""}
+        </div>
+        {entry.note ? (
+          <p className="mt-1.5 text-[12.5px] leading-relaxed text-ink2">{entry.note}</p>
+        ) : (
+          <p className="mt-1.5 text-[12.5px] text-ink3">No note on this entry.</p>
+        )}
+        <div className="mt-3 flex gap-2">
+          {entry.flagged && (
+            <button
+              type="button"
+              className={miniBtnDanger}
+              disabled={verifying}
+              onClick={(event) => {
+                event.stopPropagation();
+                onVerify();
+              }}
+            >
+              {verifying ? "Verifying…" : "Verify"}
+            </button>
+          )}
+          <button
+            type="button"
+            className={miniBtn}
+            onClick={(event) => {
+              event.stopPropagation();
+              onFix();
+            }}
+          >
+            Fix entry
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function LedgerPage({ ctx }: { ctx: PageContext }) {
   const toast = useToast();
   const [fixing, setFixing] = useState<LedgerEntry | null>(null);
   const [verifying, setVerifying] = useState<string | null>(null);
+  const [openIds, setOpenIds] = useState<Set<string>>(() => new Set());
+  // Flagged rows auto-open their detail when the range first loads. Track the
+  // data identity so a refetch after Verify doesn't re-open everything.
+  const [autoOpenedKey, setAutoOpenedKey] = useState<string | null>(null);
+
+  const entriesKey = useMemo(
+    () => ctx.entries.map((entry) => entry.id).join("|"),
+    [ctx.entries],
+  );
+  // Render-adjustment (not an effect): when a new range's rows arrive, open
+  // every still-flagged row's detail before the first paint of that data.
+  if (autoOpenedKey !== entriesKey) {
+    setAutoOpenedKey(entriesKey);
+    const flagged = ctx.entries.filter((entry) => entry.flagged).map((entry) => entry.id);
+    if (flagged.length > 0) {
+      setOpenIds((previous) => new Set([...previous, ...flagged]));
+    }
+  }
+
+  // The lunch row at each location+date, for the detail panel's "lunch
+  // recorded 3:41 PM" line.
+  const lunchByDayLocation = useMemo(() => {
+    const map = new Map<string, LedgerEntry>();
+    for (const entry of ctx.entries) {
+      if (entry.meal === "lunch") {
+        map.set(`${entry.businessDate}|${entry.locationId}`, entry);
+      }
+    }
+    return map;
+  }, [ctx.entries]);
 
   async function verify(entry: LedgerEntry) {
     if (verifying) return;
@@ -231,6 +547,15 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
     toast("Entry verified — flag cleared");
     ctx.refetch();
   }
+
+  const toggleOpen = (id: string) => {
+    setOpenIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   // Rows are already newest-first; insert a day-total row after each group.
   const rows: Array<
@@ -260,18 +585,21 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
     <section className="mb-8">
       <div className="mb-2.5 flex items-center gap-2">
         <h3 className={sectionH3}>Recorded tips</h3>
-        <span className="text-[12.5px] font-semibold text-ink3">{ctx.entries.length} records</span>
+        <span className="text-[12.5px] font-semibold text-ink3">
+          {ctx.entries.length} records · click a row for the breakdown
+        </span>
         <InfoButton label="About recorded tips">
-          <b>Cash</b> is pooled and handed out nightly — the per-person column is what each name
-          takes home. <b>Card</b> tips ride payroll. A flagged row is unusually large against the
-          4-week history: check the drawer count, then Verify. Fix reopens a recorded shift for
-          correction.
+          <b>Cash</b> is pooled and handed out nightly — the per-person column is the full
+          (100%) share; reduced shares live in the row&apos;s breakdown. <b>Card</b> tips ride
+          payroll. A flagged row is unusually large against the 4-week history: check the
+          drawer count, then Verify. Fix reopens a recorded shift for correction.
         </InfoButton>
       </div>
       <div className={`${panelWrap} overflow-x-auto`}>
-        <table className="w-full min-w-[740px] border-collapse text-[13px]">
+        <table className="w-full min-w-[780px] border-collapse text-[13px]">
           <thead>
             <tr>
+              <th className={`${th} w-[26px]`} />
               <th className={th}>Business date</th>
               <th className={th}>Restaurant</th>
               <th className={th}>Meal</th>
@@ -288,6 +616,7 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
               if (row.kind === "total") {
                 return (
                   <tr key={`total-${row.day}`} className="bg-well text-[12.5px] font-extrabold">
+                    <td className={`${td} border-b-line py-1.5`} />
                     <td colSpan={3} className={`${td} border-b-line py-1.5 font-bold text-ink2`}>
                       {shortDayLabel(row.day)} — day total
                     </td>
@@ -307,59 +636,113 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
               const { entry } = row;
               const location = ctx.locationById.get(entry.locationId);
               const flaggedTint = entry.flagged ? "bg-flagtint" : "";
+              const open = openIds.has(entry.id);
+              const partialCount = entry.weights.filter((weight) => weight < 1).length;
               return (
-                <tr key={entry.id}>
-                  <td className={`${td} ${flaggedTint}`}>{shortDayLabel(entry.businessDate)}</td>
-                  <td className={`${td} ${flaggedTint}`}>
-                    {location ? <LocationChip location={location} /> : "?"}
-                  </td>
-                  <td className={`${td} ${flaggedTint}`}>{mealLabel(entry.meal)}</td>
-                  <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cashcol"} text-right font-semibold tabular-nums`}>
-                    {moneyFromCents(entry.cashCents)}
-                    {entry.flagged && (
-                      <span className="ml-1.5 inline-flex items-center gap-1 rounded-md bg-flagtint px-1.5 py-0.5 text-[10.5px] font-extrabold uppercase tracking-[0.03em] text-alert">
-                        ⚑ check
+                <Fragment key={entry.id}>
+                  <tr
+                    className="cursor-pointer hover:bg-cream/60"
+                    onClick={() => toggleOpen(entry.id)}
+                  >
+                    <td className={`${td} ${flaggedTint} text-[11px] text-ink3`}>
+                      {open ? "▾" : "▸"}
+                    </td>
+                    <td className={`${td} ${flaggedTint}`}>{shortDayLabel(entry.businessDate)}</td>
+                    <td className={`${td} ${flaggedTint}`}>
+                      {location ? <LocationChip location={location} /> : "?"}
+                    </td>
+                    <td className={`${td} ${flaggedTint}`}>{mealLabel(entry.meal)}</td>
+                    <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cashcol"} text-right font-semibold tabular-nums`}>
+                      {entry.enteredScope === "day" && (
+                        <span
+                          className="mr-1.5 inline-flex cursor-help rounded-[5px] border border-line bg-card px-1 py-0.5 text-[10px] font-extrabold uppercase text-ink2"
+                          title={`Entered as a whole-day total${
+                            entry.rawCashCents !== null
+                              ? ` of ${moneyFromCents(entry.rawCashCents)}`
+                              : ""
+                          }, lunch subtracted`}
+                        >
+                          day −lunch
+                        </span>
+                      )}
+                      {moneyFromCents(entry.cashCents)}
+                      {entry.flagged && (
+                        <span className="ml-1.5 inline-flex items-center gap-1 rounded-md bg-flagtint px-1.5 py-0.5 text-[10.5px] font-extrabold uppercase tracking-[0.03em] text-alert">
+                          ⚑ check
+                        </span>
+                      )}
+                    </td>
+                    <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cashcol"}`}>
+                      <span className="font-semibold text-ink">
+                        {entry.splitCount} {entry.splitCount === 1 ? "name" : "names"}
                       </span>
-                    )}
-                  </td>
-                  <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cashcol"}`}>
-                    <span className="text-ink2">
-                      <b className="font-semibold text-ink">{entry.peopleNames.join(", ")}</b>
-                      <span className="ml-1 text-[11.5px] text-ink3">· {entry.splitCount}</span>
-                    </span>
-                  </td>
-                  <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cashcol"} text-right font-extrabold tabular-nums`}>
-                    {moneyFromCents(cashShareCents(entry.cashCents, entry.splitCount))}
-                  </td>
-                  <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cardcol"} text-right font-semibold tabular-nums`}>
-                    {moneyFromCents(entry.cardCents)}
-                  </td>
-                  <td className={`${td} ${flaggedTint} text-[12.5px] text-ink2`}>
-                    {entry.enteredByName ?? "—"}{" "}
-                    <span className="text-ink3">· {methodLabel(entry)}</span>
-                  </td>
-                  <td className={`${td} ${flaggedTint} text-right`}>
-                    <button type="button" className={miniBtn} onClick={() => setFixing(entry)}>
-                      Fix
-                    </button>
-                    {entry.flagged && (
-                      <button
-                        type="button"
-                        className={`${miniBtnDanger} ml-1.5`}
-                        title={entry.anomalyReason ?? undefined}
-                        disabled={verifying === entry.id}
-                        onClick={() => void verify(entry)}
-                      >
-                        {verifying === entry.id ? "Verifying…" : "Verify"}
-                      </button>
-                    )}
-                  </td>
-                </tr>
+                      {partialCount > 0 && (
+                        <span className="ml-1.5 rounded-[5px] bg-okgreen/10 px-1 py-0.5 text-[11px] font-extrabold text-okgreen">
+                          {partialCount} partial
+                        </span>
+                      )}
+                    </td>
+                    <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cashcol"} text-right font-extrabold tabular-nums`}>
+                      {moneyFromCents(entryFullShareCents(entry))}
+                      {partialCount > 0 && (
+                        <span className="ml-1 text-[11.5px] font-semibold text-ink3">
+                          full share
+                        </span>
+                      )}
+                    </td>
+                    <td className={`${td} ${entry.flagged ? "bg-flagtint" : "bg-cardcol"} text-right font-semibold tabular-nums`}>
+                      {moneyFromCents(entry.cardCents)}
+                    </td>
+                    <td className={`${td} ${flaggedTint} text-[12.5px] text-ink2`}>
+                      {entry.enteredByName ?? "—"}{" "}
+                      <span className="text-ink3">· {methodLabel(entry)}</span>
+                    </td>
+                    <td className={`${td} ${flaggedTint} text-right`}>
+                      {entry.note !== null && (
+                        <span className="rounded-[5px] bg-poki/10 px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.06em] text-poki">
+                          note
+                        </span>
+                      )}
+                      {entry.flagged && (
+                        <button
+                          type="button"
+                          className={`${miniBtnDanger} ml-1.5`}
+                          title={entry.anomalyReason ?? undefined}
+                          disabled={verifying === entry.id}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void verify(entry);
+                          }}
+                        >
+                          {verifying === entry.id ? "Verifying…" : "Verify"}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                  {open && (
+                    <tr>
+                      <td className={`${td} bg-cream/40`} />
+                      <td colSpan={9} className={`${td} bg-cream/40 pb-4`}>
+                        <DetailPanel
+                          entry={entry}
+                          lunchEntry={
+                            lunchByDayLocation.get(
+                              `${entry.businessDate}|${entry.locationId}`,
+                            ) ?? null
+                          }
+                          onFix={() => setFixing(entry)}
+                          onVerify={() => void verify(entry)}
+                          verifying={verifying === entry.id}
+                        />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               );
             })}
             {ctx.entries.length === 0 && (
               <tr>
-                <td colSpan={9} className="px-3 py-[26px] text-center text-ink3">
+                <td colSpan={10} className="px-3 py-[26px] text-center text-ink3">
                   No records in this range for this filter
                 </td>
               </tr>

--- a/web/src/components/manager/dashboard/useDashboardData.ts
+++ b/web/src/components/manager/dashboard/useDashboardData.ts
@@ -27,6 +27,13 @@ interface RawEntryRow {
   meal_period: string;
   cash_amount: number | string; // Postgres numeric can arrive as a string
   card_amount: number | string;
+  gratuity_amount: number | string | null;
+  entered_scope: string | null;
+  raw_cash_amount: number | string | null;
+  raw_card_amount: number | string | null;
+  raw_gratuity_amount: number | string | null;
+  note: string | null;
+  note_at: string | null;
   split_count: number;
   entry_method: string;
   entered_by: string | null;
@@ -34,7 +41,16 @@ interface RawEntryRow {
   anomaly_reason: string | null;
   flag_verified_at: string | null;
   created_at: string;
-  tip_entry_people: Array<{ tip_employee_id: string }>;
+  tip_entry_people: Array<{
+    tip_employee_id: string;
+    share_weight: number | string | null;
+  }>;
+}
+
+/** Postgres numeric (possibly a string) → cents; null/undefined → fallback. */
+function centsOrNull(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  return Math.round(Number(value) * 100);
 }
 
 interface RawSessionRow {
@@ -110,7 +126,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
             supabase
               .from("tip_entries")
               .select(
-                "id, business_date, location_id, meal_period, cash_amount, card_amount, split_count, entry_method, entered_by, flagged_anomaly, anomaly_reason, flag_verified_at, created_at, tip_entry_people(tip_employee_id)",
+                "id, business_date, location_id, meal_period, cash_amount, card_amount, gratuity_amount, entered_scope, raw_cash_amount, raw_card_amount, raw_gratuity_amount, note, note_at, split_count, entry_method, entered_by, flagged_anomaly, anomaly_reason, flag_verified_at, created_at, tip_entry_people(tip_employee_id, share_weight)",
               )
               .gte("business_date", start)
               .lte("business_date", end)
@@ -151,6 +167,14 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
         const peopleIds = (row.tip_entry_people ?? [])
           .map((person) => person.tip_employee_id)
           .sort((a, b) => (rosterRank.get(a) ?? 999) - (rosterRank.get(b) ?? 999));
+        const weightById = new Map(
+          (row.tip_entry_people ?? []).map((person) => [
+            person.tip_employee_id,
+            person.share_weight === null || person.share_weight === undefined
+              ? 1
+              : Number(person.share_weight),
+          ]),
+        );
         return {
           id: row.id,
           businessDate: row.business_date,
@@ -158,9 +182,17 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
           meal: row.meal_period as MealPeriod,
           cashCents: Math.round(Number(row.cash_amount) * 100),
           cardCents: Math.round(Number(row.card_amount) * 100),
+          gratuityCents: centsOrNull(row.gratuity_amount) ?? 0,
+          enteredScope: row.entered_scope === "day" ? ("day" as const) : ("shift" as const),
+          rawCashCents: centsOrNull(row.raw_cash_amount),
+          rawCardCents: centsOrNull(row.raw_card_amount),
+          rawGratuityCents: centsOrNull(row.raw_gratuity_amount),
+          note: row.note ?? null,
+          noteAt: row.note_at ?? null,
           splitCount: row.split_count,
           peopleIds,
           peopleNames: peopleIds.map((id) => nameById.get(id) ?? "?"),
+          weights: peopleIds.map((id) => weightById.get(id) ?? 1),
           enteredById: row.entered_by,
           enteredByName: row.entered_by ? (nameById.get(row.entered_by) ?? null) : null,
           entryMethod: (row.entry_method === "voice" ? "voice" : "typed") as EntryMethod,

--- a/web/src/lib/tips/__tests__/dashboardCsv.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardCsv.test.ts
@@ -19,6 +19,14 @@ function entry(overrides: Partial<LedgerEntry>): LedgerEntry {
     splitCount: 3,
     peopleIds: ["maria", "jose", "ken"],
     peopleNames: ["Maria", "Jose", "Ken"],
+    weights: [1, 1, 1],
+    gratuityCents: 0,
+    enteredScope: "shift",
+    rawCashCents: null,
+    rawCardCents: null,
+    rawGratuityCents: null,
+    note: null,
+    noteAt: null,
     enteredById: "maria",
     enteredByName: "Maria",
     entryMethod: "voice",
@@ -31,11 +39,12 @@ function entry(overrides: Partial<LedgerEntry>): LedgerEntry {
 }
 
 describe("buildLedgerCsv", () => {
-  it("writes the mockup's exact header", () => {
+  it("keeps the existing columns in place and appends the v3 columns", () => {
     const csv = buildLedgerCsv([], (id) => LOCATION_LABELS[id]);
     expect(csv).toBe(
       "Business date,Restaurant,Meal,Cash (split pool),Card (logged only)," +
-        "People on split,Names,Per-person share,Flagged,Entered by,Entry method",
+        "People on split,Names,Per-person share,Flagged,Entered by,Entry method," +
+        "Gratuity,Entered scope,Raw cash,Raw card,Note,Weights",
     );
   });
 
@@ -43,9 +52,36 @@ describe("buildLedgerCsv", () => {
     const csv = buildLedgerCsv([entry({})], (id) => LOCATION_LABELS[id]);
     const rows = csv.split("\n");
     expect(rows).toHaveLength(2);
-    // 41200¢ / 3 = 13733.33¢ → $137.33 cash-only share.
+    // 41200¢ / 3 = 13733.33¢ → $137.33 cash-only share. Pre-v3 row: zero
+    // gratuity, shift scope, no raw figures, no note, all-full weights.
     expect(rows[1]).toBe(
-      'Sun Aug 9 2026,Sushi,Dinner,412.00,688.50,3,"Maria; Jose; Ken",137.33,no,Maria,voice',
+      'Sun Aug 9 2026,Sushi,Dinner,412.00,688.50,3,"Maria; Jose; Ken",137.33,no,Maria,voice,' +
+        '0.00,shift,,,,"100; 100; 100"',
+    );
+  });
+
+  it("exports gratuity, day scope, raw figures, note, and weights", () => {
+    const csv = buildLedgerCsv(
+      [
+        entry({
+          cashCents: 20500,
+          cardCents: 63500,
+          gratuityCents: 21600,
+          enteredScope: "day",
+          rawCashCents: 32300,
+          rawCardCents: 77700,
+          rawGratuityCents: 21600,
+          note: 'Drawer $20 short, Marco said "recounted"',
+          weights: [1, 1, 0.5],
+        }),
+      ],
+      (id) => LOCATION_LABELS[id],
+    );
+    const row = csv.split("\n")[1];
+    // Full share = round(20500 / 2.5) = 8200¢ → $82.00.
+    expect(row).toBe(
+      'Sun Aug 9 2026,Sushi,Dinner,205.00,635.00,3,"Maria; Jose; Ken",82.00,no,Maria,voice,' +
+        '216.00,day,323.00,777.00,"Drawer $20 short, Marco said ""recounted""","100; 100; 50"',
     );
   });
 

--- a/web/src/lib/tips/__tests__/dashboardDerive.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardDerive.test.ts
@@ -21,6 +21,14 @@ function entry(overrides: Partial<LedgerEntry>): LedgerEntry {
     splitCount: 1,
     peopleIds: [],
     peopleNames: [],
+    weights: [],
+    gratuityCents: 0,
+    enteredScope: "shift",
+    rawCashCents: null,
+    rawCardCents: null,
+    rawGratuityCents: null,
+    note: null,
+    noteAt: null,
     enteredById: null,
     enteredByName: null,
     entryMethod: "typed",
@@ -97,12 +105,58 @@ describe("takeHomeByPerson", () => {
     ]);
   });
 
-  it("uses split_count for the share even when it disagrees with the name list", () => {
-    // The DB derives split_count from the people array at save; trust it.
+  it("allocates the whole pool to the people actually on the split", () => {
+    // v3: shares come from the weighted allocation over the people list —
+    // nothing stays in the drawer, and split_count is headcount only.
     const people = takeHomeByPerson([
       entry({ cashCents: 300, splitCount: 3, peopleIds: ["a"], peopleNames: ["A"] }),
     ]);
-    expect(people[0].cents).toBe(100);
+    expect(people[0].cents).toBe(300);
+  });
+
+  it("weights the shares: one 50% person raises everyone else", () => {
+    // The handoff's $205 vector: 45.56 / 45.56 / 45.55 / 45.55 / 22.78.
+    const people = takeHomeByPerson([
+      entry({
+        cashCents: 20500,
+        splitCount: 5,
+        peopleIds: ["ana", "marco", "priya", "dee", "kenji"],
+        peopleNames: ["Ana", "Marco", "Priya", "Dee", "Kenji"],
+        weights: [1, 1, 1, 1, 0.5],
+      }),
+    ]);
+    const byName = new Map(people.map((p) => [p.name, p.cents]));
+    expect(byName.get("Ana")).toBe(4556);
+    expect(byName.get("Marco")).toBe(4556);
+    expect(byName.get("Priya")).toBe(4555);
+    expect(byName.get("Dee")).toBe(4555);
+    expect(byName.get("Kenji")).toBe(2278);
+    expect(people.reduce((sum, p) => sum + p.cents, 0)).toBe(20500);
+  });
+
+  it("accumulates mixed weights across a range", () => {
+    const people = takeHomeByPerson([
+      entry({
+        cashCents: 82200,
+        splitCount: 2,
+        peopleIds: ["sam", "rey"],
+        peopleNames: ["Sam", "Rey"],
+        weights: [1, 0.25],
+      }),
+      entry({
+        id: "e2",
+        businessDate: "2026-08-08",
+        cashCents: 11800,
+        splitCount: 2,
+        peopleIds: ["sam", "rey"],
+        peopleNames: ["Sam", "Rey"],
+        weights: [0.5, 1],
+      }),
+    ]);
+    const byName = new Map(people.map((p) => [p.name, p]));
+    // 82200 → Sam 65760, Rey 16440; 11800 over [0.5, 1] → Sam 3933, Rey 7867.
+    expect(byName.get("Sam")).toEqual({ id: "sam", name: "Sam", cents: 69693, shifts: 2 });
+    expect(byName.get("Rey")).toEqual({ id: "rey", name: "Rey", cents: 24307, shifts: 2 });
   });
 
   it("breaks ties by name", () => {

--- a/web/src/lib/tips/__tests__/dayScope.test.ts
+++ b/web/src/lib/tips/__tests__/dayScope.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveShiftAmounts,
+  enteredTotal,
+  hasNegativeAmount,
+  type MealAmounts,
+} from "../dayScope";
+
+const amounts = (cash: number, card: number, gratuity: number): MealAmounts => ({
+  cash,
+  card,
+  gratuity,
+});
+
+describe("deriveShiftAmounts", () => {
+  it("subtracts the lunch row field by field on day scope (the mockup's default state)", () => {
+    const { derived, subtracted } = deriveShiftAmounts(
+      amounts(323, 777, 216),
+      "day",
+      amounts(118, 142, 0),
+    );
+    expect(derived).toEqual(amounts(205, 635, 216));
+    expect(subtracted).toBe(true);
+  });
+
+  it("passes typed figures through unchanged on shift scope", () => {
+    const { derived, subtracted } = deriveShiftAmounts(
+      amounts(323, 777, 216),
+      "shift",
+      amounts(118, 142, 0),
+    );
+    expect(derived).toEqual(amounts(323, 777, 216));
+    expect(subtracted).toBe(false);
+  });
+
+  it("subtracts nothing when no lunch is on record (the flagged day_total_no_lunch case)", () => {
+    const { derived, subtracted } = deriveShiftAmounts(
+      amounts(822, 210, 0),
+      "day",
+      null,
+    );
+    expect(derived).toEqual(amounts(822, 210, 0));
+    expect(subtracted).toBe(false);
+  });
+
+  it("computes in cents, avoiding float drift", () => {
+    const { derived } = deriveShiftAmounts(
+      amounts(0.3, 100.1, 0),
+      "day",
+      amounts(0.1, 0.2, 0),
+    );
+    expect(derived.cash).toBe(0.2);
+    expect(derived.card).toBe(99.9);
+  });
+
+  it("can go negative — the caller decides what to do with it", () => {
+    const { derived } = deriveShiftAmounts(
+      amounts(50, 200, 0),
+      "day",
+      amounts(118, 142, 0),
+    );
+    expect(derived.cash).toBe(-68);
+    expect(derived.card).toBe(58);
+    expect(hasNegativeAmount(derived)).toBe(true);
+  });
+
+  it("a zero entry against a recorded lunch is fully negative", () => {
+    const { derived } = deriveShiftAmounts(
+      amounts(0, 0, 0),
+      "day",
+      amounts(118, 142, 5),
+    );
+    expect(derived).toEqual(amounts(-118, -142, -5));
+    expect(hasNegativeAmount(derived)).toBe(true);
+  });
+
+  it("zero lunch on record subtracts zero but still counts as subtracted", () => {
+    const { derived, subtracted } = deriveShiftAmounts(
+      amounts(100, 50, 0),
+      "day",
+      amounts(0, 0, 0),
+    );
+    expect(derived).toEqual(amounts(100, 50, 0));
+    expect(subtracted).toBe(true);
+  });
+});
+
+describe("hasNegativeAmount", () => {
+  it("is false for all-zero amounts", () => {
+    expect(hasNegativeAmount(amounts(0, 0, 0))).toBe(false);
+  });
+
+  it("is true when any single field dips below zero", () => {
+    expect(hasNegativeAmount(amounts(0, 0, -0.01))).toBe(true);
+    expect(hasNegativeAmount(amounts(-0.01, 10, 0))).toBe(true);
+    expect(hasNegativeAmount(amounts(10, -0.01, 0))).toBe(true);
+  });
+});
+
+describe("enteredTotal", () => {
+  it("sums all three buckets cent-exactly", () => {
+    expect(enteredTotal(amounts(323, 777, 216))).toBe(1316);
+    expect(enteredTotal(amounts(0.1, 0.2, 0.3))).toBe(0.6);
+  });
+});

--- a/web/src/lib/tips/__tests__/mealPreset.test.ts
+++ b/web/src/lib/tips/__tests__/mealPreset.test.ts
@@ -8,6 +8,7 @@ function today(partial: Partial<TodayStatus>): TodayStatus {
     lunchRecorded: false,
     dinnerRecorded: false,
     defaultMeal: "lunch",
+    lunch: null,
     ...partial,
   };
 }

--- a/web/src/lib/tips/__tests__/split.test.ts
+++ b/web/src/lib/tips/__tests__/split.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { fromCents, perPersonShare, toCents, totalTips } from "../split";
+import {
+  allocatePoolCents,
+  fromCents,
+  fullShareCents,
+  perPersonShare,
+  toCents,
+  totalTips,
+} from "../split";
 
 describe("perPersonShare", () => {
   it("splits $100 three ways to $33.33 each (remainder stays in drawer)", () => {
@@ -46,6 +53,107 @@ describe("totalTips", () => {
 
   it("sums ordinary amounts exactly", () => {
     expect(totalTips(123.45, 67.89)).toBe(191.34);
+  });
+});
+
+describe("allocatePoolCents", () => {
+  // The required vectors from the v3 handoff — exactly what the mockup's live
+  // allocate() prints. Cents in, cents out.
+  it("$205.00 with one 50% share raises everyone else: 45.56/45.56/45.55/45.55/22.78", () => {
+    const shares = allocatePoolCents(20500, [1, 1, 1, 1, 0.5]);
+    expect(shares).toEqual([4556, 4556, 4555, 4555, 2278]);
+    expect(shares.reduce((a, b) => a + b, 0)).toBe(20500);
+  });
+
+  it("$205.00 all-full splits evenly: $41.00 x 5", () => {
+    expect(allocatePoolCents(20500, [1, 1, 1, 1, 1])).toEqual([
+      4100, 4100, 4100, 4100, 4100,
+    ]);
+  });
+
+  it("$205.00 with a 75% share: full share $43.16, the 75% person $32.37", () => {
+    const shares = allocatePoolCents(20500, [1, 1, 0.75, 1, 1]);
+    expect(shares[2]).toBe(3237);
+    expect(shares.reduce((a, b) => a + b, 0)).toBe(20500);
+    expect(fullShareCents(20500, [1, 1, 0.75, 1, 1])).toBe(4316);
+  });
+
+  it("$822.00 split 1 / 0.25: 657.60 and 164.40", () => {
+    expect(allocatePoolCents(82200, [1, 0.25])).toEqual([65760, 16440]);
+  });
+
+  it("$118.00 three ways sums exactly; ties give the extra cent to the earliest position", () => {
+    // The handoff's vector table shows the extra cent on the LAST person, but
+    // that contradicts both its own $205/0.5 vector and the mockup's live
+    // allocate() (stable fractional-desc sort => earliest position wins ties).
+    // The live mockup is the tie-break authority. Flagged for David.
+    const shares = allocatePoolCents(11800, [1, 1, 1]);
+    expect(shares).toEqual([3934, 3933, 3933]);
+    expect(shares.reduce((a, b) => a + b, 0)).toBe(11800);
+  });
+
+  it("a pool of 0 gives all zeros", () => {
+    expect(allocatePoolCents(0, [1, 0.5, 0.25])).toEqual([0, 0, 0]);
+  });
+
+  it("one person takes everything at any weight", () => {
+    expect(allocatePoolCents(20500, [0.25])).toEqual([20500]);
+    expect(allocatePoolCents(20500, [1])).toEqual([20500]);
+  });
+
+  it("an empty or zero-weight list allocates nothing", () => {
+    expect(allocatePoolCents(20500, [])).toEqual([]);
+    expect(allocatePoolCents(20500, [0, 0])).toEqual([0, 0]);
+  });
+
+  it("a negative pool gives all zeros", () => {
+    expect(allocatePoolCents(-500, [1, 1])).toEqual([0, 0]);
+  });
+
+  // Property-style invariants across many pools and weight mixes.
+  it("shares always sum to the pool and are never negative (30 people, mixed weights)", () => {
+    const cycle = [1, 0.75, 0.5, 0.25];
+    const weights = Array.from({ length: 30 }, (_, i) => cycle[i % 4]);
+    for (const pool of [1, 7, 99, 101, 12345, 1000003, 99999999]) {
+      const shares = allocatePoolCents(pool, weights);
+      expect(shares.reduce((a, b) => a + b, 0)).toBe(pool);
+      for (const share of shares) expect(share).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("equal weights never differ by more than one cent", () => {
+    for (const pool of [100, 101, 11800, 20500, 333333]) {
+      for (const heads of [2, 3, 5, 7, 8]) {
+        const shares = allocatePoolCents(pool, Array(heads).fill(1));
+        const min = Math.min(...shares);
+        const max = Math.max(...shares);
+        expect(max - min).toBeLessThanOrEqual(1);
+        expect(shares.reduce((a, b) => a + b, 0)).toBe(pool);
+      }
+    }
+  });
+
+  it("a heavier weight never receives less than a lighter one", () => {
+    const shares = allocatePoolCents(99999, [1, 0.75, 0.5, 0.25]);
+    for (let i = 1; i < shares.length; i++) {
+      expect(shares[i - 1]).toBeGreaterThanOrEqual(shares[i]);
+    }
+  });
+});
+
+describe("fullShareCents", () => {
+  it("matches the strip: $205.00 over weights 4.5 -> $45.56", () => {
+    expect(fullShareCents(20500, [1, 1, 1, 1, 0.5])).toBe(4556);
+  });
+
+  it("equals the even split when all weights are 1", () => {
+    expect(fullShareCents(20500, [1, 1, 1, 1, 1])).toBe(4100);
+    expect(fullShareCents(11800, [1, 1, 1])).toBe(3933);
+  });
+
+  it("returns 0 for an empty pool or empty weights", () => {
+    expect(fullShareCents(0, [1, 1])).toBe(0);
+    expect(fullShareCents(100, [])).toBe(0);
   });
 });
 

--- a/web/src/lib/tips/api.ts
+++ b/web/src/lib/tips/api.ts
@@ -29,11 +29,25 @@ export interface RosterPerson {
   scheduled: boolean;
 }
 
+/** The recorded lunch row's shift-only figures, for day-scope subtraction. */
+export interface LunchAmounts {
+  cash: number;
+  card: number;
+  gratuity: number;
+}
+
 export interface TodayStatus {
   businessDate: string;
   lunchRecorded: boolean;
   dinnerRecorded: boolean;
   defaultMeal: MealPeriod;
+  /**
+   * Today's recorded lunch at this location, null when nothing is recorded
+   * (that case saves flagged, silently to the closer). Read defensively —
+   * an older server omits the field and the client degrades to "no
+   * subtraction available".
+   */
+  lunch: LunchAmounts | null;
 }
 
 export interface SessionState {
@@ -47,8 +61,16 @@ export interface SlotEntry {
   id: string;
   businessDate: string;
   meal: MealPeriod;
+  /** Stored shift-only figures (already net of lunch on a day-scope save). */
   cash: number;
   card: number;
+  gratuity: number;
+  enteredScope: "shift" | "day";
+  /** What the closer typed; equals the stored figures on a shift save. */
+  rawCash: number;
+  rawCard: number;
+  rawGratuity: number;
+  note: string | null;
   splitCount: number;
   entryMethod: "typed" | "voice";
   voiceVariant: VoiceVariant | null;
@@ -57,6 +79,8 @@ export interface SlotEntry {
   flaggedAnomaly: boolean;
   updatedAt: string;
   peopleIds: string[];
+  /** Additive to peopleIds: each person's share weight in (0,1]. */
+  people: Array<{ id: string; weight: number }>;
 }
 
 export interface SaveResult {
@@ -168,7 +192,12 @@ export async function setCloser(sessionToken: string, closerId: string): Promise
 export async function getSlot(
   sessionToken: string,
   meal: MealPeriod,
-): Promise<{ businessDate: string; entry: SlotEntry | null; scheduledIds: string[] }> {
+): Promise<{
+  businessDate: string;
+  entry: SlotEntry | null;
+  scheduledIds: string[];
+  today: TodayStatus | null;
+}> {
   const json = await callFunction("tip-entries", { action: "get_slot", sessionToken, meal });
   return {
     businessDate: json.businessDate as string,
@@ -176,14 +205,26 @@ export async function getSlot(
     // Who the schedule says works this meal — used to re-seed pre-selection
     // when the closer switches meals. Older servers omit it.
     scheduledIds: Array.isArray(json.scheduledIds) ? (json.scheduledIds as string[]) : [],
+    // Fresh today-status (with the recorded lunch figures) so a meal switch
+    // updates the day-scope subtraction without a state round-trip. Older
+    // servers omit it.
+    today: (json.today as TodayStatus | undefined) ?? null,
   };
 }
 
 export interface SavePayload {
   meal: MealPeriod;
+  /** All three amounts AS TYPED — the server does the day-scope subtraction. */
   cash: number;
   card: number;
+  /** 0 when the well was left blank. */
+  gratuity: number;
+  enteredScope: "shift" | "day";
   peopleIds: string[];
+  /** Share weights positional against peopleIds, each in (0,1]. */
+  weights: number[];
+  /** Trimmed, ≤280 chars, null when empty. */
+  note: string | null;
   entryMethod: "typed" | "voice";
   voiceVariant: VoiceVariant | null;
   correctionsCount: number;

--- a/web/src/lib/tips/dashboardCsv.ts
+++ b/web/src/lib/tips/dashboardCsv.ts
@@ -5,11 +5,14 @@
 // fields are quoted only when they need it.
 
 import { csvDayLabel } from "./dashboardRange";
-import { cashShareCents, type LedgerEntry } from "./dashboardDerive";
+import { entryFullShareCents, type LedgerEntry } from "./dashboardDerive";
 
+// Existing columns keep their exact positions so old sheets don't break; the
+// Tips v3 columns (gratuity, scope, raw figures, note, weights) append after.
 const HEADER =
   "Business date,Restaurant,Meal,Cash (split pool),Card (logged only)," +
-  "People on split,Names,Per-person share,Flagged,Entered by,Entry method";
+  "People on split,Names,Per-person share,Flagged,Entered by,Entry method," +
+  "Gratuity,Entered scope,Raw cash,Raw card,Note,Weights";
 
 function csvField(value: string): string {
   return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
@@ -39,10 +42,24 @@ export function buildLedgerCsv(
         (entry.cardCents / 100).toFixed(2),
         String(entry.splitCount),
         `"${entry.peopleNames.join("; ").replace(/"/g, '""')}"`,
-        (cashShareCents(entry.cashCents, entry.splitCount) / 100).toFixed(2),
+        // The full (weight-1) share — same figure the ledger's Per person
+        // column shows. Identical to the old cash/count on all-full splits.
+        (entryFullShareCents(entry) / 100).toFixed(2),
         entry.flaggedRaw ? "yes" : "no",
         csvField(entry.enteredByName ?? ""),
         entry.entryMethod,
+        (entry.gratuityCents / 100).toFixed(2),
+        entry.enteredScope,
+        // Raw (as-typed) figures exist only on rows saved since Tips v3.
+        entry.rawCashCents === null ? "" : (entry.rawCashCents / 100).toFixed(2),
+        entry.rawCardCents === null ? "" : (entry.rawCardCents / 100).toFixed(2),
+        csvField(entry.note ?? ""),
+        // Percentages positional with Names, e.g. "100; 100; 75".
+        `"${entry.peopleIds
+          .map((_, index) =>
+            String(Math.round((entry.weights[index] ?? 1) * 100)),
+          )
+          .join("; ")}"`,
       ].join(","),
     );
   }

--- a/web/src/lib/tips/dashboardDerive.ts
+++ b/web/src/lib/tips/dashboardDerive.ts
@@ -8,6 +8,7 @@
 // half up; remainder cents stay in the drawer.
 
 import type { EntryMethod, MealPeriod } from "@/types/database";
+import { allocatePoolCents, fullShareCents } from "./split";
 
 export interface LedgerEntry {
   id: string;
@@ -19,6 +20,17 @@ export interface LedgerEntry {
   splitCount: number;
   peopleIds: string[];
   peopleNames: string[];
+  /** Share weight per person in (0,1], positional with peopleIds. */
+  weights: number[];
+  /** Its own bucket — never part of the cash pool or the card figure. */
+  gratuityCents: number;
+  enteredScope: "shift" | "day";
+  /** What the closer typed; null on rows saved before Tips v3. */
+  rawCashCents: number | null;
+  rawCardCents: number | null;
+  rawGratuityCents: number | null;
+  note: string | null;
+  noteAt: string | null;
   enteredById: string | null;
   enteredByName: string | null;
   entryMethod: EntryMethod;
@@ -80,17 +92,48 @@ export interface PersonTakeHome {
 }
 
 /**
- * Cash take-home per person across the range: each entry contributes
- * round(cash / splitCount) to every name on its split. Sorted highest first.
+ * One entry's per-person cash shares in cents, positional with peopleIds —
+ * the weighted largest-remainder allocation. Falls back to the legacy
+ * round(cash / splitCount) when the people list is empty (no rows to
+ * allocate to, e.g. degenerate historical data).
+ */
+export function entryShareCents(entry: LedgerEntry): number[] {
+  if (entry.peopleIds.length === 0) return [];
+  const weights =
+    entry.weights.length === entry.peopleIds.length
+      ? entry.weights
+      : entry.peopleIds.map(() => 1);
+  return allocatePoolCents(entry.cashCents, weights);
+}
+
+/**
+ * The "full share" (weight-1) figure for one entry, in cents — what the
+ * ledger's Per person column shows. Equals cashShareCents for an all-full
+ * split.
+ */
+export function entryFullShareCents(entry: LedgerEntry): number {
+  if (entry.peopleIds.length === 0) {
+    return cashShareCents(entry.cashCents, entry.splitCount);
+  }
+  const weights =
+    entry.weights.length === entry.peopleIds.length
+      ? entry.weights
+      : entry.peopleIds.map(() => 1);
+  return fullShareCents(entry.cashCents, weights);
+}
+
+/**
+ * Cash take-home per person across the range: each entry contributes its
+ * weighted allocation to every name on its split. Sorted highest first.
  */
 export function takeHomeByPerson(entries: LedgerEntry[]): PersonTakeHome[] {
   const byPerson = new Map<string, PersonTakeHome>();
   for (const entry of entries) {
-    const share = cashShareCents(entry.cashCents, entry.splitCount);
+    const shares = entryShareCents(entry);
     entry.peopleIds.forEach((personId, index) => {
       const name = entry.peopleNames[index] ?? "?";
       const person = byPerson.get(personId) ?? { id: personId, name, cents: 0, shifts: 0 };
-      person.cents += share;
+      person.cents += shares[index] ?? 0;
       person.shifts += 1;
       byPerson.set(personId, person);
     });

--- a/web/src/lib/tips/dayScope.ts
+++ b/web/src/lib/tips/dayScope.ts
@@ -1,0 +1,64 @@
+// Day-scope subtraction (Tips v3). A dinner entered as "Whole day (Square)"
+// stores shift-only figures: what the closer typed minus what lunch already
+// recorded, field by field (cash−cash, card−card, gratuity−gratuity), against
+// today's lunch row at the same location. The server recomputes this on save
+// and is authoritative; the client copy only drives the live receipt and the
+// blocking negative warning.
+//
+// MIRROR: supabase/functions/_shared/tips.ts carries a copy of this logic
+// (edge functions cannot import from web/). Keep them in sync.
+
+import { fromCents, toCents } from "./split";
+
+export type EnteredScope = "shift" | "day";
+
+export interface MealAmounts {
+  cash: number;
+  card: number;
+  gratuity: number;
+}
+
+export interface DerivedAmounts {
+  /** Shift-only figures in dollars, cent-exact. May be negative. */
+  derived: MealAmounts;
+  /** True when a lunch row existed and was subtracted. */
+  subtracted: boolean;
+}
+
+/**
+ * Derive the shift-only amounts from what the closer typed.
+ *
+ * On scope "day" with a lunch row on record, each field is typed − lunch,
+ * computed in integer cents. On scope "shift", or on "day" with no lunch
+ * recorded (the flagged day_total_no_lunch case), the typed figures pass
+ * through unchanged and `subtracted` is false.
+ */
+export function deriveShiftAmounts(
+  typed: MealAmounts,
+  scope: EnteredScope,
+  lunch: MealAmounts | null,
+): DerivedAmounts {
+  if (scope !== "day" || lunch === null) {
+    return { derived: { ...typed }, subtracted: false };
+  }
+  return {
+    derived: {
+      cash: fromCents(toCents(typed.cash) - toCents(lunch.cash)),
+      card: fromCents(toCents(typed.card) - toCents(lunch.card)),
+      gratuity: fromCents(toCents(typed.gratuity) - toCents(lunch.gratuity)),
+    },
+    subtracted: true,
+  };
+}
+
+/** True when any derived field is negative — the one blocking entry state. */
+export function hasNegativeAmount(amounts: MealAmounts): boolean {
+  return amounts.cash < 0 || amounts.card < 0 || amounts.gratuity < 0;
+}
+
+/** Entered total in dollars, cent-exact: cash + card + gratuity. */
+export function enteredTotal(amounts: MealAmounts): number {
+  return fromCents(
+    toCents(amounts.cash) + toCents(amounts.card) + toCents(amounts.gratuity),
+  );
+}

--- a/web/src/lib/tips/split.ts
+++ b/web/src/lib/tips/split.ts
@@ -30,3 +30,54 @@ export function perPersonShare(
 export function totalTips(cash: number, card: number): number {
   return fromCents(toCents(cash) + toCents(card));
 }
+
+// Weighted allocation (Tips v3 partial shares). Unlike perPersonShare above,
+// the allocated shares must sum to the pool EXACTLY — nothing stays in the
+// drawer beyond what largest-remainder cannot avoid (which is nothing).
+// Half-up rounding is wrong here: it can pay out more than the pool.
+//
+// MIRROR: supabase/functions/_shared/tips.ts carries a copy of this logic
+// (edge functions cannot import from web/). Keep them in sync.
+
+/**
+ * Split poolCents across weights by largest remainder.
+ *
+ * raw_i = poolCents * w_i / sum(w); everyone gets floor(raw_i); the leftover
+ * cents go one at a time to the largest fractional parts, ties broken by the
+ * person's position in the split (earlier wins). Returns integer cents,
+ * positional with weights, summing exactly to poolCents. A pool of 0 or an
+ * empty/zero weight list allocates all zeros.
+ */
+export function allocatePoolCents(
+  poolCents: number,
+  weights: number[],
+): number[] {
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+  if (!Number.isFinite(poolCents) || poolCents <= 0 || totalWeight <= 0) {
+    return weights.map(() => 0);
+  }
+  const raw = weights.map((w) => (poolCents * w) / totalWeight);
+  const base = raw.map(Math.floor);
+  const rest = poolCents - base.reduce((sum, c) => sum + c, 0);
+  const order = raw
+    .map((value, index) => [value - Math.floor(value), index] as const)
+    .sort((a, b) => b[0] - a[0]);
+  for (let k = 0; k < rest; k++) {
+    base[order[k % order.length][1]] += 1;
+  }
+  return base;
+}
+
+/**
+ * The "full share" a weight-1 person takes, in cents, for display: the strip,
+ * the ledger's Per person column, and the saved screen all print this.
+ * round(poolCents / sum(weights)), half-up — display only; the money that is
+ * actually assigned comes from allocatePoolCents.
+ */
+export function fullShareCents(poolCents: number, weights: number[]): number {
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+  if (!Number.isFinite(poolCents) || poolCents <= 0 || totalWeight <= 0) {
+    return 0;
+  }
+  return Math.round(poolCents / totalWeight);
+}

--- a/web/src/types/database.ts
+++ b/web/src/types/database.ts
@@ -4261,14 +4261,21 @@ export type Database = {
           corrections_count: number
           created_at: string
           entered_by: string | null
+          entered_scope: string
           entry_method: string
           entry_session_id: string | null
           flag_verified_at: string | null
           flag_verified_by: string | null
           flagged_anomaly: boolean
+          gratuity_amount: number
           id: string
           location_id: string
           meal_period: string
+          note: string | null
+          note_at: string | null
+          raw_card_amount: number | null
+          raw_cash_amount: number | null
+          raw_gratuity_amount: number | null
           split_count: number
           updated_at: string
           voice_variant: string | null
@@ -4281,14 +4288,21 @@ export type Database = {
           corrections_count?: number
           created_at?: string
           entered_by?: string | null
+          entered_scope?: string
           entry_method: string
           entry_session_id?: string | null
           flag_verified_at?: string | null
           flag_verified_by?: string | null
           flagged_anomaly?: boolean
+          gratuity_amount?: number
           id?: string
           location_id: string
           meal_period: string
+          note?: string | null
+          note_at?: string | null
+          raw_card_amount?: number | null
+          raw_cash_amount?: number | null
+          raw_gratuity_amount?: number | null
           split_count?: number
           updated_at?: string
           voice_variant?: string | null
@@ -4301,14 +4315,21 @@ export type Database = {
           corrections_count?: number
           created_at?: string
           entered_by?: string | null
+          entered_scope?: string
           entry_method?: string
           entry_session_id?: string | null
           flag_verified_at?: string | null
           flag_verified_by?: string | null
           flagged_anomaly?: boolean
+          gratuity_amount?: number
           id?: string
           location_id?: string
           meal_period?: string
+          note?: string | null
+          note_at?: string | null
+          raw_card_amount?: number | null
+          raw_cash_amount?: number | null
+          raw_gratuity_amount?: number | null
           split_count?: number
           updated_at?: string
           voice_variant?: string | null
@@ -4339,14 +4360,17 @@ export type Database = {
       }
       tip_entry_people: {
         Row: {
+          share_weight: number
           tip_employee_id: string
           tip_entry_id: string
         }
         Insert: {
+          share_weight?: number
           tip_employee_id: string
           tip_entry_id: string
         }
         Update: {
+          share_weight?: number
           tip_employee_id?: string
           tip_entry_id?: string
         }
@@ -4855,24 +4879,50 @@ export type Database = {
         Args: { p_location_id: string }
         Returns: string
       }
-      tip_save_entry: {
-        Args: {
-          p_anomaly_reason: string
-          p_business_date: string
-          p_card: number
-          p_cash: number
-          p_corrections: number
-          p_entered_by: string
-          p_entry_method: string
-          p_flagged: boolean
-          p_location_id: string
-          p_meal_period: string
-          p_people: string[]
-          p_session_id: string
-          p_voice_variant: string
-        }
-        Returns: string
-      }
+      tip_save_entry:
+        | {
+            Args: {
+              p_anomaly_reason: string
+              p_business_date: string
+              p_card: number
+              p_cash: number
+              p_corrections: number
+              p_entered_by: string
+              p_entered_scope: string
+              p_entry_method: string
+              p_flagged: boolean
+              p_gratuity: number
+              p_location_id: string
+              p_meal_period: string
+              p_note: string
+              p_people: string[]
+              p_raw_card: number
+              p_raw_cash: number
+              p_raw_gratuity: number
+              p_session_id: string
+              p_voice_variant: string
+              p_weights: number[]
+            }
+            Returns: string
+          }
+        | {
+            Args: {
+              p_anomaly_reason: string
+              p_business_date: string
+              p_card: number
+              p_cash: number
+              p_corrections: number
+              p_entered_by: string
+              p_entry_method: string
+              p_flagged: boolean
+              p_location_id: string
+              p_meal_period: string
+              p_people: string[]
+              p_session_id: string
+              p_voice_variant: string
+            }
+            Returns: string
+          }
       tip_validate_entry_pin: {
         Args: {
           p_identifier_hash: string


### PR DESCRIPTION
Tips v3 per the approved handoff (`docs/mockups/tips-v3/HANDOFF-tips-v3.md`) and mockup (`tips-v3-final.html`): gratuity, day-scope subtraction, weighted partial shares, and notes — built as a Claude-frontend / Codex-backend split against the written contract in `docs/mockups/tips-v3/CONTRACT.md`, cross-reviewed in both directions to sign-off.

## What changed

**Backend (Codex/Sol, `gpt-5.6-sol`)**
- Migration `20260828100000_tips_v3_grat_scope_weights_notes.sql`: `gratuity_amount`, `entered_scope`, `raw_*`, `note`, `note_at` on `tip_entries`; `share_weight` on `tip_entry_people`; extended 20-arg `tip_save_entry` (weights positional, `note_at` maintenance, session guard preserved) plus a **13-arg compatibility wrapper** so the currently-deployed edge function keeps working through the migration→functions window. Grants re-issued for both signatures.
- `tip-entries` `save`: server-side lunch subtraction (client sends as-typed; server is authoritative), `negative_after_lunch` 400, `bad_weights` 400 (validated before and kept positional through UUID dedupe), anomaly check on **derived** amounts, `day_total_no_lunch` flagged **silently** (needsConfirm only ever comes from the statistical check; combined reason is prefix-stable). `get_slot` gains `today` with the recorded lunch. `SlotEntry` gains gratuity/scope/raw/note/`people:[{id,weight}]` while keeping `peopleIds`.
- `tip-entry-auth` `state`: `today.lunch` amounts.
- `_shared/tips.ts`: exact mirror of the canonical web math (keep-in-sync convention).

**Frontend (Claude)**
- Canonical math: `split.ts` largest-remainder `allocatePoolCents` (+`fullShareCents`), `dayScope.ts` field-by-field subtraction — integer cents throughout, shares always sum to the pool.
- Entry screen: scope switch (dinner only, no label, defaults Whole day), third Gratuity well (identical, no tint), editable underline on all wells (voice sheet included), live receipt, the single blocking negative warning, %-badges as their own ≥28px hit targets, conditional "What each person takes", cash-pool-only split strip, note (280 cap, Save), 10s saved-screen countdown → scan gate.
- Recorded tips (D2): unfolding rows with the three detail cards, `day −lunch` badge with raw figure on hover, `N names · x partial`, full-share Per person column, flagged rows auto-open. Fix dialog implements the same scope/raw contract as save (as-typed fields, lunch derivation, negative block, weights, note) — still the direct RLS path with the recoverable ordering.
- `takeHomeByPerson`, Overview ranking, and the CSV use the weighted allocation; CSV appends `Gratuity, Entered scope, Raw cash, Raw card, Note, Weights` after the existing columns.
- Allocation order is canonicalized to roster order on every surface so largest-remainder ties land on the same person everywhere.
- `database.ts` tips sections regenerated from the migrated schema.

## Verification (all green)

- `npm run typecheck` / `lint` / `test` (222 unit tests, incl. every handoff vector + property invariants).
- Playwright e2e 8/8 against an isolated Supabase branch (`tips-v3-verify`), with server-persistence assertions on the stored rows.
- Migration proven on the branch: legacy rows read back **byte-identical** (md5 snapshot), 13-arg wrapper works, mismatched weights raise, day-save-without-lunch flags silently, negative derived amounts refused (400), manager RLS path writes weights while a non-manager is blocked (policy-level proof; `current_user_is_manager()` stubbed on the branch — prod's function is untouched by this change).
- Manual side-by-side pass with the mockup: whole-day receipt (1,316.00 − 260.00 → 1,056.00), badge states, $45.56/45.56/45.55/45.55/22.78 allocation, all-100% strip ($41.00 each), empty gratuity, 1-person and 8-person splits, note flow, saved screen (derived figures + countdown → scan gate), D2 details and Fix dialog.
- Codex/Luna black-box campaign against the branch — **12/12 checks pass** over 77 live HTTP requests: session lifecycle (incl. `end_session` → 401), exact persistence round-trips (a 280-char note with quotes, a comma, an emoji and a literal `$5` returns byte-identical; `gratuity 12.34` exact), day-scope derivation, same-session overwrite vs different-session `already_recorded` 409, every validation error, old-client defaults, note trim/null, cross-location isolation, REST lockdown (`permission denied` on all five tables **and** on a schema-valid INSERT), session-token abuse (location comes from the session, never the payload), and rate limiting (real 429s). **LEAKAGE: none found** — no hashes, tokens, service identifiers, or other locations' data in any response body.
- Cross-review: Fable signed off the backend after the live battery; Sol reviewed the frontend (4 findings, all fixed) and re-reviewed to **SIGNOFF: clean**.

## Deploy

Order matters: **migration → edge functions (`tip-entries`, `tip-entry-auth`) → web**. The wrapper makes the old functions safe after the migration alone; old clients keep working against the new functions by design. The 13-arg wrapper can be dropped in a later cleanup migration.

## For David to confirm (from the handoff's four questions — built on the stated defaults)

1. **Is the 18% already inside Square's Card number?** Assumed **no** (entered separately; `cash + card + gratuity` is the entry total). If it's actually inside the card figure, gratuity becomes a carve-out and totals need rework.
2. **Reflow vs fixed cut** — built **reflow** (weighted; one person at 50% raises everyone else), per the default and the mockup.
3. **Who sets a partial share** — the closer at entry; the manager can change weights in Fix.
4. Missing-lunch silence was pre-decided and is implemented (flag only, nothing at the register).

## Spec discrepancies flagged (resolved by "the live mockup wins")

- The handoff's `$118 → 39.33/39.33/39.34` vector contradicts both its own `$205` vector and the mockup's live `allocate()` (stable sort ⇒ earliest position wins ties). Built to the live mockup: `39.34/39.33/39.33`.
- The mockup's spec footnote says the CSV gains `auto_grat`; the revised handoff bans "auto-grat" — the CSV header is `Gratuity`.
- The split strip changes from cash+card to **cash-pool-only** (mockup: `of $205.00 cash`); existing e2e assertions were updated accordingly.
- `e2e/landing.spec.ts` had a stale "Scan the sticker" assertion (copy changed on main in 536618e) — updated to "Scan the QR code"; pre-existing, unrelated to v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
