### PR TITLE
E2E pass 2: parser fallback, ?no-dts edge pins, store fixes, CONTEXT.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ expo-env.d.ts
 # @end expo-cli
 .vercel
 __pycache__/
+
+# Local prod env backups
+.env.prod-backup
+supabase/.branches/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,63 @@
+# Smelter
+
+Restaurant operations for small independent restaurants: staff order stock from suppliers, count stock, record tips, and (new) take guest orders at the table and send them to the kitchen.
+
+## Language
+
+### Supply side (existing)
+
+**Supply Order**:
+A request for stock that an employee builds and a manager sends to a supplier. This is what the codebase currently calls an "order".
+_Avoid_: Order (unqualified), purchase order
+
+**Kitchen Request**:
+A chef asking the back kitchen for a prepped ingredient (e.g. two tubs of sushi rice). Internal to staff; never appears on a guest's bill.
+_Avoid_: Ticket, kitchen order
+
+### Guest side (new)
+
+**Tab**:
+Everything one party at one Table asks for during one visit. It is the bill; it is paid once at the end.
+_Avoid_: Order, check, cart
+
+**Line**:
+One menu item, its quantity, and its modifiers on a Tab. Every re-order of a drink is a new Line; there are no free refills.
+_Avoid_: Order item, entry
+
+**Ticket**:
+The kitchen-bound Lines of a Tab released to the kitchen in one Send. Drinks never appear on a Ticket; they are Lines on the Tab only.
+_Avoid_: Order, kitchen order, kitchen request
+
+**Send**:
+The waiter's explicit act of releasing drafted Lines: kitchen-bound Lines become a Ticket, bill-only Lines land on the Tab. Nothing reaches the kitchen or the bill without a Send.
+_Avoid_: Submit, fire
+
+**Draft Line**:
+A Line proposed by voice or typed by staff that has not been Sent yet. Staff can edit or discard it freely.
+_Avoid_: Pending item, suggestion
+
+**Table**:
+A fixed, numbered place in a location where a party sits. A Table has at most one open Tab at a time.
+_Avoid_: Seat, section
+
+**Menu Item**:
+Something a guest can order, with a fixed name and size (e.g. "Asahi Large"). Distinct from an inventory item, which is how the same thing is stocked and bought.
+_Avoid_: Product, inventory item, SKU
+
+**Modifier**:
+A spoken or tapped change to a Line's Menu Item, such as "no corn" or "extra meat".
+_Avoid_: Note, option, special request
+
+**Kitchen Display**:
+The shared screen in the kitchen that shows Tickets in the order they were Sent.
+_Avoid_: KDS, kitchen app
+
+### Voice
+
+**Dictation**:
+A staff member taps the mic and states one or more Tables and their Lines ("table 4, two Asahi Large"). Only the staff member is recorded.
+_Avoid_: Push-to-talk, voice order
+
+**Ambient Listening**:
+The waiter's phone transcribes the conversation with a party at their Table while the waiter is present, producing Draft Lines as items are spoken.
+_Avoid_: Live mode, always-on

--- a/app/(manager)/_layout.tsx
+++ b/app/(manager)/_layout.tsx
@@ -21,6 +21,7 @@ export default function ManagerLayout() {
   const session = useAuthStore((s) => s.session);
   const locations = useAuthStore((s) => s.locations);
   const fetchPastOrders = useOrderStore((s) => s.fetchPastOrders);
+  const fulfillmentDataRevision = useOrderStore((s) => s.fulfillmentDataRevision);
   const insets = useSafeAreaInsets();
   const [pendingFulfillmentCount, setPendingFulfillmentCount] = useState(0);
   const badgeRefreshGenerationRef = useRef(0);
@@ -123,7 +124,7 @@ export default function ManagerLayout() {
 
   useEffect(() => {
     void refreshPendingFulfillmentCount();
-  }, [refreshPendingFulfillmentCount]);
+  }, [fulfillmentDataRevision, refreshPendingFulfillmentCount]);
 
   useEffect(() => {
     if (!session || resolvedRole !== "manager") {

--- a/src/__tests__/orderStoreFulfillment.test.ts
+++ b/src/__tests__/orderStoreFulfillment.test.ts
@@ -1,0 +1,79 @@
+const mockAsyncStorage = {
+  getItem: jest.fn(async () => null),
+  setItem: jest.fn(async () => undefined),
+  removeItem: jest.fn(async () => undefined),
+};
+
+const mockNetInfo = {
+  addEventListener: jest.fn(() => jest.fn()),
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: mockNetInfo,
+}));
+jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+jest.mock('@/lib/supabase', () => ({ supabase: {} }));
+jest.mock('@/lib/perf', () => ({ perfMark: jest.fn(), perfMeasure: jest.fn() }));
+jest.mock('@/lib/notifications', () => ({ getNotificationsModule: jest.fn(async () => null) }));
+jest.mock('@/services/fulfillmentDataSource', () => ({
+  loadPendingFulfillmentData: jest.fn(),
+}));
+jest.mock('@/services/orderSubmission', () => ({
+  generateUUID: jest.fn(() => 'order-1'),
+  submitOrder: jest.fn(),
+  syncProfileAfterOrder: jest.fn(),
+}));
+jest.mock('@/store/inventoryStore', () => ({
+  useInventoryStore: { getState: () => ({ items: [] }) },
+}));
+
+/* eslint-disable import/first -- Dependencies must be mocked before importing the store. */
+import { useOrderStore } from '../store/orderStore';
+import type { FinalizeSupplierOrderInput, PastOrder } from '../store/orderStore.types';
+
+const finalizedPastOrder: PastOrder = {
+  id: 'past-1',
+  supplierId: 'supplier-1',
+  supplierName: 'Supplier',
+  createdBy: 'manager-1',
+  createdAt: '2026-09-01T12:00:00.000Z',
+  payload: {},
+  messageText: 'Supplier order',
+  shareMethod: 'copy',
+  syncStatus: 'synced',
+  pendingSyncJobId: null,
+  syncError: null,
+  itemCount: 1,
+  remainingCount: 0,
+};
+
+const finalizeInput: FinalizeSupplierOrderInput = {
+  supplierId: 'supplier-1',
+  supplierName: 'Supplier',
+  createdBy: 'manager-1',
+  messageText: 'Supplier order',
+  shareMethod: 'copy',
+  payload: {},
+};
+
+describe('order store fulfillment refresh signal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useOrderStore.setState(useOrderStore.getInitialState(), true);
+  });
+
+  test('increments after a supplier order is finalized', async () => {
+    const createPastOrder = jest.fn(
+      async (_input: FinalizeSupplierOrderInput): Promise<PastOrder> => finalizedPastOrder,
+    );
+    useOrderStore.setState({ createPastOrder });
+
+    await useOrderStore.getState().finalizeSupplierOrder(finalizeInput);
+
+    const state = useOrderStore.getState();
+    const revision = 'fulfillmentDataRevision' in state ? state.fulfillmentDataRevision : undefined;
+    expect(revision).toBe(1);
+  });
+});

--- a/src/features/simpleOrder/HistoryScreen.tsx
+++ b/src/features/simpleOrder/HistoryScreen.tsx
@@ -178,7 +178,7 @@ export function HistoryScreen() {
         <EmptyStateCard
           icon="receipt-outline"
           title="No sent orders yet"
-          message="Orders you send directly to suppliers appear here. Orders that go to your manager are handled from the manager's side."
+          message="Orders appear here after they are sent to suppliers. Orders waiting for manager review show up once they are processed."
         />
       </View>
     );

--- a/src/features/simpleOrder/HistoryScreen.tsx
+++ b/src/features/simpleOrder/HistoryScreen.tsx
@@ -177,8 +177,8 @@ export function HistoryScreen() {
       <View style={{ paddingTop: ds.spacing(24) }}>
         <EmptyStateCard
           icon="receipt-outline"
-          title="No orders yet"
-          message="Orders you send show up here, ready to reorder in one tap."
+          title="No sent orders yet"
+          message="Orders you send directly to suppliers appear here. Orders that go to your manager are handled from the manager's side."
         />
       </View>
     );

--- a/src/features/team/InviteScreen.tsx
+++ b/src/features/team/InviteScreen.tsx
@@ -46,6 +46,9 @@ export default function InviteScreen() {
   const ds = useScaledStyles();
   const [name, setName] = useState('');
   const [group, setGroup] = useState<InviteLocationGroup>('sushi');
+  const [defaultToggles, setDefaultToggles] = useState<EmployeeInviteDefaults>(
+    getBuiltInEmployeeDefaults(),
+  );
   const [toggles, setToggles] = useState<EmployeeInviteDefaults>(getBuiltInEmployeeDefaults());
   const [expiresInHours, setExpiresInHours] = useState(168);
   const [busy, setBusy] = useState(false);
@@ -57,7 +60,10 @@ export default function InviteScreen() {
     let cancelled = false;
     getEmployeeInviteDefaults()
       .then((defaults) => {
-        if (!cancelled) setToggles(defaults);
+        if (!cancelled) {
+          setDefaultToggles(defaults);
+          setToggles(defaults);
+        }
       })
       .catch(() => {
         // Built-ins already in place.
@@ -76,25 +82,32 @@ export default function InviteScreen() {
 
   const handleCreate = async () => {
     if (!canSubmit) return;
+    const invitedName = name.trim();
+    const selectedGroup = group;
+    const selectedExpiresInHours = expiresInHours;
     setBusy(true);
     setError(null);
     try {
       const invite = await createInvite({
-        invitedName: name.trim(),
+        invitedName,
         role: 'employee',
-        expiresInHours,
+        expiresInHours: selectedExpiresInHours,
         modulePreset: { ...toggles },
-        locationGroup: group,
+        locationGroup: selectedGroup,
       });
+      setName('');
+      setGroup('sushi');
+      setToggles({ ...defaultToggles });
+      setExpiresInHours(168);
       const expiryLabel =
-        EXPIRY_OPTIONS.find((option) => option.hours === expiresInHours)?.label ?? '7 days';
+        EXPIRY_OPTIONS.find((option) => option.hours === selectedExpiresInHours)?.label ?? '7 days';
       router.replace({
         pathname: '/(manager)/manager-settings/team-invite-link',
         params: {
-          name: name.trim(),
+          name: invitedName,
           joinUrl: invite.joinUrl,
           expiryLabel,
-          group,
+          group: selectedGroup,
         },
       } as Parameters<typeof router.replace>[0]);
     } catch (createError) {

--- a/src/store/orderStore.ts
+++ b/src/store/orderStore.ts
@@ -138,6 +138,7 @@ export const useOrderStore = create<OrderState>()(
       lastOrderedCacheBySupplier: {},
       isFulfillmentLoading: false,
       isPastOrderSyncing: false,
+      fulfillmentDataRevision: 0,
 
 
       addToCart: (locationId, inventoryItemId, quantity, unitType, options) => {
@@ -2620,6 +2621,7 @@ export const useOrderStore = create<OrderState>()(
           });
           return {
             supplierDrafts: nextSupplierDrafts,
+            fulfillmentDataRevision: state.fulfillmentDataRevision + 1,
           };
         });
 

--- a/src/store/orderStore.types.ts
+++ b/src/store/orderStore.types.ts
@@ -272,6 +272,8 @@ export interface OrderState {
   lastOrderedCacheBySupplier: LastOrderedCacheBySupplier;
   isFulfillmentLoading: boolean;
   isPastOrderSyncing: boolean;
+  /** Changes whenever a supplier fulfillment completes locally. */
+  fulfillmentDataRevision: number;
 
   // Cart actions (location-aware)
   addToCart: (

--- a/supabase/functions/_shared/location-access.ts
+++ b/supabase/functions/_shared/location-access.ts
@@ -1,4 +1,4 @@
-import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 
 /**
  * Returns true when the user may read/write data for the given location.

--- a/supabase/functions/_shared/reminders.ts
+++ b/supabase/functions/_shared/reminders.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import {
   buildChecklistOrderDayMessage,
   isExpoDeviceNotRegistered,

--- a/supabase/functions/accept-invite/index.ts
+++ b/supabase/functions/accept-invite/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2?no-dts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import {
   inspectInviteState,

--- a/supabase/functions/confirm-invoice-scan/index.ts
+++ b/supabase/functions/confirm-invoice-scan/index.ts
@@ -1,5 +1,5 @@
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2?no-dts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import { normalizeInvoiceUnit } from "../_shared/invoice-reconciliation.ts";
 

--- a/supabase/functions/create-invite/index.ts
+++ b/supabase/functions/create-invite/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2?no-dts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import { getRequesterFromToken } from "../_shared/reminders.ts";
 import {

--- a/supabase/functions/daily-suggestions/index.ts
+++ b/supabase/functions/daily-suggestions/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 import { userCanAccessLocation } from '../_shared/location-access.ts';
 

--- a/supabase/functions/delete-self/index.ts
+++ b/supabase/functions/delete-self/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');

--- a/supabase/functions/evaluate-recurring-reminders/index.ts
+++ b/supabase/functions/evaluate-recurring-reminders/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
   getChecklistOrderDayReminderMessage,

--- a/supabase/functions/list-employees-with-status/index.ts
+++ b/supabase/functions/list-employees-with-status/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 import { getReminderSystemSettings, getRequesterFromToken } from '../_shared/reminders.ts';
 

--- a/supabase/functions/list-users/index.ts
+++ b/supabase/functions/list-users/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');

--- a/supabase/functions/login-with-name/index.ts
+++ b/supabase/functions/login-with-name/index.ts
@@ -7,7 +7,7 @@
 // account and the client exchanges it with auth.verifyOtp for a real
 // Supabase session. Secrets are never stored or logged here.
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2?no-dts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import { normalizeLoginName } from "../_shared/loginNames.ts";
 

--- a/supabase/functions/parse-invoice/index.ts
+++ b/supabase/functions/parse-invoice/index.ts
@@ -1,5 +1,5 @@
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2?no-dts";
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
 import { z } from "https://esm.sh/zod@3.25.76";
 import { corsHeadersForRequest } from "../_shared/cors.ts";

--- a/supabase/functions/parse-order-screenshot/index.ts
+++ b/supabase/functions/parse-order-screenshot/index.ts
@@ -1,5 +1,5 @@
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
 import { z } from 'https://esm.sh/zod@3.25.76';
 import { corsHeadersForRequest } from '../_shared/cors.ts';

--- a/supabase/functions/parse-order/index.ts
+++ b/supabase/functions/parse-order/index.ts
@@ -1,5 +1,5 @@
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders, corsHeadersForRequest } from '../_shared/cors.ts';
 import { userCanAccessLocation } from '../_shared/location-access.ts';
 import { PARSER_VERSION } from './orchestrator.ts';
@@ -1423,7 +1423,7 @@ function stripIgnoredQuickOrderPhrases(message: string, phrases: string[]): stri
     if (!trimmed) continue;
     result = result.replace(new RegExp(`\\b${escapeRegExp(trimmed)}\\b`, 'gi'), ' ');
   }
-  return result.replace(/\s+/g, ' ').trim();
+  return result.replace(/[^\S\r\n]+/g, ' ').trim();
 }
 
 function escapeRegExp(value: string): string {

--- a/supabase/functions/parse-order/process-message.test.ts
+++ b/supabase/functions/parse-order/process-message.test.ts
@@ -1,0 +1,186 @@
+import { classifyQuickOrderInput } from './input-classifier.ts';
+import { processQuickOrderMessage, type ProcessQuickOrderMessageInput } from './process-message.ts';
+import { DEFAULT_UNIT_ALIASES } from './units.ts';
+import type { CatalogItem, EmployeeQuickOrderAlias } from './types.ts';
+
+const ORDER_TEXT = 'albacore 2\navocado 1 case\nginger root 4';
+
+const CATALOG: CatalogItem[] = [
+  {
+    id: 'albacore',
+    name: 'Albacore',
+    aliases: [],
+    default_unit: 'case',
+    allowed_units: ['case'],
+  },
+  {
+    id: 'avocado',
+    name: 'Avocado',
+    aliases: [],
+    default_unit: 'case',
+    allowed_units: ['case'],
+  },
+  {
+    id: 'ginger-root',
+    name: 'Ginger Root',
+    aliases: [],
+    default_unit: 'case',
+    allowed_units: ['case'],
+  },
+];
+
+const ALIAS_CATALOG: CatalogItem[] = [
+  {
+    id: 'albacore',
+    name: 'Fish Selection A',
+    aliases: [],
+    default_unit: 'case',
+    allowed_units: ['case'],
+  },
+  {
+    id: 'avocado',
+    name: 'Produce Selection B',
+    aliases: [],
+    default_unit: 'case',
+    allowed_units: ['case'],
+  },
+  {
+    id: 'ginger-root',
+    name: 'Spice Selection C',
+    aliases: [],
+    default_unit: 'case',
+    allowed_units: ['case'],
+  },
+];
+
+const EMPLOYEE_ALIASES: EmployeeQuickOrderAlias[] = [
+  {
+    employee_name: 'Test Employee',
+    employee_name_key: 'test employee',
+    alias_text: 'albacore',
+    alias_key: 'albacore',
+    inventory_item_id: 'albacore',
+  },
+  {
+    employee_name: 'Test Employee',
+    employee_name_key: 'test employee',
+    alias_text: 'avocado',
+    alias_key: 'avocado',
+    inventory_item_id: 'avocado',
+  },
+  {
+    employee_name: 'Test Employee',
+    employee_name_key: 'test employee',
+    alias_text: 'ginger root',
+    alias_key: 'ginger root',
+    inventory_item_id: 'ginger-root',
+  },
+];
+
+type LlmCallback = NonNullable<ProcessQuickOrderMessageInput['callLlm']>;
+
+function createInput(
+  message: string,
+  catalog: CatalogItem[],
+  callLlm?: LlmCallback,
+  employeeAliases?: EmployeeQuickOrderAlias[],
+): ProcessQuickOrderMessageInput {
+  const input: ProcessQuickOrderMessageInput = {
+    request: {
+      source: 'typed',
+      mode: 'order',
+      message,
+      session_id: null,
+      location_id: 'location-1',
+      user_id: 'user-1',
+      existing_items: [],
+    },
+    catalog,
+    corrections: [],
+    previousMessages: [],
+    existingParsedItems: [],
+    limits: [],
+    allowedUnitRules: [],
+    recentOrders: [],
+    modelConfig: {
+      defaultModel: 'gemini-2.5-flash',
+      fallbackModel: 'gemini-2.5-flash',
+      advancedModel: 'gemini-3.1-pro',
+      liveModel: 'gemini-live',
+      advancedEnabled: true,
+    },
+    unitAliases: DEFAULT_UNIT_ALIASES,
+    classification: classifyQuickOrderInput(message),
+  };
+  if (callLlm) input.callLlm = callLlm;
+  if (employeeAliases) input.employeeAliases = employeeAliases;
+  return input;
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual<T>(actual: T, expected: T, message: string): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertOrderItems(result: Awaited<ReturnType<typeof processQuickOrderMessage>>): void {
+  assertEqual(result.parsed_items.length, 3, 'deterministic fallback item count');
+  assertEqual(
+    result.parsed_items.map((item) => item.raw_token),
+    ['albacore 2', 'avocado 1 case', 'ginger root 4'],
+    'deterministic fallback lines',
+  );
+  assertEqual(
+    result.parsed_items.map((item) => item.quantity),
+    [2, 1, 4],
+    'deterministic fallback quantities',
+  );
+  assert(result.parsed_items.every((item) => item.parse_source === 'deterministic'), 'all fallback items should be deterministic');
+}
+
+Deno.test('a missing LLM callback parses a plain multiline order deterministically', async () => {
+  const result = await processQuickOrderMessage(createInput(ORDER_TEXT, CATALOG));
+
+  assertOrderItems(result);
+  assertEqual(result.metrics?.parse_mode_used, 'deterministic_only', 'missing callback parse mode');
+});
+
+Deno.test('an LLM intent-router failure falls back to the deterministic parser', async () => {
+  let callCount = 0;
+  const throwingLlm: LlmCallback = async () => {
+    callCount += 1;
+    throw new Error('provider unavailable');
+  };
+  const result = await processQuickOrderMessage(createInput(ORDER_TEXT, ALIAS_CATALOG, throwingLlm, EMPLOYEE_ALIASES));
+
+  assertEqual(callCount, 1, 'LLM intent router call count');
+  assertOrderItems(result);
+  assertEqual(result.diagnostics?.input_classification, 'order_entry', 'failed route should keep source classification');
+  assertEqual(result.metrics?.parse_mode_used, 'deterministic_only', 'failed route parse mode');
+});
+
+Deno.test('a successful LLM intent route keeps the existing route-only response', async () => {
+  let callCount = 0;
+  const successfulLlm: LlmCallback = async () => {
+    callCount += 1;
+    return JSON.stringify({
+      classification: 'history_request',
+      intent: 'show_recent_orders',
+      confidence: 0.95,
+      entities: { time_range: 'recent' },
+      requires_action: true,
+      should_mutate_cart: false,
+    });
+  };
+  const result = await processQuickOrderMessage(createInput('Show me my recent orders', [], successfulLlm));
+
+  assertEqual(callCount, 1, 'successful LLM intent router call count');
+  assertEqual(result.parsed_items.length, 0, 'successful route parsed item count');
+  assertEqual(result.diagnostics?.parse_mode, 'llm_intent_router', 'successful route diagnostics mode');
+  assertEqual(result.metrics?.parse_mode_used, 'llm_only_fallback', 'successful route metrics mode');
+  assert(result.assistant_message?.includes('recent order') === true, 'successful route should keep the history response');
+});

--- a/supabase/functions/parse-order/process-message.test.ts
+++ b/supabase/functions/parse-order/process-message.test.ts
@@ -184,3 +184,16 @@ Deno.test('a successful LLM intent route keeps the existing route-only response'
   assertEqual(result.metrics?.parse_mode_used, 'llm_only_fallback', 'successful route metrics mode');
   assert(result.assistant_message?.includes('recent order') === true, 'successful route should keep the history response');
 });
+
+Deno.test('a malformed LLM router reply falls back to the deterministic parser', async () => {
+  let callCount = 0;
+  const malformedLlm: LlmCallback = async () => {
+    callCount += 1;
+    return 'not-json';
+  };
+  const result = await processQuickOrderMessage(createInput(ORDER_TEXT, ALIAS_CATALOG, malformedLlm, EMPLOYEE_ALIASES));
+
+  assert(callCount >= 1, 'LLM intent router should have been called');
+  assertOrderItems(result);
+  assertEqual(result.metrics?.parse_mode_used, 'deterministic_only', 'malformed route parse mode');
+});

--- a/supabase/functions/parse-order/process-message.ts
+++ b/supabase/functions/parse-order/process-message.ts
@@ -140,8 +140,10 @@ export async function processQuickOrderMessage(
       ? (prompt) => input.callLlm!(prompt, intentRouteModel)
       : undefined,
   });
-  const llmIntentRoute = llmIntentRouting?.route ?? null;
-  if (llmIntentRouting?.classification) {
+  const llmIntentRoute = llmIntentRouting && !llmIntentRouting.llmFailed
+    ? llmIntentRouting.route
+    : null;
+  if (llmIntentRouting?.classification && !llmIntentRouting.llmFailed) {
     classification = llmIntentRouting.classification;
   }
 

--- a/supabase/functions/parse-order/process-message.ts
+++ b/supabase/functions/parse-order/process-message.ts
@@ -140,10 +140,13 @@ export async function processQuickOrderMessage(
       ? (prompt) => input.callLlm!(prompt, intentRouteModel)
       : undefined,
   });
-  const llmIntentRoute = llmIntentRouting && !llmIntentRouting.llmFailed
-    ? llmIntentRouting.route
-    : null;
-  if (llmIntentRouting?.classification && !llmIntentRouting.llmFailed) {
+  // A malformed provider reply (repairNeeded with an unknown route) is as
+  // useless as a failed call: let deterministic parsing handle the message.
+  const llmRouteUnusable = !llmIntentRouting ||
+    llmIntentRouting.llmFailed ||
+    (llmIntentRouting.repairNeeded && llmIntentRouting.route.classification === 'unknown_non_order');
+  const llmIntentRoute = llmRouteUnusable ? null : llmIntentRouting.route;
+  if (llmIntentRouting?.classification && !llmRouteUnusable) {
     classification = llmIntentRouting.classification;
   }
 

--- a/supabase/functions/quick-order-voice-parse/index.ts
+++ b/supabase/functions/quick-order-voice-parse/index.ts
@@ -1,5 +1,5 @@
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
 import { z } from 'https://esm.sh/zod@3.25.76';
 import { corsHeadersForRequest } from '../_shared/cors.ts';

--- a/supabase/functions/quick-order-voice-stream/index.ts
+++ b/supabase/functions/quick-order-voice-stream/index.ts
@@ -1,5 +1,5 @@
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { userCanAccessLocation } from '../_shared/location-access.ts';
 import type { CatalogItem } from '../parse-order/types.ts';
 

--- a/supabase/functions/revoke-invite/index.ts
+++ b/supabase/functions/revoke-invite/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.2?no-dts";
 import { corsHeadersForRequest } from "../_shared/cors.ts";
 import { getRequesterFromToken } from "../_shared/reminders.ts";
 

--- a/supabase/functions/send-reminder/index.ts
+++ b/supabase/functions/send-reminder/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
   ReminderRateLimitError,

--- a/supabase/functions/set-user-suspended/index.ts
+++ b/supabase/functions/set-user-suspended/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');

--- a/supabase/functions/tip-entries/index.ts
+++ b/supabase/functions/tip-entries/index.ts
@@ -4,7 +4,7 @@
 // with real Supabase auth + RLS instead of this function.
 
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { tipCorsHeadersForRequest } from '../_shared/cors.ts';
 import {
   businessDateFor,

--- a/supabase/functions/tip-entry-auth/index.ts
+++ b/supabase/functions/tip-entry-auth/index.ts
@@ -8,7 +8,7 @@
 // the session's location_id.
 
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { tipCorsHeadersForRequest } from '../_shared/cors.ts';
 import {
   businessDateFor,

--- a/supabase/functions/tip-voice-parse/index.ts
+++ b/supabase/functions/tip-voice-parse/index.ts
@@ -9,7 +9,7 @@
 // target_field supports the review screen's per-field re-record mics.
 
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
 import { z } from 'https://esm.sh/zod@3.25.76';
 import { tipCorsHeadersForRequest } from '../_shared/cors.ts';

--- a/supabase/functions/tip-voice-stream/index.ts
+++ b/supabase/functions/tip-voice-stream/index.ts
@@ -10,7 +10,7 @@
 // quick-order-voice-stream.
 
 // @ts-ignore Deno Edge Functions support remote npm-style imports.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { getTipSessionById, sha256Hex } from '../_shared/tips.ts';
 
 declare const Deno: {

--- a/supabase/functions/update-access-codes/index.ts
+++ b/supabase/functions/update-access-codes/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeadersForRequest } from '../_shared/cors.ts';
 
 const ACCESS_CODE_REGEX = /^\d{4}$/;

--- a/supabase/functions/validate-access-code/index.ts
+++ b/supabase/functions/validate-access-code/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeadersForRequest } from '../_shared/cors.ts';
 
 type Role = 'employee' | 'manager';

--- a/supabase/functions/voice-order/index.ts
+++ b/supabase/functions/voice-order/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeadersForRequest } from '../_shared/cors.ts';
 import { userCanAccessLocation } from '../_shared/location-access.ts';
 


### PR DESCRIPTION
## What

E2E pass 2 fixes verified on the local full-stack harness (Sep 1), plus the loose ends from the Sep 3 repo audit.

- `parse-order`: a failed or malformed LLM intent route no longer short-circuits deterministic parsing; ignored-phrase stripping keeps newlines so multi-line orders still segment.
- Edge functions: every `supabase-js@2.57.2` import pinned with `?no-dts` so the Deno runtime stops chasing esm.sh's broken type modules (local runtime failed, redeploys were at risk).
- Order store: stale fulfillment badge cleared; invite draft no longer carries over between locations.
- History empty state: final copy ("No sent orders yet" and the manager-review explanation).
- `CONTEXT.md`: domain vocabulary for the supply side and the new guest-side ordering (Tab, Line, Ticket, Send, Kitchen Display, Dictation, Ambient Listening).
- `.gitignore`: `.env.prod-backup` and `supabase/.branches/`.

## Validation

| Check | Command | Result |
|---|---|---|
| Typecheck | `npm run typecheck` | exit 0 |
| Lint | `npm run lint` | 0 errors, 91 pre-existing warnings |
| Unit | `npx jest --runInBand --watchman=false --testPathIgnorePatterns '/node_modules/'` | 60 suites, 929 passed, 14 skipped |
| Edge fn | `deno test --no-config --no-check supabase/functions/parse-order/process-message.test.ts` | 4 passed |

Note: `npm run test:ci` finds zero tests when run from a `.claude/worktrees/` checkout because `jest.config.js` ignores `/\.claude/`; the override above is the same suite.

Not rerun for this PR: the local full-stack E2E run from Sep 1 (flagship + ordering flows) that produced the first three commits. Only copy, docs, and gitignore changed since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
