### PR TITLE
Tips: entry-screen polish, ledger closed by default, adjustable flag rules

### DIFF
--- a/web/src/components/InfoButton.tsx
+++ b/web/src/components/InfoButton.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+// Small "i" button that opens a plain-language popover. Shared by the manager
+// dashboard and the phone entry flow so hints live behind one tap instead of
+// taking up space on the screen.
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+export function InfoButton({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: MouseEvent) => {
+      if (buttonRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("click", close);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", close);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label={label}
+        aria-expanded={open}
+        onClick={() => {
+          const rect = buttonRef.current?.getBoundingClientRect();
+          if (rect) {
+            const width = Math.min(320, window.innerWidth - 32);
+            const left = Math.max(16, Math.min(rect.left, window.innerWidth - width - 16));
+            // Open upward when the trigger sits in the bottom quarter of the
+            // screen so the text cannot land below the fold.
+            const openUp = rect.bottom > window.innerHeight * 0.75;
+            setPos(
+              openUp
+                ? { left, bottom: window.innerHeight - rect.top + 8 }
+                : { left, top: rect.bottom + 8 },
+            );
+          }
+          setOpen((value) => !value);
+        }}
+        className={`h-5 w-5 flex-none rounded-full border border-line font-serif text-[11px] font-extrabold italic leading-none text-ink3 hover:border-ink3 hover:text-ink ${className}`}
+      >
+        i
+      </button>
+      {open && pos && (
+        <div
+          role="dialog"
+          className="fixed z-[80] w-[min(320px,calc(100vw-32px))] rounded-[14px] border border-line bg-card px-3.5 py-3 text-[13px] leading-relaxed text-ink2 shadow-[0_6px_24px_rgba(16,20,28,0.16)] [&_b]:text-ink"
+          style={{ left: pos.left, top: pos.top, bottom: pos.bottom }}
+        >
+          {children}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/entry/AmountWell.tsx
+++ b/web/src/components/entry/AmountWell.tsx
@@ -4,6 +4,9 @@
 // entry form amounts grid and (via the same styling) the voice sheet's inline
 // cash/card editors.
 
+import type { ReactNode } from "react";
+import { InfoButton } from "@/components/InfoButton";
+
 /**
  * Sanitize raw keyboard input to digits + one dot + max two decimals,
  * clamped to 99999.99. Empty string means "not yet entered".
@@ -37,6 +40,7 @@ export function AmountWell({
   autoFocus = false,
   onCommit,
   compact = false,
+  hint,
 }: {
   label: string;
   value: string;
@@ -46,10 +50,15 @@ export function AmountWell({
   onCommit?: (value: string) => void;
   /** Smaller type for the three-up Cash·Card·Gratuity grid. */
   compact?: boolean;
+  /** Guidance for this amount, kept behind an "i" next to the label. */
+  hint?: ReactNode;
 }) {
   return (
     <div className={`bg-well rounded-well ${compact ? "p-2.5" : "p-4"}`}>
-      <div className="section-label">{label}</div>
+      <div className="flex items-center gap-1.5">
+        <div className="section-label">{label}</div>
+        {hint && <InfoButton label={`About ${label.toLowerCase()}`}>{hint}</InfoButton>}
+      </div>
       {/* The bottom rule is the only cue that the amount is typeable — it is
           not decoration. Read-only wells (the saved screen) render their own
           markup without it. */}

--- a/web/src/components/entry/EntryForm.tsx
+++ b/web/src/components/entry/EntryForm.tsx
@@ -4,13 +4,16 @@
 // segmented (time-of-day preset; recorded shifts locked out), cash/card
 // amounts, roster split chips, live split strip, and the sticky
 // "Speak it in" / "Save" bar. Voice entry opens the VoiceSheet, whose result
-// feeds the same save flow (including the anomaly confirm). A successful
-// save shows a full-screen confirmation, then ends the session and returns
-// to the scan gate — one QR scan per entry.
+// fills the form and scrolls to the split so the closer checks who gets what
+// before pressing Save. A successful save shows a full-screen confirmation
+// (with a way back to edit), then ends the session and returns to the scan
+// gate. One QR scan per entry.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Avatar } from "@/components/Avatar";
+import { InfoButton } from "@/components/InfoButton";
+import { SmelterLogo } from "@/components/Logo";
 import {
   endSession,
   fetchState,
@@ -86,11 +89,11 @@ function MicIcon() {
   );
 }
 
-function ChevronRightIcon() {
+function ChevronRightIcon({ size = 18 }: { size?: number }) {
   return (
     <svg
-      width="18"
-      height="18"
+      width={size}
+      height={size}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -125,8 +128,9 @@ function CheckIcon({ size = 14 }: { size?: number }) {
 /**
  * Full-screen post-save confirmation. Holds SAVED_SCREEN_MS with a visible
  * countdown over a draining progress bar, then ends the session and sends
- * the phone back to the scan gate; "Done" skips the wait. The three wells
- * mirror the entry form's grid but are read-only — no editable underline.
+ * the phone back to the scan gate; "Done" skips the wait and "Go back and
+ * edit" returns to the filled-in form (the same session may re-save the
+ * slot). The three wells mirror the entry form's grid but are read-only.
  */
 function SavedScreen({
   payload,
@@ -136,6 +140,7 @@ function SavedScreen({
   businessDate,
   splitNames,
   onFinished,
+  onEdit,
 }: {
   payload: SavePayload;
   /** The saved row from the server — its derived figures are authoritative. */
@@ -146,6 +151,7 @@ function SavedScreen({
   businessDate: string;
   splitNames: string[];
   onFinished: () => void;
+  onEdit: () => void;
 }) {
   const totalSeconds = Math.round(SAVED_SCREEN_MS / 1000);
   const [secondsLeft, setSecondsLeft] = useState(totalSeconds);
@@ -266,13 +272,25 @@ function SavedScreen({
           style={{ width: `${(secondsLeft / totalSeconds) * 100}%` }}
         />
       </div>
-      <button
-        type="button"
-        onClick={onFinished}
-        className="mt-4 w-full rounded-full bg-card py-4 font-semibold text-ink active:bg-well"
-      >
-        Done
-      </button>
+      <div className="mt-4 flex gap-3">
+        <button
+          type="button"
+          onClick={onEdit}
+          className="flex-1 rounded-full border border-line bg-card py-4 font-semibold text-ink2 active:bg-well"
+        >
+          Go back and edit
+        </button>
+        <button
+          type="button"
+          onClick={onFinished}
+          className="flex-1 rounded-full bg-card py-4 font-semibold text-ink active:bg-well"
+        >
+          Done
+        </button>
+      </div>
+      <div className="mt-6 flex justify-center">
+        <SmelterLogo height={24} />
+      </div>
     </main>
   );
 }
@@ -358,11 +376,22 @@ export function EntryForm() {
   const [savedEntry, setSavedEntry] = useState<SlotEntry | null>(null);
   const [pickPersonWarning, setPickPersonWarning] = useState(false);
 
+  // Set by "Go back and edit": the saved meal stays editable and the other
+  // meal locks, so one scan still records one shift.
+  const [editingSavedMeal, setEditingSavedMeal] = useState<MealPeriod | null>(null);
+  // Fields the closer changed by hand after a voice result was reviewed;
+  // each counts as one more correction on the eventual save.
+  const [postVoiceEdits, setPostVoiceEdits] = useState<Set<"cash" | "card" | "people">>(
+    () => new Set(),
+  );
   const [showVoice, setShowVoice] = useState(false);
   const [showLocationDialog, setShowLocationDialog] = useState(false);
   const [voiceMeta, setVoiceMeta] = useState<VoiceMeta | null>(null);
 
   const lastPayloadRef = useRef<SavePayload | null>(null);
+  // The split readout: voice results scroll here so the closer sees who gets
+  // what before saving.
+  const splitRef = useRef<HTMLDivElement | null>(null);
   const finishedRef = useRef(false);
   // Synchronous in-flight guard: the `saving` state lags a render behind the
   // click, so two fast taps (or Save + anomaly "Save anyway") could both
@@ -711,7 +740,7 @@ export function EntryForm() {
         peopleIds: selectedIds,
         entryMethod: voiceMeta ? "voice" : "typed",
         voiceVariant: voiceMeta?.variant ?? null,
-        correctionsCount: voiceMeta?.corrections ?? 0,
+        correctionsCount: voiceMeta ? voiceMeta.corrections + postVoiceEdits.size : 0,
       }),
     );
   };
@@ -727,23 +756,45 @@ export function EntryForm() {
       variant: result.variant,
       corrections: result.correctionsCount,
     });
-    // Voice still fills cash/card/people only — the typed gratuity, scope,
-    // weights and note ride along unchanged.
-    void doSave(
-      buildPayload({
-        meal: result.meal,
-        cash: Number(result.cash),
-        card: Number(result.card),
-        peopleIds: result.peopleIds,
-        entryMethod: "voice",
-        voiceVariant: result.variant,
-        correctionsCount: result.correctionsCount,
-      }),
-    );
+    setPostVoiceEdits(new Set());
+    // Voice may have switched the shift without going through changeMeal.
+    // Confirm that slot with the server so the day-scope subtraction uses
+    // today's recorded lunch and a slot saved meanwhile locks here too.
+    if (result.meal !== meal && session) {
+      const token = session.token;
+      void getSlot(token, result.meal)
+        .then((slot) => {
+          if (slot.entry) {
+            applyAlreadyRecorded(result.meal);
+            return;
+          }
+          if (slot.today) {
+            const freshToday = slot.today;
+            setState((prev) => (prev ? { ...prev, today: freshToday } : prev));
+          }
+          setScheduledByMeal((prev) => ({ ...prev, [result.meal]: slot.scheduledIds }));
+        })
+        .catch((error: unknown) => {
+          if (isSessionInvalid(error)) {
+            clearSession();
+            router.replace("/");
+          }
+        });
+    }
+    // Voice fills cash/card/people only; the typed gratuity, scope, weights
+    // and note stay as they were. Nothing is saved yet: the closer still
+    // hands out the cash in person, so bring the split into view and let
+    // them press Save once it looks right.
+    window.setTimeout(() => {
+      splitRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 50);
   };
 
   const markTouched = useCallback((field: "cash" | "card" | "people") => {
     setTouchedFields((prev) =>
+      prev.has(field) ? prev : new Set(prev).add(field),
+    );
+    setPostVoiceEdits((prev) =>
       prev.has(field) ? prev : new Set(prev).add(field),
     );
   }, []);
@@ -797,6 +848,12 @@ export function EntryForm() {
     );
   }, [state, scheduledByMeal, meal]);
 
+  // Recorded shifts are locked; while editing a just-saved shift the other
+  // one locks too (one scan, one shift).
+  const lockedMeals: MealPeriod[] = editingSavedMeal
+    ? [...new Set<MealPeriod>([...disabledMeals, editingSavedMeal === "lunch" ? "dinner" : "lunch"])]
+    : disabledMeals;
+
   if (loading) {
     return (
       <main className="max-w-md mx-auto px-5 min-h-dvh flex items-center justify-center">
@@ -846,6 +903,11 @@ export function EntryForm() {
           )
           .filter(Boolean)}
         onFinished={finishSession}
+        onEdit={() => {
+          setEditingSavedMeal(savedPayload.meal);
+          setSavedPayload(null);
+          setSavedEntry(null);
+        }}
       />
     );
   }
@@ -881,16 +943,16 @@ export function EntryForm() {
           </div>
         </header>
 
-        {/* Location */}
+        {/* Location: a pill the size of the date and closer chips. */}
         <button
           type="button"
           onClick={() => setShowLocationDialog(true)}
-          className="w-full bg-card rounded-card p-4 flex items-center gap-3 text-left"
+          className="bg-card rounded-full px-3 py-1.5 text-sm text-ink inline-flex items-center gap-2"
         >
           <span className="w-2 h-2 rounded-full bg-accent shrink-0" aria-hidden />
-          <span className="font-semibold text-ink">{state.location.name}</span>
-          <span className="ml-auto text-ink3">
-            <ChevronRightIcon />
+          <span className="font-semibold">{state.location.name}</span>
+          <span className="text-ink3">
+            <ChevronRightIcon size={14} />
           </span>
         </button>
 
@@ -900,14 +962,16 @@ export function EntryForm() {
           value={meal}
           onChange={(next) => void changeMeal(next)}
           disabled={slotLoading}
-          disabledValues={disabledMeals}
+          disabledValues={lockedMeals}
+          disabledHints={{
+            lunch: disabledMeals.includes("lunch")
+              ? "Lunch is already recorded for today."
+              : "Scan the QR code again to enter lunch.",
+            dinner: disabledMeals.includes("dinner")
+              ? "Dinner is already recorded for today."
+              : "Scan the QR code again to enter dinner.",
+          }}
         />
-        {disabledMeals.length === 1 && (
-          <p className="text-sm text-ink3">
-            {disabledMeals[0] === "lunch" ? "Lunch" : "Dinner"} is already
-            recorded today — ask a manager if it needs a fix
-          </p>
-        )}
 
         {/* Amounts */}
         <div className="bg-card rounded-card p-4">
@@ -926,11 +990,9 @@ export function EntryForm() {
               value={gratuity}
               onChange={handleGratuityChange}
               compact
+              hint="Leave gratuity blank on a night with no large parties."
             />
           </div>
-          <p className="mt-2 text-sm text-ink3">
-            Leave gratuity blank on a night with no large parties.
-          </p>
           {meal === "dinner" && (
             <div className="mt-3 grid gap-1 border-t border-dashed border-line pt-2.5 text-sm tabular-nums">
               <div className="flex text-ink2">
@@ -943,7 +1005,7 @@ export function EntryForm() {
               </div>
               {scope === "day" && (
                 <div className="flex text-ink2">
-                  <span>&minus; Lunch already recorded</span>
+                  <span>Lunch amount</span>
                   <span className="ml-auto font-semibold text-alert">
                     &minus;
                     {formatMoney(
@@ -965,7 +1027,7 @@ export function EntryForm() {
               for the manager. */}
           {negativeAfterLunch && (
             <div className="mt-3 rounded-well bg-tint p-3 text-sm text-alert">
-              Lunch already recorded more than this. Check the Square report —{" "}
+              Lunch already recorded more than this. Check the Square report.{" "}
               <b>Save is off until this is fixed.</b>
             </div>
           )}
@@ -973,11 +1035,12 @@ export function EntryForm() {
 
         {/* Roster */}
         <div className="bg-card rounded-card p-4">
-          <div className="flex items-baseline">
+          <div className="flex items-center gap-1.5">
             <div className="section-label">Who&apos;s splitting</div>
-            <span className="ml-auto text-sm text-ink3">
-              tap a badge to change a share
-            </span>
+            <InfoButton label="About splitting">
+              Tap a name to add or remove them. Tap the % badge on a selected name to
+              give them a smaller share.
+            </InfoButton>
           </div>
           <div className="mt-3">
             <RosterChips
@@ -1004,7 +1067,9 @@ export function EntryForm() {
           }))}
         />
 
-        <SplitStrip poolCents={poolCents} weights={selectedWeights} />
+        <div ref={splitRef}>
+          <SplitStrip poolCents={poolCents} weights={selectedWeights} />
+        </div>
 
         <NoteField note={note} onChange={setNote} />
       </div>

--- a/web/src/components/entry/RosterChips.tsx
+++ b/web/src/components/entry/RosterChips.tsx
@@ -3,8 +3,8 @@
 // Toggleable name pills for "who's splitting". Selected = filled accent red.
 // Selected chips carry a % badge (Tips v3 partial shares): tapping the badge
 // cycles 100 → 75 → 50 → 25 → 100 without toggling the person; tapping the
-// chip body still toggles selection. The badge is its own hit target (≥28px)
-// even though it renders small.
+// chip body still toggles selection. The badge is its own hit target (≥36px)
+// and reads at chip-text size so it is easy to hit with a thumb.
 
 import type { RosterPerson } from "@/lib/tips/api";
 
@@ -56,9 +56,9 @@ export function RosterChips({
                 type="button"
                 aria-label={`${person.name} share ${Math.round(weight * 100)}%`}
                 onClick={() => onCycleWeight(person.id)}
-                className="flex min-h-[28px] min-w-[28px] items-center rounded-full rounded-l-none bg-accent pl-1 pr-2.5 text-white"
+                className="flex min-h-[40px] min-w-[44px] items-center rounded-full rounded-l-none bg-accent pl-1 pr-2.5 text-white"
               >
-                <span className="rounded-full bg-white px-1.5 py-0.5 text-[10.5px] font-extrabold text-alert">
+                <span className="rounded-full bg-white px-2 py-1 text-[13px] font-extrabold leading-none text-alert">
                   {Math.round(weight * 100)}%
                 </span>
               </button>

--- a/web/src/components/entry/Segmented.tsx
+++ b/web/src/components/entry/Segmented.tsx
@@ -3,7 +3,11 @@
 // White pill-track segmented control (Lunch | Dinner). `compact` renders the
 // smaller inline variant used inside the voice sheet checklist.
 // `disabledValues` grays out individual options (an already-recorded shift
-// can't be picked again).
+// can't be picked again); `disabledHints` puts the reason behind an "i" on
+// that option instead of a line of text under the control.
+
+import type { ReactNode } from "react";
+import { InfoButton } from "@/components/InfoButton";
 
 export interface SegmentedOption<T extends string> {
   value: T;
@@ -17,6 +21,7 @@ export function Segmented<T extends string>({
   compact = false,
   disabled = false,
   disabledValues = [],
+  disabledHints,
   wellTrack = false,
 }: {
   options: ReadonlyArray<SegmentedOption<T>>;
@@ -26,6 +31,8 @@ export function Segmented<T extends string>({
   disabled?: boolean;
   /** Individual options that can't be selected (e.g. recorded shifts). */
   disabledValues?: ReadonlyArray<T>;
+  /** Why an option is disabled, shown in a popover from an "i" on the option. */
+  disabledHints?: Partial<Record<T, ReactNode>>;
   /** Cream track for use inside white cards (voice sheet inline editor). */
   wellTrack?: boolean;
 }) {
@@ -38,27 +45,39 @@ export function Segmented<T extends string>({
     >
       {options.map((option) => {
         const selected = option.value === value;
-        const optionDisabled = disabled || disabledValues.includes(option.value);
-        return (
+        // Locked = this option can't be picked today (a recorded shift). A
+        // global `disabled` (a slot fetch in flight) only dims the control.
+        const locked = disabledValues.includes(option.value);
+        const hint = locked ? disabledHints?.[option.value] : undefined;
+        const tab = (
           <button
-            key={option.value}
+            key={hint ? undefined : option.value}
             type="button"
             role="tab"
             aria-selected={selected}
-            disabled={optionDisabled}
+            disabled={disabled || locked}
             onClick={() => onChange(option.value)}
-            className={`flex-1 rounded-full text-center font-semibold ${
+            className={`${hint ? "" : "flex-1"} rounded-full text-center font-semibold ${
               compact ? "py-1.5 text-sm" : "py-2.5"
             } ${
               selected
                 ? "bg-accent text-white"
-                : optionDisabled
+                : locked
                   ? "text-disabled line-through"
                   : "text-ink2"
             }`}
           >
             {option.label}
           </button>
+        );
+        if (!hint) return tab;
+        // The "i" cannot live inside the tab button, so it sits beside it in
+        // the same flex cell; the pair keeps the cell's height and centring.
+        return (
+          <span key={option.value} className="flex flex-1 items-center justify-center gap-1.5">
+            {tab}
+            <InfoButton label={`About ${option.label}`}>{hint}</InfoButton>
+          </span>
         );
       })}
     </div>

--- a/web/src/components/entry/VoiceSheet.tsx
+++ b/web/src/components/entry/VoiceSheet.tsx
@@ -4,7 +4,9 @@
 // tip-voice-parse after each speech pause, and fills a five-row checklist
 // (Location, Shift, Cash, Card, People). Every field stays editable by tap.
 // "Done talking" moves to a review state with low-confidence flags and
-// per-field re-record; "Save tips" hands the values back to the entry form.
+// per-field re-record; "Review split" hands the values back to the entry
+// form, which scrolls to the split so the closer can check who gets what
+// before pressing Save.
 //
 // Engines: where the browser supports native SpeechRecognition (variant
 // "local_live"), words are transcribed ON DEVICE and parsed locally — fields
@@ -64,10 +66,10 @@ const MEAL_OPTIONS = [
 ] as const;
 
 const WAITING_TEXT: Record<Exclude<RowKey, "location">, string> = {
-  meal: "Waiting — say the shift",
-  cash: "Waiting — say the cash amount",
-  card: "Waiting — say the card amount",
-  people: "Waiting — say the names",
+  meal: "Waiting. Say the shift",
+  cash: "Waiting. Say the cash amount",
+  card: "Waiting. Say the card amount",
+  people: "Waiting. Say the names",
 };
 
 const ROW_LABELS: Record<RowKey, string> = {
@@ -840,7 +842,7 @@ export function VoiceSheet({
           <div className="w-10 h-1.5 rounded-full bg-disabled mx-auto mt-3" />
           <div className="p-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] space-y-4">
             <div className="bg-card rounded-card p-5 text-ink2">
-              Can&apos;t use the mic on this phone — type it in instead.
+              Can&apos;t use the mic on this phone. Type it in instead.
             </div>
             <button
               type="button"
@@ -1054,7 +1056,7 @@ export function VoiceSheet({
 
           {voiceBroken && (
             <div className="bg-tint text-alert rounded-well p-3 text-sm">
-              Voice isn&apos;t working right now — your captured fields are
+              Voice isn&apos;t working right now. Your captured fields are
               kept. Tap rows to finish typing.
             </div>
           )}
@@ -1068,7 +1070,7 @@ export function VoiceSheet({
 
           {listening ? (
             <div className="bg-card rounded-card p-4 text-ink2 text-sm">
-              Speak in any order — it fills in what it hears. Tap any row to
+              Speak in any order and it fills in what it hears. Tap any row to
               type it.
             </div>
           ) : (
@@ -1084,14 +1086,14 @@ export function VoiceSheet({
 
           {parseWarning && !voiceBroken && (
             <p className="text-alert text-sm">
-              Voice is having trouble — captured fields are kept
+              Voice is having trouble. Captured fields are kept.
             </p>
           )}
 
           {mealLockedHint && (
             <p className="text-alert text-sm">
               {mealLockedHint === "lunch" ? "Lunch" : "Dinner"} is already
-              recorded today — keeping{" "}
+              recorded today, so this stays on{" "}
               {mealLockedHint === "lunch" ? "dinner" : "lunch"}.
             </p>
           )}
@@ -1134,7 +1136,7 @@ export function VoiceSheet({
                   canSave ? "bg-accent" : "bg-disabled"
                 }`}
               >
-                Save tips →
+                Review split →
               </button>
             </div>
           )}

--- a/web/src/components/manager/dashboard/DashboardShell.tsx
+++ b/web/src/components/manager/dashboard/DashboardShell.tsx
@@ -16,6 +16,7 @@ import {
   thisWeek,
   type DashboardRange,
 } from "@/lib/tips/dashboardRange";
+import { applyFlagRules } from "@/lib/tips/flagRules";
 import { deriveMissingShifts } from "@/lib/tips/schedule";
 import { DevicesPage } from "./DevicesPage";
 import { LedgerPage } from "./LedgerPage";
@@ -25,6 +26,7 @@ import { StaffPage } from "./StaffPage";
 import { Toolbar } from "./Toolbar";
 import { btn, ToastProvider, useToast } from "./ui";
 import { useDashboardData } from "./useDashboardData";
+import { useFlagRules } from "./useFlagRules";
 import type { LocFilter, NavId, PageContext } from "./types";
 
 const SIDEBAR_KEY = "bt_dash_sidebar";
@@ -88,6 +90,7 @@ function ShellInner({
   }, []);
 
   const { data, loading, error, refetch } = useDashboardData(range);
+  const [flagRules, setFlagRules] = useFlagRules();
 
   const navigate = useCallback((next: NavId) => {
     setNav(next);
@@ -100,7 +103,10 @@ function ShellInner({
       (location) => loc === "both" || location.kind === loc,
     );
     const visibleIds = new Set(visibleLocations.map((location) => location.id));
-    const entries = data.entries.filter((entry) => visibleIds.has(entry.locationId));
+    // "Needs attention" follows the manager's flag rules on every page.
+    const entries = data.entries
+      .filter((entry) => visibleIds.has(entry.locationId))
+      .map((entry) => applyFlagRules(entry, flagRules));
     const bounds = rangeBounds(range);
     const missing = deriveMissingShifts({
       schedules: data.schedules,
@@ -128,8 +134,10 @@ function ShellInner({
       userId,
       navigate,
       refetch,
+      flagRules,
+      setFlagRules,
     };
-  }, [data, loc, range, today, userId, navigate, refetch]);
+  }, [data, loc, range, today, userId, navigate, refetch, flagRules, setFlagRules]);
 
   const totals = ctx ? rangeTotals(ctx.entries) : null;
   const attention = Boolean(
@@ -151,7 +159,7 @@ function ShellInner({
       (locationId) => ctx.locationById.get(locationId)?.label ?? locationId,
     );
     downloadCsv(`smelter-tips_${bounds.start}_${bounds.end}.csv`, csv);
-    toast(`CSV exported — ${ctx.entries.length} rows (${ctx.rangeLabel})`);
+    toast(`CSV exported: ${ctx.entries.length} rows (${ctx.rangeLabel})`);
   }, [ctx, range, toast]);
 
   return (

--- a/web/src/components/manager/dashboard/FlagRulesMenu.tsx
+++ b/web/src/components/manager/dashboard/FlagRulesMenu.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+// "Flag rules" popover for the Recorded tips header: which conditions turn a
+// row red. Two switches for the flags the phone records at save time and two
+// optional dollar limits evaluated here on the dashboard.
+
+import { useState } from "react";
+import type { FlagRules } from "@/lib/tips/flagRules";
+import { btn, ModalShell } from "./ui";
+
+function dollarsFromCents(cents: number | null): string {
+  return cents === null ? "" : (cents / 100).toFixed(cents % 100 === 0 ? 0 : 2);
+}
+
+/** "300" or "300.50" → cents ($0 is a valid limit); blank or invalid → null (off). */
+function centsFromDollars(value: string): number | null {
+  const stripped = value.replace(/[$,\s]/g, "");
+  if (stripped === "" || !/^\d+(\.\d{0,2})?$/.test(stripped)) return null;
+  return Math.round(Number(stripped) * 100);
+}
+
+const switchRow = "flex items-start gap-3 py-2.5";
+const limitInput =
+  "w-28 rounded-[10px] border border-line bg-well px-2.5 py-1.5 text-[13px] tabular-nums text-ink outline-none focus:border-accent";
+
+export function FlagRulesMenu({
+  rules,
+  onChange,
+}: {
+  rules: FlagRules;
+  onChange: (rules: FlagRules) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [cashText, setCashText] = useState(() => dollarsFromCents(rules.cashOverCents));
+  const [cardText, setCardText] = useState(() => dollarsFromCents(rules.cardOverCents));
+
+  // Limits commit on blur and again on close, so Escape or a backdrop tap
+  // after typing a figure keeps it.
+  const commitLimits = () => {
+    const cash = centsFromDollars(cashText);
+    const card = centsFromDollars(cardText);
+    setCashText(dollarsFromCents(cash));
+    setCardText(dollarsFromCents(card));
+    if (cash !== rules.cashOverCents || card !== rules.cardOverCents) {
+      onChange({ ...rules, cashOverCents: cash, cardOverCents: card });
+    }
+  };
+  const close = () => {
+    commitLimits();
+    setOpen(false);
+  };
+
+  const activeCount =
+    Number(rules.noLunch) +
+    Number(rules.unusualAmounts) +
+    Number(rules.cashOverCents !== null) +
+    Number(rules.cardOverCents !== null);
+
+  return (
+    <>
+      <button type="button" className={`${btn} ml-auto`} onClick={() => setOpen(true)}>
+        Flag rules · {activeCount} on
+      </button>
+      {open && (
+        <ModalShell title="What gets flagged" onClose={close}>
+          <p className="text-[13px] text-ink2">
+            A flagged row shows in red with a Verify button until you check it. Changing a
+            rule re-checks every recorded shift; verified rows stay clear.
+          </p>
+          <div className="mt-3 divide-y divide-hairline">
+            <label className={switchRow}>
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 accent-accent"
+                checked={rules.noLunch}
+                onChange={(event) => onChange({ ...rules, noLunch: event.target.checked })}
+              />
+              <span className="text-[13.5px] text-ink">
+                <b>Lunch was never entered</b>
+                <span className="block text-[12.5px] text-ink2">
+                  A whole-day dinner total was saved with no lunch recorded to subtract.
+                </span>
+              </span>
+            </label>
+            <label className={switchRow}>
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 accent-accent"
+                checked={rules.unusualAmounts}
+                onChange={(event) =>
+                  onChange({ ...rules, unusualAmounts: event.target.checked })
+                }
+              />
+              <span className="text-[13.5px] text-ink">
+                <b>Unusual cash or card amount</b>
+                <span className="block text-[12.5px] text-ink2">
+                  Far above what that shift usually records over the last 4 weeks.
+                </span>
+              </span>
+            </label>
+            <div className={switchRow}>
+              <span className="mt-1 h-4 w-4 flex-none" aria-hidden />
+              <span className="text-[13.5px] text-ink">
+                <b>Amount limits</b>
+                <span className="block text-[12.5px] text-ink2">
+                  Flag any shift over these figures. Leave blank to turn a limit off.
+                </span>
+                <span className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 text-[13px] text-ink2">
+                  <label className="flex items-center gap-2">
+                    Cash over $
+                    <input
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="off"
+                      className={limitInput}
+                      value={cashText}
+                      onChange={(event) => setCashText(event.target.value)}
+                      onBlur={commitLimits}
+                    />
+                  </label>
+                  <label className="flex items-center gap-2">
+                    Card over $
+                    <input
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="off"
+                      className={limitInput}
+                      value={cardText}
+                      onChange={(event) => setCardText(event.target.value)}
+                      onBlur={commitLimits}
+                    />
+                  </label>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end">
+            <button type="button" className={btn} onClick={close}>
+              Done
+            </button>
+          </div>
+        </ModalShell>
+      )}
+    </>
+  );
+}

--- a/web/src/components/manager/dashboard/LedgerPage.tsx
+++ b/web/src/components/manager/dashboard/LedgerPage.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-// Recorded tips — the dense ledger (Tips v3, option D2). Rows newest-first
+// Recorded tips, the dense ledger (Tips v3, option D2). Rows newest-first
 // grouped by day with day-total rows; tinted cash/card column groups; flagged
-// rows get a red tint, a "⚑ check" chip, and a Verify button. Clicking a row
-// unfolds a three-card detail panel: how the number was reached (raw →
-// −lunch → recorded, then card and gratuity), who takes what (weighted), and
-// the note. Fix updates every v3 field through one atomic manager RPC.
+// rows get a red tint, a "⚑ check" chip, and a Verify button. Every row
+// starts closed; clicking it unfolds a three-card detail panel: how the
+// number was reached (entered, lunch amount, recorded, then card and
+// gratuity) with the flag reasons in plain English, who takes what
+// (weighted), and the note. Which conditions flag a row is set in the
+// "Flag rules" menu. Fix updates every v3 field through one atomic RPC.
 
 import { Fragment, useMemo, useState } from "react";
 import { getSupabase } from "@/lib/supabase";
@@ -17,6 +19,7 @@ import {
 } from "@/lib/tips/dashboardDerive";
 import { shortDayLabel } from "@/lib/tips/dashboardRange";
 import { FIX_ENTRY_RPC, FIX_ENTRY_SELECT } from "@/lib/tips/dashboardQueries";
+import { flagReasons, NO_LUNCH_CODE } from "@/lib/tips/flagRules";
 import { fullShareCents as poolFullShareCents } from "@/lib/tips/split";
 import {
   btn,
@@ -32,6 +35,7 @@ import {
   th,
   useToast,
 } from "./ui";
+import { FlagRulesMenu } from "./FlagRulesMenu";
 import type { EmployeeRow, PageContext } from "./types";
 
 function methodLabel(entry: LedgerEntry): string {
@@ -348,7 +352,7 @@ function FixDialog({
   return (
     <ModalShell
       wide
-      title={`Fix — ${shortDayLabel(entry.businessDate)} · ${location?.label ?? "?"} ${entry.meal}`}
+      title={`Fix ${shortDayLabel(entry.businessDate)} · ${location?.label ?? "?"} ${entry.meal}`}
       onClose={busy ? () => {} : onClose}
     >
       {entry.meal === "dinner" && (
@@ -491,7 +495,7 @@ function FixDialog({
       )}
       {negativeAfterLunch && (
         <p className="mt-3 text-sm text-alert">
-          Lunch already recorded more than this — the whole-day figures can&apos;t
+          Lunch already recorded more than this. The whole-day figures can&apos;t
           be below the recorded lunch.
         </p>
       )}
@@ -528,6 +532,7 @@ function FixDialog({
 function DetailPanel({
   entry,
   lunchEntry,
+  reasons,
   onFix,
   onVerify,
   verifying,
@@ -535,6 +540,8 @@ function DetailPanel({
   entry: LedgerEntry;
   /** The recorded lunch row at the same location + business date, if shown. */
   lunchEntry: LedgerEntry | null;
+  /** Why the row is flagged under the current rules (empty when it is not). */
+  reasons: string[];
   onFix: () => void;
   onVerify: () => void;
   verifying: boolean;
@@ -542,7 +549,7 @@ function DetailPanel({
   const shares = entryShareCents(entry);
   // Prefix match: when the save was ALSO a statistical outlier the reason is
   // "day_total_no_lunch; <statistical reason>" (contract amendment 2).
-  const noLunchFlag = entry.anomalyReason?.startsWith("day_total_no_lunch") ?? false;
+  const noLunchFlag = entry.anomalyReason?.startsWith(NO_LUNCH_CODE) ?? false;
   // What was actually subtracted at save time — shown from the raw figures,
   // not the current lunch row (which a fix may have changed since).
   const subtractedCents =
@@ -563,11 +570,11 @@ function DetailPanel({
               </div>
               <div className="flex text-ink2">
                 <span>
-                  &minus; lunch recorded
-                  {lunchEntry && !noLunchFlag ? ` ${timeLabel(lunchEntry.createdAt)}` : ""}
+                  Lunch amount
+                  {lunchEntry && !noLunchFlag ? ` (recorded ${timeLabel(lunchEntry.createdAt)})` : ""}
                 </span>
                 {noLunchFlag ? (
-                  <span className="ml-auto font-semibold text-alert">nothing on record</span>
+                  <span className="ml-auto font-semibold text-alert">not entered</span>
                 ) : (
                   <span className="ml-auto font-semibold text-alert">
                     &minus;{moneyFromCents(subtractedCents ?? 0)}
@@ -586,11 +593,17 @@ function DetailPanel({
             </div>
           )}
         </div>
-        {noLunchFlag && (
-          <p className="mt-2 text-[12.5px] text-alert">
-            Flagged <code className="rounded bg-well px-1">day_total_no_lunch</code> — a
-            whole-day total was entered with no lunch to subtract.
-          </p>
+        {reasons.length > 0 && (
+          <div className="mt-2 rounded-[10px] bg-flagtint px-2.5 py-2 text-[12.5px] leading-relaxed text-alert">
+            <b className="block text-[11px] font-extrabold uppercase tracking-[0.06em]">
+              Why this is flagged
+            </b>
+            {reasons.map((reason) => (
+              <p key={reason} className="mt-1">
+                {reason}
+              </p>
+            ))}
+          </div>
         )}
         <div className="my-2.5 h-px bg-hairline" />
         <div className="grid gap-1 text-[12.5px] tabular-nums">
@@ -686,24 +699,9 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
   const toast = useToast();
   const [fixing, setFixing] = useState<LedgerEntry | null>(null);
   const [verifying, setVerifying] = useState<string | null>(null);
+  // Every row starts closed, flagged or not; the red tint and "check" chip
+  // say which ones to open.
   const [openIds, setOpenIds] = useState<Set<string>>(() => new Set());
-  // Flagged rows auto-open their detail when the range first loads. Track the
-  // data identity so a refetch after Verify doesn't re-open everything.
-  const [autoOpenedKey, setAutoOpenedKey] = useState<string | null>(null);
-
-  const entriesKey = useMemo(
-    () => ctx.entries.map((entry) => entry.id).join("|"),
-    [ctx.entries],
-  );
-  // Render-adjustment (not an effect): when a new range's rows arrive, open
-  // every still-flagged row's detail before the first paint of that data.
-  if (autoOpenedKey !== entriesKey) {
-    setAutoOpenedKey(entriesKey);
-    const flagged = ctx.entries.filter((entry) => entry.flagged).map((entry) => entry.id);
-    if (flagged.length > 0) {
-      setOpenIds((previous) => new Set([...previous, ...flagged]));
-    }
-  }
 
   // The lunch row at each location+date, for the detail panel's "lunch
   // recorded 3:41 PM" line.
@@ -732,7 +730,7 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
       toast(`Could not verify: ${error.message}`);
       return;
     }
-    toast("Entry verified — flag cleared");
+    toast("Entry verified, flag cleared");
     ctx.refetch();
   }
 
@@ -777,11 +775,13 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
           {ctx.entries.length} records · click a row for the breakdown
         </span>
         <InfoButton label="About recorded tips">
-          <b>Cash</b> is pooled and handed out nightly — the per-person column is the full
-          (100%) share; reduced shares live in the row&apos;s breakdown. <b>Card</b> tips ride
-          payroll. A flagged row is unusually large against the 4-week history: check the
-          drawer count, then Verify. Fix reopens a recorded shift for correction.
+          <b>Cash</b> is pooled and handed out nightly; the per-person column is the full
+          (100%) share and reduced shares live in the row&apos;s breakdown. <b>Card</b> tips
+          ride payroll. A red row needs a look: open it to read why, check the drawer count,
+          then Verify. Flag rules sets what turns a row red. Fix reopens a recorded shift
+          for correction.
         </InfoButton>
+        <FlagRulesMenu rules={ctx.flagRules} onChange={ctx.setFlagRules} />
       </div>
       <div className={`${panelWrap} overflow-x-auto`}>
         <table className="w-full min-w-[780px] border-collapse text-[13px]">
@@ -806,7 +806,7 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
                   <tr key={`total-${row.day}`} className="bg-well text-[12.5px] font-extrabold">
                     <td className={`${td} border-b-line py-1.5`} />
                     <td colSpan={3} className={`${td} border-b-line py-1.5 font-bold text-ink2`}>
-                      {shortDayLabel(row.day)} — day total
+                      {shortDayLabel(row.day)} total
                     </td>
                     <td className={`${td} border-b-line bg-cashcol py-1.5 text-right tabular-nums`}>
                       {moneyFromCents(row.cashCents)}
@@ -823,6 +823,9 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
               }
               const { entry } = row;
               const location = ctx.locationById.get(entry.locationId);
+              const reasons = entry.flagged
+                ? flagReasons(entry, ctx.flagRules).map((reason) => reason.text)
+                : [];
               const flaggedTint = entry.flagged ? "bg-flagtint" : "";
               const open = openIds.has(entry.id);
               const partialCount = entry.weights.filter((weight) => weight < 1).length;
@@ -895,7 +898,7 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
                         <button
                           type="button"
                           className={`${miniBtnDanger} ml-1.5`}
-                          title={entry.anomalyReason ?? undefined}
+                          title={reasons.join(" ") || undefined}
                           disabled={verifying === entry.id}
                           onClick={(event) => {
                             event.stopPropagation();
@@ -913,6 +916,7 @@ export function LedgerPage({ ctx }: { ctx: PageContext }) {
                       <td colSpan={9} className={`${td} bg-cream/40 pb-4`}>
                         <DetailPanel
                           entry={entry}
+                          reasons={reasons}
                           lunchEntry={
                             lunchByDayLocation.get(
                               `${entry.businessDate}|${entry.locationId}`,

--- a/web/src/components/manager/dashboard/OverviewPage.tsx
+++ b/web/src/components/manager/dashboard/OverviewPage.tsx
@@ -6,12 +6,12 @@
 
 import {
   dailyTrend,
-  moneyFromCents,
   rangeTotals,
   splitTrendSeries,
   takeHomeByPerson,
   wholeDollarsFromCents,
 } from "@/lib/tips/dashboardDerive";
+import { flagReasons } from "@/lib/tips/flagRules";
 import { shortDayLabel, trendDayLabel } from "@/lib/tips/dashboardRange";
 import { btn, panelWrap, sectionH3 } from "./ui";
 import type { LocationInfo, PageContext } from "./types";
@@ -164,7 +164,7 @@ export function OverviewPage({ ctx }: { ctx: PageContext }) {
     <section className="mb-8">
       <div className={`${panelWrap} mb-[26px]`}>
         <div className="flex flex-wrap items-center gap-3.5 border-b border-line px-4 py-3.5">
-          <b className="text-[14.5px] font-extrabold text-ink">Tips trend — {ctx.rangeLabel}</b>
+          <b className="text-[14.5px] font-extrabold text-ink">Tips trend, {ctx.rangeLabel}</b>
           {showLegend && (
             <span className="flex items-center gap-3 text-xs text-ink2">
               {ctx.visibleLocations.map((location) => (
@@ -207,7 +207,9 @@ export function OverviewPage({ ctx }: { ctx: PageContext }) {
                 {shortDayLabel(entry.businessDate)} ·{" "}
                 {ctx.locationById.get(entry.locationId)?.label ?? "?"} {entry.meal}
               </b>{" "}
-              — cash {moneyFromCents(entry.cashCents)} looks unusually large
+              {flagReasons(entry, ctx.flagRules)
+                .map((reason) => reason.text)
+                .join(" ") || "needs a look"}
             </span>
             <button type="button" className={`${btn} ml-auto`} onClick={() => ctx.navigate("ledger")}>
               Review
@@ -239,7 +241,7 @@ export function OverviewPage({ ctx }: { ctx: PageContext }) {
           >
             <span className="h-2 w-2 flex-none rounded-full bg-warnamber" aria-hidden />
             <span className="min-w-0 text-ink2">
-              <b className="text-ink">{location.label} QR</b> has never been rotated — mint a
+              <b className="text-ink">{location.label} QR</b> has never been rotated. Mint a
               QR code so closers can scan in
             </span>
             <button type="button" className={`${btn} ml-auto`} onClick={() => ctx.navigate("logdev")}>

--- a/web/src/components/manager/dashboard/types.ts
+++ b/web/src/components/manager/dashboard/types.ts
@@ -1,6 +1,7 @@
 // Shared shapes for the Tip Dashboard (manager surface).
 
 import type { LedgerEntry } from "@/lib/tips/dashboardDerive";
+import type { FlagRules } from "@/lib/tips/flagRules";
 import type { MealPeriod } from "@/types/database";
 
 /**
@@ -88,6 +89,9 @@ export interface PageContext {
   userId: string;
   navigate: (nav: NavId) => void;
   refetch: () => void;
+  /** What counts as "needs attention"; entries above already reflect it. */
+  flagRules: FlagRules;
+  setFlagRules: (rules: FlagRules) => void;
 }
 
 export function locationKindFor(name: string): LocationKind | null {

--- a/web/src/components/manager/dashboard/ui.tsx
+++ b/web/src/components/manager/dashboard/ui.tsx
@@ -101,61 +101,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
  * The ⓘ button. All explanatory copy lives behind these — never as visible
  * paragraphs on the page.
  */
-export function InfoButton({ label, children }: { label: string; children: ReactNode }) {
-  const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const close = (event: MouseEvent) => {
-      if (buttonRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
-    };
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("click", close);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("click", close);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  return (
-    <>
-      <button
-        ref={buttonRef}
-        type="button"
-        aria-label={label}
-        aria-expanded={open}
-        onClick={() => {
-          const rect = buttonRef.current?.getBoundingClientRect();
-          if (rect) {
-            setPos({
-              left: Math.min(rect.left, window.innerWidth - 340),
-              top: rect.bottom + 8,
-            });
-          }
-          setOpen((value) => !value);
-        }}
-        className="h-5 w-5 flex-none rounded-full border border-line font-serif text-[11px] font-extrabold italic leading-none text-ink3 hover:border-ink3 hover:text-ink"
-      >
-        i
-      </button>
-      {open && pos && (
-        <div
-          role="dialog"
-          className="fixed z-[80] max-w-[320px] rounded-[14px] border border-line bg-card px-3.5 py-3 text-[12.5px] leading-relaxed text-ink2 shadow-[0_6px_24px_rgba(16,20,28,0.16)] [&_b]:text-ink"
-          style={{ left: pos.left, top: pos.top }}
-        >
-          {children}
-        </div>
-      )}
-    </>
-  );
-}
+export { InfoButton } from "@/components/InfoButton";
 
 /* ---------- centered modal ---------- */
 

--- a/web/src/components/manager/dashboard/useDashboardData.ts
+++ b/web/src/components/manager/dashboard/useDashboardData.ts
@@ -209,6 +209,7 @@ export function useDashboardData(range: DashboardRange): DashboardDataState {
           entryMethod: (row.entry_method === "voice" ? "voice" : "typed") as EntryMethod,
           flagged: row.flagged_anomaly && row.flag_verified_at === null,
           flaggedRaw: row.flagged_anomaly,
+          flagVerifiedAt: row.flag_verified_at,
           anomalyReason: row.anomaly_reason,
           createdAt: row.created_at,
         };

--- a/web/src/components/manager/dashboard/useFlagRules.ts
+++ b/web/src/components/manager/dashboard/useFlagRules.ts
@@ -1,0 +1,35 @@
+"use client";
+
+// The manager's flag rules, kept in this browser's localStorage. Display-time
+// preferences only: nothing on the server changes when a rule changes, and
+// Verify still clears a row for everyone.
+
+import { useCallback, useState } from "react";
+import { DEFAULT_FLAG_RULES, parseFlagRules, type FlagRules } from "@/lib/tips/flagRules";
+
+const STORAGE_KEY = "smelter_tip_flag_rules";
+
+function readStored(): FlagRules {
+  try {
+    if (typeof window === "undefined") return DEFAULT_FLAG_RULES;
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? parseFlagRules(JSON.parse(raw)) : DEFAULT_FLAG_RULES;
+  } catch {
+    return DEFAULT_FLAG_RULES;
+  }
+}
+
+export function useFlagRules(): [FlagRules, (rules: FlagRules) => void] {
+  // Safe to read localStorage in the initializer: the shell only mounts
+  // client-side behind the auth gate. try/catch covers blocked storage.
+  const [rules, setRulesState] = useState<FlagRules>(readStored);
+  const setRules = useCallback((next: FlagRules) => {
+    setRulesState(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Preference simply won't persist.
+    }
+  }, []);
+  return [rules, setRules];
+}

--- a/web/src/lib/tips/__tests__/dashboardCsv.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardCsv.test.ts
@@ -32,6 +32,7 @@ function entry(overrides: Partial<LedgerEntry>): LedgerEntry {
     entryMethod: "voice",
     flagged: false,
     flaggedRaw: false,
+    flagVerifiedAt: null,
     anomalyReason: null,
     createdAt: "2026-08-10T05:24:00Z",
     ...overrides,

--- a/web/src/lib/tips/__tests__/dashboardDerive.test.ts
+++ b/web/src/lib/tips/__tests__/dashboardDerive.test.ts
@@ -35,6 +35,7 @@ function entry(overrides: Partial<LedgerEntry>): LedgerEntry {
     entryMethod: "typed",
     flagged: false,
     flaggedRaw: false,
+    flagVerifiedAt: null,
     anomalyReason: null,
     createdAt: "2026-08-08T05:28:00Z",
     ...overrides,

--- a/web/src/lib/tips/__tests__/flagRules.test.ts
+++ b/web/src/lib/tips/__tests__/flagRules.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { LedgerEntry } from "../dashboardDerive";
+import {
+  applyFlagRules,
+  DEFAULT_FLAG_RULES,
+  describeStoredReason,
+  flagReasons,
+  parseFlagRules,
+} from "../flagRules";
+
+function entry(overrides: Partial<LedgerEntry> = {}): LedgerEntry {
+  return {
+    id: "e1",
+    businessDate: "2026-08-31",
+    locationId: "loc",
+    meal: "dinner",
+    cashCents: 1500,
+    cardCents: 16000,
+    splitCount: 2,
+    peopleIds: ["a", "b"],
+    peopleNames: ["Xander", "Ma"],
+    weights: [1, 1],
+    gratuityCents: 0,
+    enteredScope: "day",
+    rawCashCents: 1500,
+    rawCardCents: 16000,
+    rawGratuityCents: 0,
+    note: null,
+    noteAt: null,
+    enteredById: null,
+    enteredByName: null,
+    entryMethod: "typed",
+    flagged: true,
+    flaggedRaw: true,
+    flagVerifiedAt: null,
+    anomalyReason: "day_total_no_lunch",
+    createdAt: "2026-09-01T04:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("describeStoredReason", () => {
+  it("turns the no-lunch code into a sentence", () => {
+    expect(describeStoredReason("day_total_no_lunch")).toEqual([
+      { kind: "no_lunch", text: expect.stringContaining("before lunch was recorded") },
+    ]);
+  });
+
+  it("rewrites the statistical reason with dollar amounts", () => {
+    const [part] = describeStoredReason("cash $500.00 vs typical $10-$30 (max ever $40)");
+    expect(part.kind).toBe("unusual");
+    expect(part.text).toBe(
+      "Cash $500.00 is far above the usual $10.00 to $30.00 for this shift (highest before this: $40.00).",
+    );
+  });
+
+  it("splits a combined reason into both parts", () => {
+    const parts = describeStoredReason(
+      "day_total_no_lunch; card $900.00 vs typical $100-$200 (max ever $250)",
+    );
+    expect(parts.map((part) => part.kind)).toEqual(["no_lunch", "unusual"]);
+  });
+
+  it("passes unknown text through and handles null", () => {
+    expect(describeStoredReason("something else")).toEqual([{ kind: "unusual", text: "something else" }]);
+    expect(describeStoredReason(null)).toEqual([]);
+  });
+});
+
+describe("flagReasons + applyFlagRules", () => {
+  it("flags the no-lunch case only while that rule is on", () => {
+    expect(flagReasons(entry(), DEFAULT_FLAG_RULES)).toHaveLength(1);
+    expect(flagReasons(entry(), { ...DEFAULT_FLAG_RULES, noLunch: false })).toHaveLength(0);
+    expect(applyFlagRules(entry(), { ...DEFAULT_FLAG_RULES, noLunch: false }).flagged).toBe(false);
+  });
+
+  it("keeps a verified row clear whatever the rules say", () => {
+    const verified = entry({ flagged: false, flagVerifiedAt: "2026-09-01T05:00:00Z" });
+    expect(applyFlagRules(verified, DEFAULT_FLAG_RULES).flagged).toBe(false);
+    expect(
+      applyFlagRules(verified, { ...DEFAULT_FLAG_RULES, cashOverCents: 100 }).flagged,
+    ).toBe(false);
+  });
+
+  it("applies the cash and card limits to rows that were never flagged at save", () => {
+    const quiet = entry({ flagged: false, flaggedRaw: false, anomalyReason: null });
+    expect(flagReasons(quiet, DEFAULT_FLAG_RULES)).toHaveLength(0);
+    const reasons = flagReasons(quiet, {
+      ...DEFAULT_FLAG_RULES,
+      cashOverCents: 1000,
+      cardOverCents: 20000,
+    });
+    expect(reasons).toEqual([
+      { kind: "cash_over", text: "Cash $15.00 is over the $10.00 limit you set." },
+    ]);
+    expect(applyFlagRules(quiet, { ...DEFAULT_FLAG_RULES, cashOverCents: 1000 }).flagged).toBe(true);
+  });
+
+  it("treats a legacy flagged row with no reason as an unusual amount", () => {
+    const legacy = entry({ anomalyReason: null });
+    expect(flagReasons(legacy, DEFAULT_FLAG_RULES)[0]?.kind).toBe("unusual");
+    expect(flagReasons(legacy, { ...DEFAULT_FLAG_RULES, unusualAmounts: false })).toHaveLength(0);
+  });
+
+  it("returns the same object when nothing changes", () => {
+    const row = entry();
+    expect(applyFlagRules(row, DEFAULT_FLAG_RULES)).toBe(row);
+  });
+});
+
+describe("parseFlagRules", () => {
+  it("falls back to defaults on junk and validates limits", () => {
+    expect(parseFlagRules(null)).toEqual(DEFAULT_FLAG_RULES);
+    expect(parseFlagRules("nope")).toEqual(DEFAULT_FLAG_RULES);
+    expect(
+      parseFlagRules({ noLunch: false, unusualAmounts: "yes", cashOverCents: -5, cardOverCents: 250.4 }),
+    ).toEqual({ noLunch: false, unusualAmounts: true, cashOverCents: null, cardOverCents: 250 });
+  });
+});

--- a/web/src/lib/tips/dashboardDerive.ts
+++ b/web/src/lib/tips/dashboardDerive.ts
@@ -38,6 +38,8 @@ export interface LedgerEntry {
   flagged: boolean;
   /** flagged_anomaly as stored, regardless of verification. */
   flaggedRaw: boolean;
+  /** When a manager verified the row; null until then. */
+  flagVerifiedAt: string | null;
   anomalyReason: string | null;
   createdAt: string; // ISO timestamp of the save (powers the entry log)
 }

--- a/web/src/lib/tips/flagRules.ts
+++ b/web/src/lib/tips/flagRules.ts
@@ -1,0 +1,141 @@
+// Manager-adjustable flag rules for the Tip Dashboard.
+//
+// The phone saves two kinds of flag onto tip_entries.anomaly_reason: the
+// literal "day_total_no_lunch" (a whole-day dinner saved before lunch was
+// recorded) and the save-time statistical check ("cash $500.00 vs typical
+// $10-$30 (max ever $40)"), joined with "; " when both apply. The rules here
+// decide which of those the dashboard treats as "needs attention", and add
+// two plain limits (cash over $X, card over $Y) evaluated on the dashboard.
+// Everything is display-time: changing a rule re-evaluates history, and
+// Verify still clears a row by stamping flag_verified_at.
+
+import type { LedgerEntry } from "./dashboardDerive";
+import { moneyFromCents } from "./dashboardDerive";
+
+export interface FlagRules {
+  /** Flag a whole-day dinner that was saved before lunch was recorded. */
+  noLunch: boolean;
+  /** Flag amounts the save-time check called unusual against the 4-week history. */
+  unusualAmounts: boolean;
+  /** Flag any entry whose cash pool is over this many cents ($0 flags any cash). null = off. */
+  cashOverCents: number | null;
+  /** Flag any entry whose card figure is over this many cents. null = off. */
+  cardOverCents: number | null;
+}
+
+export const DEFAULT_FLAG_RULES: FlagRules = {
+  noLunch: true,
+  unusualAmounts: true,
+  cashOverCents: null,
+  cardOverCents: null,
+};
+
+export const NO_LUNCH_CODE = "day_total_no_lunch";
+
+function centsOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.round(value)
+    : null;
+}
+
+/** Validate a stored rules object; anything malformed falls back to the default. */
+export function parseFlagRules(raw: unknown): FlagRules {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return DEFAULT_FLAG_RULES;
+  const source = raw as Record<string, unknown>;
+  return {
+    noLunch: typeof source.noLunch === "boolean" ? source.noLunch : DEFAULT_FLAG_RULES.noLunch,
+    unusualAmounts:
+      typeof source.unusualAmounts === "boolean"
+        ? source.unusualAmounts
+        : DEFAULT_FLAG_RULES.unusualAmounts,
+    cashOverCents: centsOrNull(source.cashOverCents),
+    cardOverCents: centsOrNull(source.cardOverCents),
+  };
+}
+
+export type FlagKind = "no_lunch" | "unusual" | "cash_over" | "card_over";
+
+export interface FlagReason {
+  kind: FlagKind;
+  /** One plain-English sentence a manager can act on. */
+  text: string;
+}
+
+const STATISTICAL_PATTERN =
+  /^(cash|card) \$([\d,]+(?:\.\d+)?) vs typical \$([\d,]+(?:\.\d+)?)-\$([\d,]+(?:\.\d+)?) \(max ever \$([\d,]+(?:\.\d+)?)\)$/;
+
+function dollars(text: string): string {
+  const value = Number(text.replace(/,/g, ""));
+  return Number.isFinite(value) ? moneyFromCents(Math.round(value * 100)) : `$${text}`;
+}
+
+/**
+ * The stored anomaly_reason as plain-English sentences, one per part.
+ * Unknown parts pass through untouched so nothing the server said is lost.
+ */
+export function describeStoredReason(
+  reason: string | null,
+): Array<{ kind: "no_lunch" | "unusual"; text: string }> {
+  if (!reason) return [];
+  return reason
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      if (part === NO_LUNCH_CODE) {
+        return {
+          kind: "no_lunch" as const,
+          text: "Whole-day total entered before lunch was recorded, so nothing was subtracted for lunch.",
+        };
+      }
+      const match = STATISTICAL_PATTERN.exec(part);
+      if (match) {
+        const [, field, value, low, high, maxEver] = match;
+        const label = field === "cash" ? "Cash" : "Card";
+        return {
+          kind: "unusual" as const,
+          text: `${label} ${dollars(value)} is far above the usual ${dollars(low)} to ${dollars(high)} for this shift (highest before this: ${dollars(maxEver)}).`,
+        };
+      }
+      return { kind: "unusual" as const, text: part };
+    });
+}
+
+type FlagInput = Pick<LedgerEntry, "anomalyReason" | "flaggedRaw" | "cashCents" | "cardCents">;
+
+/** Why this entry needs attention under the given rules; empty when it does not. */
+export function flagReasons(entry: FlagInput, rules: FlagRules): FlagReason[] {
+  const reasons: FlagReason[] = [];
+  const stored = describeStoredReason(entry.anomalyReason);
+  for (const part of stored) {
+    if (part.kind === "no_lunch" && rules.noLunch) reasons.push(part);
+    if (part.kind === "unusual" && rules.unusualAmounts) reasons.push(part);
+  }
+  // A row flagged at save time with no reason text (pre-v3) still counts as
+  // an unusual amount, since that was the only flag source then.
+  if (entry.flaggedRaw && stored.length === 0 && rules.unusualAmounts) {
+    reasons.push({ kind: "unusual", text: "Flagged as unusual when it was saved." });
+  }
+  if (rules.cashOverCents !== null && entry.cashCents > rules.cashOverCents) {
+    reasons.push({
+      kind: "cash_over",
+      text: `Cash ${moneyFromCents(entry.cashCents)} is over the ${moneyFromCents(rules.cashOverCents)} limit you set.`,
+    });
+  }
+  if (rules.cardOverCents !== null && entry.cardCents > rules.cardOverCents) {
+    reasons.push({
+      kind: "card_over",
+      text: `Card ${moneyFromCents(entry.cardCents)} is over the ${moneyFromCents(rules.cardOverCents)} limit you set.`,
+    });
+  }
+  return reasons;
+}
+
+/**
+ * Re-derive `flagged` for the dashboard: needs attention under the rules and
+ * not yet verified. Verified rows stay clear whatever the rules say.
+ */
+export function applyFlagRules(entry: LedgerEntry, rules: FlagRules): LedgerEntry {
+  const flagged = entry.flagVerifiedAt === null && flagReasons(entry, rules).length > 0;
+  return entry.flagged === flagged ? entry : { ...entry, flagged };
+}


### PR DESCRIPTION
## What changed

### Phone entry screen (`web/src/components/entry/*`)
- Locked shift: the "already recorded, ask a manager" line under Lunch|Dinner is gone. The struck-through option carries an "i" whose popover says "Dinner is already recorded for today."
- Voice: "Save tips" is now **Review split**. It fills the form and scrolls to the split instead of saving; Save is a separate tap (the closer still hands out cash in person). Hand edits after the review count as voice corrections. If voice switched the shift, the form re-checks that slot with the server (fresh lunch figures; a slot saved meanwhile locks).
- Whole-day breakdown reads "Entered (whole day)" / "Lunch amount" / "Dinner records". Leading dash and em dashes removed.
- Gratuity hint and the "tap a badge" hint moved behind "i" buttons next to their labels.
- Share badge on a selected name is larger (13px text, 40x44 hit area).
- Location is a pill the size of the date and closer chips.
- Saved screen: **Go back and edit** returns to the filled-in form; the other shift locks ("Scan the QR code again to enter dinner") so one scan still records one shift. Full smelter lockup under the buttons. Countdown stops on go-back.

### Manager ledger (`web/src/components/manager/dashboard/*`)
- Every row starts closed.
- Flag reasons are plain sentences in the detail panel ("Why this is flagged"), the Verify tooltip, and Overview's Needs attention list. `day_total_no_lunch` reads "Whole-day total entered before lunch was recorded, so nothing was subtracted for lunch."
- New **Flag rules** menu: switches for "Lunch was never entered" and "Unusual cash or card amount", optional cash / card dollar limits. Rules apply at display time on every page (Overview, sidebar dot, ledger) and never re-flag a verified row. `LedgerEntry` gains `flagVerifiedAt`.
- `lib/tips/flagRules.ts` is pure and unit-tested. `InfoButton` moved to `components/InfoButton.tsx` (dashboard `ui.tsx` re-exports it).
- Em dashes removed from every user-facing string in the touched files.

**Assumption to confirm:** flag rules are stored per browser (localStorage). Sharing across managers would need an `app_config` write RPC and a migration.

**Left as is (from review):** the CSV "flagged" column still exports the save-time flag (an audit fact), not the rules-adjusted view.

## Verification

Run in this worktree on the final commit.

| Check | Command | Result |
|---|---|---|
| Typecheck | `cd web && npm run typecheck` | exit 0 |
| Lint | `cd web && npm run lint` | exit 0 |
| Unit | `cd web && npm test` | 21 files, 242 passed (new `src/lib/tips/__tests__/flagRules.test.ts`: reason wording, rule toggles, limits, verified rows stay clear, `parseFlagRules` edge cases) |

Visual (Playwright, 390px viewport, throwaway page rendering the changed pieces; page and dev server removed before commit):
- Locked Dinner tab with the "i" and its popover; slot-loading state only dims (no false strike-through or hint).
- Gratuity hint popover; "Who's splitting" popover; larger share badges; location pill.
- Flag rules dialog with both switches and the two limit inputs.
- Saved-screen buttons ("Go back and edit" / "Done") with the smelter lockup beneath.
- Popover flips upward when the trigger is in the bottom quarter of the screen.

The visual loop caught one real defect before commit: the "i" inside an `aria-disabled` tab was itself reported disabled. Fixed by keeping the tab a real disabled `<button>` and placing the "i" beside it in the same flex cell.

Independent review: Codex (gpt-5.6-sol, xhigh) reviewed the first commit and returned 11 findings; 10 were fixed in the final commit (go-back meal lock, voice slot refresh, post-review corrections count, loading-state strike-through leak, tab semantics, Escape discarding a typed limit, `$0` limit, popover close-others and bottom-edge flip, remaining em dashes). The CSV column finding was left as noted above.

Not covered here: a live phone run (needs a real QR session). What to test on the device:
1. Scan, record lunch, confirm Dinner shows the "i" and its popover.
2. Speak it in, tap Review split, confirm it lands on the split, then Save.
3. On Saved, tap Go back and edit, change a number, Save again.
4. Dashboard: rows closed; open a red one and read the reason; in Flag rules turn off "Lunch was never entered" and watch the red rows clear.

Note: PR #24 also touches `LedgerPage.tsx` (two import lines). Whichever merges second may need a trivial import-order conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
