### PR TITLE
Tips: live schema contract check, sidebar toggle, unsquashed logo

### DIFF
--- a/scripts/local-db/verify-migrations.sh
+++ b/scripts/local-db/verify-migrations.sh
@@ -20,8 +20,10 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 MIGRATIONS_DIR="$REPO_ROOT/supabase/migrations"
 BASELINE="$SCRIPT_DIR/baseline_public_schema.sql"
 AUTH_STUB="$SCRIPT_DIR/auth_stub.sql"
-# The snapshot was captured after this production migration on 2026-08-11.
-BASELINE_MIGRATION_CUTOFF="20260811204219_tip_entry_session_duplicate_guard.sql"
+# The snapshot was captured on 2026-08-11 after this production migration. It
+# predates 20260811204219 (no tip_entries.entry_session_id, 12-argument
+# tip_save_entry), so that file must be applied on top of it.
+BASELINE_MIGRATION_CUTOFF="20260807101000_tip_set_updated_at_search_path.sql"
 
 KEEP=false
 if [[ "${1:-}" == "--keep" ]]; then

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "vitest run",
     "typecheck": "next typegen && tsc --noEmit",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "check:schema": "LIVE_SCHEMA_CHECK=1 vitest run src/lib/tips/__tests__/schemaContract.live.test.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.12.4",

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -16,6 +16,7 @@ import {
   type LedgerEntry,
 } from "@/lib/tips/dashboardDerive";
 import { shortDayLabel } from "@/lib/tips/dashboardRange";
+import { FIX_ENTRY_RPC, FIX_ENTRY_SELECT } from "@/lib/tips/dashboardQueries";
 import { fullShareCents as poolFullShareCents } from "@/lib/tips/split";
 import {
   btn,
@@ -138,9 +139,7 @@ async function readFixEntryState(
 ): Promise<FixEntryState> {
   const { data, error } = await supabase
     .from("tip_entries")
-    .select(
-      "cash_amount, card_amount, gratuity_amount, entered_scope, raw_cash_amount, raw_card_amount, raw_gratuity_amount, split_count, note, tip_entry_people(tip_employee_id, share_weight)",
-    )
+    .select(FIX_ENTRY_SELECT)
     .eq("id", entryId)
     .maybeSingle();
   if (error) throw new Error(error.message);
@@ -288,7 +287,7 @@ function FixDialog({
     // Amounts, scope, raw inputs, note, split count, roster, and weights must
     // commit together; a partial manager correction would corrupt the ledger.
     try {
-      const { error: fixError } = await supabase.rpc("tip_manager_fix_entry", {
+      const { error: fixError } = await supabase.rpc(FIX_ENTRY_RPC, {
         p_entry_id: entry.id,
         p_cash: derivedCents.cash / 100,
         p_card: derivedCents.card / 100,

--- a/web/src/components/manager/dashboard/Sidebar.tsx
+++ b/web/src/components/manager/dashboard/Sidebar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-// Collapsible sidebar: 216px full ↔ 66px icon rail. Pages, then profile +
-// Log out pinned to the bottom. Nav icons come straight from the approved
-// mockup.
+// Collapsible sidebar: 216px full ↔ 66px icon rail. Brand row with a quiet
+// collapse control, pages, then profile + Log out pinned to the bottom. Nav
+// icons and the toggle treatment come from the approved mockup
+// (docs/mockups/tips-dashboard/tip-dashboard-final.html, #sidenav).
 
 import type { NavId } from "./types";
 import { SmelterLogo, SmelterMark } from "@/components/Logo";
@@ -74,28 +75,31 @@ export function Sidebar({
   profileEmail: string;
   onSignOut: () => void;
 }) {
+  const toggleLabel = collapsed ? "Expand sidebar" : "Collapse sidebar";
   return (
     <aside
       className={`sticky top-0 flex h-screen flex-none flex-col border-r border-line bg-card ${
         collapsed ? "w-[66px] px-[9px]" : "w-[216px] px-3"
       } py-[18px]`}
     >
+      {/* Brand row. The lockup is never padded or constrained: its box is
+          its exact rendered size, so the artwork cannot be squashed. The
+          toggle is a quiet icon button at the far edge; in the rail it
+          stacks under the mark. */}
       <div
-        className={`mb-3 flex items-center ${
-          collapsed ? "justify-center" : "justify-between"
+        className={`mb-4 flex ${
+          collapsed ? "flex-col items-center gap-2" : "items-center gap-1.5 pl-1.5"
         }`}
       >
-        {collapsed ? (
-          <SmelterMark size={24} />
-        ) : (
-          <SmelterLogo height={26} className="px-2" />
-        )}
+        {collapsed ? <SmelterMark size={28} /> : <SmelterLogo height={28} />}
+        {!collapsed && <span className="min-w-0 flex-1" />}
         <button
           type="button"
           onClick={onToggleCollapsed}
-          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          className="flex h-9 w-9 flex-none items-center justify-center rounded-[10px] border border-line bg-well text-ink2 hover:bg-tint hover:text-ink"
+          aria-label={toggleLabel}
+          aria-expanded={!collapsed}
+          title={toggleLabel}
+          className="flex h-7 w-7 flex-none items-center justify-center rounded-[7px] text-ink2 opacity-70 transition-[opacity,background-color] hover:bg-well hover:opacity-100 focus-visible:opacity-100"
         >
           <svg
             viewBox="0 0 24 24"
@@ -105,10 +109,9 @@ export function Sidebar({
             strokeLinecap="round"
             strokeLinejoin="round"
             aria-hidden
-            className={`h-[18px] w-[18px] ${collapsed ? "rotate-180" : ""}`}
+            className={`h-4 w-4 ${collapsed ? "rotate-180" : ""}`}
           >
-            <path d="M11 7l-5 5 5 5" />
-            <path d="M18 7l-5 5 5 5" />
+            <path d="M15 6l-6 6 6 6" />
           </svg>
         </button>
       </div>

--- a/web/src/components/manager/dashboard/useDashboardData.ts
+++ b/web/src/components/manager/dashboard/useDashboardData.ts
@@ -11,6 +11,7 @@ import { businessDateFor } from "@/lib/tips/businessDate";
 import { addDays, rangeBounds, type DashboardRange } from "@/lib/tips/dashboardRange";
 import type { LedgerEntry } from "@/lib/tips/dashboardDerive";
 import { fetchAll } from "../fetchAll";
+import { DASHBOARD_SELECTS } from "@/lib/tips/dashboardQueries";
 import {
   toLocationInfo,
   type DashboardData,
@@ -98,7 +99,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
           // one locations request also gets each missing-shift floor.
           supabase
             .from("locations")
-            .select("id, name, tip_entries(business_date)")
+            .select(DASHBOARD_SELECTS.locations)
             .order("name")
             .order("business_date", { ascending: true, referencedTable: "tip_entries" })
             .limit(1, { referencedTable: "tip_entries" })
@@ -108,7 +109,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
             }),
           supabase
             .from("tip_employees")
-            .select("id, name, location_id, active, sort_order")
+            .select(DASHBOARD_SELECTS.tip_employees)
             .order("active", { ascending: false })
             .order("sort_order", { ascending: true })
             .order("name", { ascending: true })
@@ -118,7 +119,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
             }),
           supabase
             .from("tip_employee_schedules")
-            .select("id, tip_employee_id, location_id, weekday, meal, created_at")
+            .select(DASHBOARD_SELECTS.tip_employee_schedules)
             .order("id")
             .then((r) => {
               if (r.error) throw new Error(r.error.message);
@@ -126,7 +127,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
             }),
           supabase
             .from("tip_location_access")
-            .select("location_id, token_rotated_at, entry_token_plain")
+            .select(DASHBOARD_SELECTS.tip_location_access)
             .then((r) => {
               if (r.error) throw new Error(r.error.message);
               return r.data ?? [];
@@ -134,9 +135,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
           fetchAll<RawEntryRow>((from, to) =>
             supabase
               .from("tip_entries")
-              .select(
-                "id, business_date, location_id, meal_period, cash_amount, card_amount, gratuity_amount, entered_scope, raw_cash_amount, raw_card_amount, raw_gratuity_amount, note, note_at, split_count, entry_method, entered_by, flagged_anomaly, anomaly_reason, flag_verified_at, created_at, tip_entry_people(tip_employee_id, share_weight)",
-              )
+              .select(DASHBOARD_SELECTS.tip_entries)
               .gte("business_date", start)
               .lte("business_date", end)
               .order("business_date", { ascending: false })
@@ -147,7 +146,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
           fetchAll<RawSessionRow>((from, to) =>
             supabase
               .from("tip_entry_sessions")
-              .select("id, location_id, closer_id, created_at")
+              .select(DASHBOARD_SELECTS.tip_entry_sessions)
               .gte("created_at", sessionsFloor)
               .lt("created_at", sessionsCeil)
               .order("created_at", { ascending: false })

--- a/web/src/lib/tips/__tests__/schemaContract.live.test.ts
+++ b/web/src/lib/tips/__tests__/schemaContract.live.test.ts
@@ -1,0 +1,116 @@
+// Live schema contract: every select and RPC the Tip Dashboard sends must be
+// accepted by the database the web app is configured against.
+//
+// Skipped unless LIVE_SCHEMA_CHECK=1 (`npm run check:schema`). Read-only.
+//
+// By default it runs as the anon role, which either sees zero rows (200) or is
+// denied the table outright (42501). Postgres resolves the column list before
+// it checks privileges, so a column the schema lacks still surfaces as 42703
+// and a missing function as 404 / PGRST202. That proves the schema, not the
+// manager's grants or RLS. Set LIVE_SCHEMA_BEARER to a signed-in manager's
+// access token to run as that user instead; then every select must return
+// 200. Credentials come from the environment or web/.env.local.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  DASHBOARD_SELECTS,
+  FIX_ENTRY_RPC,
+  FIX_ENTRY_RPC_ARGS,
+  FIX_ENTRY_SELECT,
+} from "../dashboardQueries";
+
+const ENABLED = process.env.LIVE_SCHEMA_CHECK === "1";
+
+function readEnvFile(): Record<string, string> {
+  try {
+    const text = readFileSync(fileURLToPath(new URL("../../../../.env.local", import.meta.url)), "utf8");
+    const out: Record<string, string> = {};
+    for (const line of text.split("\n")) {
+      const match = /^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/.exec(line);
+      if (match) out[match[1]] = match[2].replace(/^["']|["']$/g, "");
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+const BEARER = process.env.LIVE_SCHEMA_BEARER?.trim() || null;
+
+function credentials(): { url: string; key: string } {
+  const file = readEnvFile();
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? file.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? file.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY not set (env or web/.env.local)");
+  }
+  return { url: url.replace(/\/$/, ""), key };
+}
+
+async function rest(path: string, init: RequestInit = {}) {
+  const { url, key } = credentials();
+  const response = await fetch(`${url}/rest/v1/${path}`, {
+    ...init,
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${BEARER ?? key}`,
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body: unknown = null;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { status: response.status, body };
+}
+
+/**
+ * As anon, 200 (rows or none under RLS) or 42501 (denied the table) both prove
+ * the column list parsed. As a signed-in manager only 200 will do.
+ */
+function expectSelectParsed(status: number, body: unknown, label: string) {
+  const ok = status === 200 || (BEARER === null && errorCode(body) === "42501");
+  expect(ok, `${label}: HTTP ${status} ${JSON.stringify(body)}`).toBe(true);
+}
+
+function errorCode(body: unknown): string | null {
+  return typeof body === "object" && body !== null && "code" in body && typeof body.code === "string"
+    ? body.code
+    : null;
+}
+
+describe.skipIf(!ENABLED)("Tip Dashboard schema contract (live)", () => {
+  for (const [table, select] of Object.entries(DASHBOARD_SELECTS)) {
+    it(`accepts the ${table} select`, async () => {
+      const { status, body } = await rest(`${table}?select=${encodeURIComponent(select)}&limit=1`);
+      expectSelectParsed(status, body, table);
+    });
+  }
+
+  it("accepts the Fix dialog select", async () => {
+    const { status, body } = await rest(
+      `tip_entries?select=${encodeURIComponent(FIX_ENTRY_SELECT)}&limit=1`,
+    );
+    expectSelectParsed(status, body, "fix dialog");
+  });
+
+  it(`exposes ${FIX_ENTRY_RPC} with the v3 argument set`, async () => {
+    // Anon is not a manager, so a present function answers with a permission
+    // or manager-check error. Only "no such function" (PGRST202) or an
+    // ambiguous overload (PGRST203) fails this test.
+    const args = Object.fromEntries(FIX_ENTRY_RPC_ARGS.map((name) => [name, null]));
+    const { status, body } = await rest(`rpc/${FIX_ENTRY_RPC}`, {
+      method: "POST",
+      body: JSON.stringify(args),
+    });
+    const code = errorCode(body);
+    expect(status, JSON.stringify(body)).not.toBe(404);
+    expect(code, JSON.stringify(body)).not.toMatch(/^PGRST20[23]$/);
+  });
+});

--- a/web/src/lib/tips/dashboardQueries.ts
+++ b/web/src/lib/tips/dashboardQueries.ts
@@ -1,0 +1,48 @@
+// The exact PostgREST selects and RPC the Tip Dashboard issues, in one place.
+//
+// The pages import these so the live schema check
+// (__tests__/schemaContract.live.test.ts, `npm run check:schema`) exercises
+// the same strings the browser sends. A column or function the database does
+// not have yet fails there, before a deploy, instead of on the manager's
+// screen. Tips v3 shipped its web half ahead of its migrations once; this is
+// the seam that catches that.
+
+import type { Database } from "@/types/database";
+
+export const DASHBOARD_SELECTS = {
+  locations: "id, name, tip_entries(business_date)",
+  tip_employees: "id, name, location_id, active, sort_order",
+  tip_employee_schedules: "id, tip_employee_id, location_id, weekday, meal, created_at",
+  tip_location_access: "location_id, token_rotated_at, entry_token_plain",
+  tip_entries:
+    "id, business_date, location_id, meal_period, cash_amount, card_amount, gratuity_amount, entered_scope, raw_cash_amount, raw_card_amount, raw_gratuity_amount, note, note_at, split_count, entry_method, entered_by, flagged_anomaly, anomaly_reason, flag_verified_at, created_at, tip_entry_people(tip_employee_id, share_weight)",
+  tip_entry_sessions: "id, location_id, closer_id, created_at",
+} as const;
+
+/** What the Fix dialog reads back before and after a manager correction. */
+export const FIX_ENTRY_SELECT =
+  "cash_amount, card_amount, gratuity_amount, entered_scope, raw_cash_amount, raw_card_amount, raw_gratuity_amount, split_count, note, tip_entry_people(tip_employee_id, share_weight)" as const;
+
+export const FIX_ENTRY_RPC = "tip_manager_fix_entry" as const;
+
+type FixEntryRpcArgs = Database["public"]["Functions"][typeof FIX_ENTRY_RPC]["Args"];
+
+/**
+ * Named arguments of the Tips v3 signature; PostgREST resolves overloads by
+ * name set. `satisfies Record<keyof Args, true>` fails to compile if this list
+ * and the generated RPC type (which also types the LedgerPage call) diverge in
+ * either direction.
+ */
+export const FIX_ENTRY_RPC_ARGS = Object.keys({
+  p_entry_id: true,
+  p_cash: true,
+  p_card: true,
+  p_gratuity: true,
+  p_entered_scope: true,
+  p_raw_cash: true,
+  p_raw_card: true,
+  p_raw_gratuity: true,
+  p_people: true,
+  p_weights: true,
+  p_note: true,
+} satisfies Record<keyof FixEntryRpcArgs, true>) as ReadonlyArray<keyof FixEntryRpcArgs>;


### PR DESCRIPTION
## Why

The Tip Dashboard failed on every page with `column tip_entry_people_1.share_weight does not exist`. Tips v3 (PR #22) deployed its web half through Vercel on Aug 30 while migrations `20260827120000_tip_manager_fix_entry` and `20260828100000_tips_v3_grat_scope_weights_notes` were never applied to production and `tip-entries` / `tip-entry-auth` stayed on the Aug 26 build. Any closer save from the v3 phone UI was being stored by the old function without gratuity, share weights, note, or the day-scope lunch subtraction. The Supabase branch `tips-v3-verify` used for v3 verification is in `MIGRATIONS_FAILED`, so it never exercised the schema.

## Production state (done 2026-08-31, outside this PR)

- `supabase db push` applied both migrations (dry run listed exactly those two).
- `tip-entries` deployed as v8 (Supabase MCP, same bundle layout as the CLI, verify_jwt on).
- `tip-entry-auth` is still v7: the deploy was blocked by my session's permission classifier. Run `supabase functions deploy tip-entry-auth` to finish. Until then the entry page gets today's lunch figures from `get_slot` rather than the initial session state, which the client already handles, and the Aug 27 rate-limit hardening for token validation is not live.

## What this PR changes

- `web/src/lib/tips/dashboardQueries.ts`: every select and the RPC the dashboard sends, imported by `useDashboardData.ts` and `LedgerPage.tsx`. The RPC arg list is `satisfies`-tied to the generated `Database` type so it cannot drift from the call site.
- `npm run check:schema` (`schemaContract.live.test.ts`): replays those strings read-only against the configured Supabase project. As anon, 200 or 42501 both prove the column list parsed (Postgres resolves columns before privileges); 42703 / PGRST202 / PGRST203 fail. Set `LIVE_SCHEMA_BEARER` to a manager token to require 200 everywhere. Skipped in normal `npm test`.
- Sidebar: the collapse control is the approved mockup's quiet chevron instead of a boxed button; the rail stacks mark then toggle. The lockup had `px-2` inside its fixed-size box, compressing the artwork 13%; removed.
- `scripts/local-db/verify-migrations.sh`: baseline cutoff corrected (the snapshot predates `20260811204219`), which is why the harness failed on the v3 migration for an unrelated reason.

## Validation

- `npx tsc --noEmit` 0, `npm run lint` 0, `npm test` 232 passed / 8 skipped (web/).
- `npm run check:schema` against prod: 3 red before the migration (tip_entries select, Fix select, RPC), 8/8 green after.
- Original repro (`curl` of the dashboard select) went from 42703 to the expected anon 42501.
- Local harness: all 28 migrations apply on the prod baseline; in that DB the old 13-arg `tip_save_entry` wrapper saves with weight 1 / gratuity 0, the 20-arg RPC stores weights 0.75/0.25 + note, the `already_recorded` session guard still fires, zero weight is rejected, grants are correct.
- Ping smoke on both functions after deploy: see PR comments if anything changes.
- Codex (gpt-5.6-sol, xhigh) reviewed `568c469`: RPC arg drift and anon-only limitation fixed in `48d04f2`; the deploy-window finding is the production state described above.
- `pstack-picks:blast-radius` was not available in the session; the blast radius pass above was done by hand.

## What to look at

- Reload https://tips.babytunasystems.com/manager: Overview, Recorded tips, Staff, Devices all load; Fix dialog saves.
- Sidebar toggle top-right of the brand row; collapsed rail shows the mark, then the chevron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)