### PR TITLE
Enforce device push token ownership server side

### DIFF
--- a/scripts/local-db/README.md
+++ b/scripts/local-db/README.md
@@ -124,6 +124,26 @@ idempotent sends, actor identity, location scope, suspension, and RLS for
 display, no-module, and anonymous users. It ends with
 `PASS: kitchen requests fixture assertions all held` and rolls back.
 
+### Push token ownership fixture
+
+After a kept migration run, execute the push token ownership fixture:
+
+```sh
+docker exec -i <container-name> psql -U postgres -d postgres \
+  -v ON_ERROR_STOP=1 < scripts/local-db/push_token_ownership_fixture.sql
+```
+
+It proves the three clauses of the shared-device rule: registering a token
+claims it, the claim deactivates prior owners' rows for that token only, and
+`active_device_push_tokens` never returns a token the recipient no longer owns
+(including a stale active row that a later claim outranks). It also covers the
+reverse handover, the one-active-owner unique index, the unchanged per-user
+RLS, and the service-role-only grant on the resolver. It ends with
+`PASS: push token ownership fixture assertions all held` and rolls back.
+
+The fixture restates the table grants itself, because the baseline snapshot is
+DDL-only.
+
 ## What this does NOT prove
 
 - **No gotrue / real auth.** `auth` is a stub: only `auth.users(id, email,

--- a/scripts/local-db/README.md
+++ b/scripts/local-db/README.md
@@ -17,7 +17,7 @@ This harness answers a narrower, more useful question instead:
 | --- | --- |
 | `baseline_public_schema.sql` | Full DDL snapshot of prod's `public` schema (project `whrohvitvmcrmedepurd`): 75 tables with columns/defaults/generated columns, PK/unique/check constraints, FKs, 2 sequences, 55 functions, 45 triggers, all non-constraint indexes, RLS enablement and all 142 policies. Generated 2026-08-11 via read-only `pg_catalog` / `information_schema` queries (`pg_get_constraintdef`, `pg_get_indexdef`, `pg_get_functiondef`, `pg_get_triggerdef`, `pg_policies`). |
 | `auth_stub.sql` | Minimal stand-in for Supabase-managed dependencies: roles `anon` / `authenticated` / `service_role`, an `auth` schema with a minimal `auth.users` table, and `auth.uid()` / `auth.role()` / `auth.jwt()` stubs that read the `request.jwt.claim.*` GUCs (null-safe). |
-| `verify-migrations.sh` | The runner. Disposable `postgres:17` Docker container on a random free localhost port; loads `auth_stub.sql`, then `baseline_public_schema.sql`, then applies every migration newer than the snapshot cutoff plus any older branch-new migration, in timestamp order. Fails loudly on the first error; always removes the container via an EXIT trap unless `--keep` is passed. |
+| `verify-migrations.sh` | The runner. Disposable `postgres:17` Docker container on a Docker-assigned localhost port; loads `auth_stub.sql`, then `baseline_public_schema.sql`, then applies every migration newer than the snapshot cutoff plus any older branch-new migration, in timestamp order. Each SQL file runs with `--single-transaction`, so a failed migration does not leave a partial schema. The runner fails on the first error and removes the container through an EXIT trap unless `--keep` is passed. |
 
 ## Usage
 
@@ -137,12 +137,14 @@ It proves the three clauses of the shared-device rule: registering a token
 claims it, the claim deactivates prior owners' rows for that token only, and
 `active_device_push_tokens` never returns a token the recipient no longer owns
 (including a stale active row that a later claim outranks, and a late sign-out
-whose `updated_at` is newer than the active owner's claim). It also covers the
-canonical token form (a padded spelling collapses onto the existing token and
-claims it, a non-token is refused), the server-owned ownership clock (a
-non-activating write cannot move `claimed_at` or the token), the reverse
-handover, the one-active-owner unique index, the unchanged per-user RLS, and
-the service-role-only grant on the resolver. It ends with
+whose `updated_at` is newer than the active owner's claim). It rewinds and
+reapplies the ownership migration inside the fixture transaction to cover the
+backfill. Cases include leading and trailing U+FEFF, U+00A0, both wrapped
+around one token, and a newer inactive canonical row beside an older active
+padded alias. Runtime checks cover the same Unicode canonicalization, exact
+token grammar, inactive-insert rejection, the server-owned ownership clock,
+reverse handover, the one-active-owner unique index, unchanged per-user RLS,
+and the service-role-only resolver grant. It ends with
 `PASS: push token ownership fixture assertions all held` and rolls back.
 
 The fixture restates the table grants itself, because the baseline snapshot is

--- a/scripts/local-db/README.md
+++ b/scripts/local-db/README.md
@@ -17,7 +17,7 @@ This harness answers a narrower, more useful question instead:
 | --- | --- |
 | `baseline_public_schema.sql` | Full DDL snapshot of prod's `public` schema (project `whrohvitvmcrmedepurd`): 75 tables with columns/defaults/generated columns, PK/unique/check constraints, FKs, 2 sequences, 55 functions, 45 triggers, all non-constraint indexes, RLS enablement and all 142 policies. Generated 2026-08-11 via read-only `pg_catalog` / `information_schema` queries (`pg_get_constraintdef`, `pg_get_indexdef`, `pg_get_functiondef`, `pg_get_triggerdef`, `pg_policies`). |
 | `auth_stub.sql` | Minimal stand-in for Supabase-managed dependencies: roles `anon` / `authenticated` / `service_role`, an `auth` schema with a minimal `auth.users` table, and `auth.uid()` / `auth.role()` / `auth.jwt()` stubs that read the `request.jwt.claim.*` GUCs (null-safe). |
-| `verify-migrations.sh` | The runner. Disposable `postgres:17` Docker container on a Docker-assigned localhost port; loads `auth_stub.sql`, then `baseline_public_schema.sql`, then applies every migration newer than the snapshot cutoff plus any older branch-new migration, in timestamp order. Each SQL file runs with `--single-transaction`, so a failed migration does not leave a partial schema. The runner fails on the first error and removes the container through an EXIT trap unless `--keep` is passed. |
+| `verify-migrations.sh` | The runner. Disposable `postgres:17` Docker container on a Docker-assigned localhost port; loads `auth_stub.sql`, then `baseline_public_schema.sql`, then applies every migration newer than the snapshot cutoff plus any older branch-new migration, in timestamp order. Each SQL file runs with `--single-transaction`, so a failed migration does not leave a partial schema, except for the handful of older files that open and commit their own transaction (`20260526100000_google_sheets_quick_order_restructure.sql` is one; psql warns and the file commits early). The runner fails on the first error and removes the container through an EXIT trap unless `--keep` is passed. |
 
 ## Usage
 
@@ -132,6 +132,11 @@ After a kept migration run, execute the push token ownership fixture:
 docker exec -i <container-name> psql -U postgres -d postgres \
   -v ON_ERROR_STOP=1 < scripts/local-db/push_token_ownership_fixture.sql
 ```
+
+It only runs against a `verify-migrations.sh` container. The fixture
+`\i`s the migration back in from `/workspace`, a read-only bind mount that
+only that runner creates, so against a `full-stack.sh` container it fails with
+an unexplained file-not-found.
 
 It proves the three clauses of the shared-device rule: registering a token
 claims it, the claim deactivates prior owners' rows for that token only, and

--- a/scripts/local-db/README.md
+++ b/scripts/local-db/README.md
@@ -136,13 +136,28 @@ docker exec -i <container-name> psql -U postgres -d postgres \
 It proves the three clauses of the shared-device rule: registering a token
 claims it, the claim deactivates prior owners' rows for that token only, and
 `active_device_push_tokens` never returns a token the recipient no longer owns
-(including a stale active row that a later claim outranks). It also covers the
-reverse handover, the one-active-owner unique index, the unchanged per-user
-RLS, and the service-role-only grant on the resolver. It ends with
+(including a stale active row that a later claim outranks, and a late sign-out
+whose `updated_at` is newer than the active owner's claim). It also covers the
+canonical token form (a padded spelling collapses onto the existing token and
+claims it, a non-token is refused), the server-owned ownership clock (a
+non-activating write cannot move `claimed_at` or the token), the reverse
+handover, the one-active-owner unique index, the unchanged per-user RLS, and
+the service-role-only grant on the resolver. It ends with
 `PASS: push token ownership fixture assertions all held` and rolls back.
 
 The fixture restates the table grants itself, because the baseline snapshot is
 DDL-only.
+
+Concurrent claims need two connections, so they live in a separate script:
+
+```sh
+scripts/local-db/push_token_concurrency_check.sh <container-name>
+```
+
+Two users register the same token with no active row to arbitrate between
+them. It asserts the later registration wins and no unique violation is raised,
+and it fails if the second session did not actually contend for the lock. It
+cleans up its own rows and leaves the container running.
 
 ## What this does NOT prove
 

--- a/scripts/local-db/push_token_concurrency_check.sh
+++ b/scripts/local-db/push_token_concurrency_check.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# push_token_concurrency_check.sh
+#
+# Two users register the same device token at the same moment, with no active
+# row to arbitrate between them. The advisory lock in claim_device_push_token
+# has to serialize them so the later registration wins, instead of the second
+# one failing on the one-active-owner unique index.
+#
+# The single-session fixture cannot express this: it needs two connections.
+#
+# Usage, against a container left by verify-migrations.sh --keep:
+#   scripts/local-db/verify-migrations.sh --keep
+#   scripts/local-db/push_token_concurrency_check.sh <container-name>
+#
+# Exit 0 = PASS. The script removes its own rows and leaves the container up.
+
+set -euo pipefail
+
+CONTAINER="${1:-}"
+if [[ -z "$CONTAINER" ]]; then
+  echo "usage: $0 <postgres-container-name>" >&2
+  exit 2
+fi
+
+USER_A='dddddddd-3000-4000-8000-000000000001'
+USER_B='dddddddd-3000-4000-8000-000000000002'
+TOKEN='ExponentPushToken[concurrency-shared-device]'
+# Session 1 holds its transaction open this long after claiming.
+HOLD_SECONDS=3
+
+psql_in() {
+  docker exec -i "$CONTAINER" psql -U postgres -d postgres -v ON_ERROR_STOP=1 "$@"
+}
+
+cleanup() {
+  psql_in -q <<SQL || true
+delete from public.device_push_tokens where user_id in ('$USER_A', '$USER_B');
+delete from public.users where id in ('$USER_A', '$USER_B');
+delete from auth.users where id in ('$USER_A', '$USER_B');
+SQL
+}
+trap cleanup EXIT
+
+echo "==> Seeding two users"
+psql_in -q <<SQL
+insert into auth.users (id, email) values
+  ('$USER_A', 'concurrency-a@example.test'),
+  ('$USER_B', 'concurrency-b@example.test')
+on conflict (id) do nothing;
+insert into public.users (id, email, name, role) values
+  ('$USER_A', 'concurrency-a@example.test', 'Concurrency A', 'employee'),
+  ('$USER_B', 'concurrency-b@example.test', 'Concurrency B', 'employee')
+on conflict (id) do nothing;
+delete from public.device_push_tokens where expo_push_token = '$TOKEN';
+SQL
+
+echo "==> Session 1 claims the token and holds its transaction for ${HOLD_SECONDS}s"
+(
+  psql_in -q <<SQL
+begin;
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values ('$USER_A', '$TOKEN', 'ios', true);
+select pg_sleep($HOLD_SECONDS);
+commit;
+SQL
+  echo "    session 1 committed"
+) &
+SESSION_ONE=$!
+
+# Long enough that session 1 is certainly inside its transaction holding the
+# advisory lock, short enough that it is still holding it.
+python3 -c "import time; time.sleep(1)"
+
+echo "==> Session 2 registers the same token while session 1 still holds it"
+SECOND_START=$(python3 -c "import time; print(time.time())")
+if ! psql_in -q <<SQL
+begin;
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values ('$USER_B', '$TOKEN', 'ios', true);
+commit;
+SQL
+then
+  echo "FAIL: the second registration errored instead of taking the token over" >&2
+  wait "$SESSION_ONE" || true
+  exit 1
+fi
+SECOND_WAITED=$(python3 -c "import time; print(round(time.time() - $SECOND_START, 2))")
+echo "    session 2 committed after waiting ${SECOND_WAITED}s"
+
+wait "$SESSION_ONE"
+
+echo "==> Result"
+psql_in -c "select user_id, active, claimed_at from public.device_push_tokens where expo_push_token = '$TOKEN' order by claimed_at;"
+
+WINNER="$(psql_in -Atc "select user_id::text from public.device_push_tokens where expo_push_token = '$TOKEN' and active")"
+LOSERS="$(psql_in -Atc "select count(*) from public.device_push_tokens where expo_push_token = '$TOKEN' and not active")"
+
+if [[ "$WINNER" != "$USER_B" ]]; then
+  echo "FAIL: the later registration did not win the token (active owner: '$WINNER')" >&2
+  exit 1
+fi
+if [[ "$LOSERS" != "1" ]]; then
+  echo "FAIL: expected exactly one retired row, found $LOSERS" >&2
+  exit 1
+fi
+if python3 -c "import sys; sys.exit(0 if $SECOND_WAITED >= 0.5 else 1)"; then
+  echo "PASS: concurrent claims serialized, the later registration won, no unique violation."
+else
+  echo "FAIL: session 2 did not wait, so it never contended for the lock" >&2
+  exit 1
+fi

--- a/scripts/local-db/push_token_ownership_fixture.sql
+++ b/scripts/local-db/push_token_ownership_fixture.sql
@@ -9,13 +9,20 @@
 --   1. A device token belongs to the last user who registers it.
 --   2. A new registration deactivates prior owners' rows.
 --   3. A send never targets a token whose current owner is not the recipient.
+-- plus the canonical token form and the server-owned ownership clock that the
+-- three clauses rest on.
+--
+-- Concurrent claims are covered separately, by
+-- scripts/local-db/push_token_concurrency_check.sh, which needs two sessions.
 
 \set ON_ERROR_STOP on
 
 \set user_a '''aaaaaaaa-2000-4000-8000-000000000001'''
 \set user_b '''aaaaaaaa-2000-4000-8000-000000000002'''
 \set shared_token '''ExponentPushToken[fixture-shared-device]'''
+\set spaced_token '''  ExponentPushToken[fixture-shared-device] '''
 \set other_token '''ExponentPushToken[fixture-user-a-tablet]'''
+\set late_signout_token '''ExponentPushToken[fixture-late-signout]'''
 
 begin;
 
@@ -159,13 +166,141 @@ $$;
 reset role;
 
 -- ---------------------------------------------------------------------------
--- Handover is reversible: the original user reclaims the device on next login.
+-- A padded spelling is the same device. The Data API is reachable directly, so
+-- a client can send whitespace the app would have trimmed. It must collapse
+-- onto the existing token rather than open a second, unowned lane to the same
+-- phone. B currently owns the device; A re-registers with the padded form.
 -- ---------------------------------------------------------------------------
 select set_config('request.jwt.claim.sub', :user_a, false);
 set role authenticated;
 
 insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
-values (:user_a, :shared_token, 'ios', true)
+values (:user_a, :spaced_token, 'ios', true)
+on conflict (user_id, expo_push_token)
+do update set platform = excluded.platform, active = true;
+
+reset role;
+
+do $$
+declare
+  v_rows_for_a integer;
+  v_padded_rows integer;
+  v_a_shared boolean;
+  v_b_shared boolean;
+begin
+  select count(*) into v_rows_for_a
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000001';
+
+  select count(*) into v_padded_rows
+  from public.device_push_tokens
+  where expo_push_token <> btrim(expo_push_token);
+
+  select active into v_a_shared
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000001'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  select active into v_b_shared
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  if v_padded_rows <> 0 then
+    raise exception 'FAIL: a padded token spelling was stored verbatim';
+  end if;
+  if v_rows_for_a <> 2 then
+    raise exception 'FAIL: the padded spelling created a second row, % rows for the user', v_rows_for_a;
+  end if;
+  if v_a_shared is not true or v_b_shared is not false then
+    raise exception 'FAIL: the padded registration did not claim the device';
+  end if;
+  raise notice 'ok: a padded token spelling collapses onto the canonical token and claims it';
+end;
+$$;
+
+-- A value that cannot be canonicalized into an Expo token is refused outright.
+select set_config('request.jwt.claim.sub', :user_a, false);
+set role authenticated;
+
+do $$
+begin
+  begin
+    insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+    values ('aaaaaaaa-2000-4000-8000-000000000001', '   ', 'ios', true);
+    raise exception 'FAIL: a blank token was accepted';
+  exception
+    when invalid_parameter_value then
+      raise notice 'ok: a value that is not an Expo token is refused';
+  end;
+end;
+$$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- The ownership clock is server owned. A former owner holds a row they may
+-- update freely under RLS; neither claimed_at nor the token identity may move
+-- on a write that does not activate the row.
+-- ---------------------------------------------------------------------------
+select set_config('request.jwt.claim.sub', :user_b, false);
+set role authenticated;
+
+update public.device_push_tokens
+set claimed_at = 'infinity'::timestamptz,
+    expo_push_token = 'ExponentPushToken[fixture-hijack]',
+    platform = 'android'
+where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
+  and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+reset role;
+
+do $$
+declare
+  v_claimed timestamptz;
+  v_platform text;
+  v_hijack integer;
+  v_a_tokens text[];
+begin
+  select claimed_at, platform into v_claimed, v_platform
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  select count(*) into v_hijack
+  from public.device_push_tokens
+  where expo_push_token = 'ExponentPushToken[fixture-hijack]';
+
+  if v_claimed is null or v_claimed = 'infinity'::timestamptz then
+    raise exception 'FAIL: a client rewrote the ownership clock';
+  end if;
+  if v_hijack <> 0 then
+    raise exception 'FAIL: a client moved an inactive row onto another token';
+  end if;
+  if v_platform <> 'android' then
+    raise exception 'FAIL: the pin-back blocked an ordinary column update';
+  end if;
+
+  -- Read as the owner of the resolver rather than switching role mid-block.
+  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  into v_a_tokens
+  from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
+
+  if not ('ExponentPushToken[fixture-shared-device]' = any (v_a_tokens)) then
+    raise exception 'FAIL: a forged claim locked the real owner out: %', v_a_tokens;
+  end if;
+  raise notice 'ok: a non-activating write cannot move the clock or the token';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Handover is reversible: B reclaims the device on next login.
+-- ---------------------------------------------------------------------------
+select set_config('request.jwt.claim.sub', :user_b, false);
+set role authenticated;
+
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values (:user_b, :shared_token, 'ios', true)
 on conflict (user_id, expo_push_token)
 do update set platform = excluded.platform, active = true;
 
@@ -186,7 +321,7 @@ begin
   where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
     and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
 
-  if v_a_shared is not true or v_b_shared is not false then
+  if v_b_shared is not true or v_a_shared is not false then
     raise exception 'FAIL: re-registering did not hand the device back';
   end if;
   raise notice 'ok: ownership follows the most recent registration in both directions';
@@ -204,7 +339,7 @@ begin
   begin
     insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
     values (
-      'aaaaaaaa-2000-4000-8000-000000000002',
+      'aaaaaaaa-2000-4000-8000-000000000001',
       'ExponentPushToken[fixture-shared-device]',
       'ios',
       true
@@ -219,17 +354,23 @@ begin
 end;
 $$;
 
-alter table public.device_push_tokens enable trigger device_push_tokens_claim_device;
+-- A late sign-out writing after the current owner registered must not read as
+-- a newer claim: the inactive row carries a newer updated_at but an older
+-- claimed_at, and the active owner stays reachable. This is the shape the
+-- migration's backfill has to produce for legacy rows.
+insert into public.device_push_tokens
+  (user_id, expo_push_token, platform, active, created_at, updated_at, claimed_at)
+values
+  (
+    'aaaaaaaa-2000-4000-8000-000000000001', 'ExponentPushToken[fixture-late-signout]', 'ios',
+    true, '2026-01-01 00:00:00+00', '2026-01-01 00:00:00+00', '2026-01-01 00:00:00+00'
+  ),
+  (
+    'aaaaaaaa-2000-4000-8000-000000000002', 'ExponentPushToken[fixture-late-signout]', 'ios',
+    false, '2025-12-01 00:00:00+00', '2026-06-01 00:00:00+00', '2025-12-01 00:00:00+00'
+  );
 
--- A's row is active again after the reclaim above. Give B the newer claim
--- without reactivating B: the shape left behind when the current owner signs
--- out normally while an earlier owner's row was never retired. The stale
--- active row must still not be targetable. B's row stays inactive, so this
--- update does not fire the claim trigger.
-update public.device_push_tokens
-set claimed_at = clock_timestamp()
-where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
-  and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+alter table public.device_push_tokens enable trigger device_push_tokens_claim_device;
 
 set role service_role;
 
@@ -241,7 +382,36 @@ begin
   into v_a_tokens
   from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
 
-  if 'ExponentPushToken[fixture-shared-device]' = any (v_a_tokens) then
+  if not ('ExponentPushToken[fixture-late-signout]' = any (v_a_tokens)) then
+    raise exception 'FAIL: a late sign-out outranked the active owner: %', v_a_tokens;
+  end if;
+  raise notice 'ok: a newer deactivation does not outrank the active owner';
+end;
+$$;
+
+reset role;
+
+-- The mirror case: a stale active row must lose to a later claim, even when
+-- the later claimant has since signed out. Only B's claim moves; A's row stays
+-- active, which is exactly the state the resolver has to see through.
+alter table public.device_push_tokens disable trigger device_push_tokens_claim_device;
+update public.device_push_tokens
+set claimed_at = clock_timestamp()
+where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
+  and expo_push_token = 'ExponentPushToken[fixture-late-signout]';
+alter table public.device_push_tokens enable trigger device_push_tokens_claim_device;
+
+set role service_role;
+
+do $$
+declare
+  v_a_tokens text[];
+begin
+  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  into v_a_tokens
+  from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
+
+  if 'ExponentPushToken[fixture-late-signout]' = any (v_a_tokens) then
     raise exception 'FAIL: a stale active row outranked a later claim: %', v_a_tokens;
   end if;
   raise notice 'ok: a later claim beats a stale active row on the same token';

--- a/scripts/local-db/push_token_ownership_fixture.sql
+++ b/scripts/local-db/push_token_ownership_fixture.sql
@@ -41,6 +41,137 @@ insert into public.users (id, email, name, role) values
   (:user_b, 'push-owner-b@example.test', 'Push Owner B', 'employee');
 
 -- ---------------------------------------------------------------------------
+-- Migration repair. Rewind only the objects added by the ownership migration,
+-- seed legacy rows, and apply the checked-in migration again inside this
+-- fixture transaction. verify-migrations.sh mounts the worktree read-only at
+-- /workspace for this include.
+-- ---------------------------------------------------------------------------
+drop function public.active_device_push_tokens(uuid);
+drop trigger device_push_tokens_claim_device on public.device_push_tokens;
+drop function public.claim_device_push_token();
+drop index public.device_push_tokens_one_active_owner_idx;
+drop index public.device_push_tokens_token_claimed_idx;
+alter table public.device_push_tokens
+  drop constraint device_push_tokens_expo_push_token_canonical;
+alter table public.device_push_tokens drop column claimed_at;
+drop function public.is_expo_push_token(text);
+drop function public.canonical_expo_push_token(text);
+
+insert into public.device_push_tokens
+  (user_id, expo_push_token, platform, active, created_at, updated_at)
+values
+  (
+    :user_a,
+    '  ExponentPushToken[fixture-alias-newer-deactivation]  ',
+    'ios',
+    true,
+    '2026-01-01 00:00:00+00',
+    '2026-01-01 00:00:00+00'
+  ),
+  (
+    :user_a,
+    'ExponentPushToken[fixture-alias-newer-deactivation]',
+    'ios',
+    false,
+    '2026-01-01 00:00:00+00',
+    '2026-02-01 00:00:00+00'
+  ),
+  (
+    :user_a,
+    U&'\FEFFExponentPushToken[fixture-backfill-leading-feff]',
+    'ios',
+    true,
+    '2026-03-01 00:00:00+00',
+    '2026-03-01 00:00:00+00'
+  ),
+  (
+    :user_a,
+    U&'ExponentPushToken[fixture-backfill-trailing-feff]\FEFF',
+    'ios',
+    true,
+    '2026-03-02 00:00:00+00',
+    '2026-03-02 00:00:00+00'
+  ),
+  (
+    :user_a,
+    U&'\00A0ExpoPushToken[fixture-backfill-nbsp]\00A0',
+    'ios',
+    true,
+    '2026-03-03 00:00:00+00',
+    '2026-03-03 00:00:00+00'
+  ),
+  (
+    :user_a,
+    U&'\FEFF\00A0ExponentPushToken[fixture-backfill-wrapped]\00A0\FEFF',
+    'ios',
+    true,
+    '2026-03-04 00:00:00+00',
+    '2026-03-04 00:00:00+00'
+  ),
+  (
+    :user_a,
+    U&'\FEFFnot-an-expo-token\FEFF',
+    'ios',
+    true,
+    '2026-03-05 00:00:00+00',
+    '2026-03-05 00:00:00+00'
+  );
+
+\i /workspace/supabase/migrations/20260905120000_device_push_token_ownership.sql
+
+do $$
+declare
+  v_alias_count integer;
+  v_alias_active boolean;
+  v_alias_updated timestamptz;
+  v_unicode_tokens text[];
+  v_invalid_count integer;
+begin
+  select count(*), bool_or(active), max(updated_at)
+  into v_alias_count, v_alias_active, v_alias_updated
+  from public.device_push_tokens
+  where expo_push_token = 'ExponentPushToken[fixture-alias-newer-deactivation]';
+
+  if v_alias_count <> 1 or v_alias_active is not false then
+    raise exception 'FAIL: alias cleanup kept the stale active spelling';
+  end if;
+  if v_alias_updated <> '2026-02-01 00:00:00+00'::timestamptz then
+    raise exception 'FAIL: alias cleanup did not keep the newest write: %', v_alias_updated;
+  end if;
+
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
+  into v_unicode_tokens
+  from public.device_push_tokens
+  where expo_push_token like '%fixture-backfill-%';
+
+  if v_unicode_tokens <> array[
+    'ExpoPushToken[fixture-backfill-nbsp]',
+    'ExponentPushToken[fixture-backfill-leading-feff]',
+    'ExponentPushToken[fixture-backfill-trailing-feff]',
+    'ExponentPushToken[fixture-backfill-wrapped]'
+  ] then
+    raise exception 'FAIL: backfill did not canonicalize ECMAScript padding: %', v_unicode_tokens;
+  end if;
+
+  select count(*) into v_invalid_count
+  from public.device_push_tokens
+  where position('not-an-expo-token' in expo_push_token) > 0;
+  if v_invalid_count <> 0 then
+    raise exception 'FAIL: backfill kept a value outside the canonical grammar';
+  end if;
+
+  raise notice 'ok: backfill canonicalizes ECMAScript padding and deletes only invalid values';
+  raise notice 'ok: alias cleanup keeps a newer inactive row over a stale active spelling';
+end;
+$$;
+
+delete from public.device_push_tokens
+where user_id in (
+  'aaaaaaaa-2000-4000-8000-000000000001',
+  'aaaaaaaa-2000-4000-8000-000000000002'
+);
+
+-- ---------------------------------------------------------------------------
 -- Clause 1: registering a token claims it for the registering user.
 -- The insert shape matches the client upsert in src/services/notificationService.ts.
 -- ---------------------------------------------------------------------------
@@ -79,6 +210,54 @@ begin
   raise notice 'ok: registering a token claims it for the registering user';
 end;
 $$;
+
+-- An inactive insert is not a registration and must not create a claim that
+-- suppresses the active owner. Client deactivation uses UPDATE only.
+select set_config('request.jwt.claim.sub', :user_b, false);
+set role authenticated;
+
+do $$
+declare
+  v_error text;
+begin
+  begin
+    insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+    values (
+      'aaaaaaaa-2000-4000-8000-000000000002',
+      'ExponentPushToken[fixture-shared-device]',
+      'ios',
+      false
+    );
+    raise exception 'FAIL: an inactive insert was accepted';
+  exception
+    when invalid_parameter_value then
+      get stacked diagnostics v_error = message_text;
+      if position('inactive' in lower(v_error)) = 0 then
+        raise exception 'FAIL: inactive insert error was unclear: %', v_error;
+      end if;
+  end;
+end;
+$$;
+
+reset role;
+set role service_role;
+
+do $$
+declare
+  v_a_tokens text[];
+begin
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
+  into v_a_tokens
+  from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
+
+  if not ('ExponentPushToken[fixture-shared-device]' = any (v_a_tokens)) then
+    raise exception 'FAIL: an inactive insert suppressed the active owner: %', v_a_tokens;
+  end if;
+  raise notice 'ok: an inactive insert is rejected and cannot suppress the active owner';
+end;
+$$;
+
+reset role;
 
 -- ---------------------------------------------------------------------------
 -- Clause 2: the next user to register the same token takes it over, and the
@@ -145,11 +324,11 @@ declare
   v_a_tokens text[];
   v_b_tokens text[];
 begin
-  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
   into v_a_tokens
   from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
 
-  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
   into v_b_tokens
   from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000002');
 
@@ -166,10 +345,11 @@ $$;
 reset role;
 
 -- ---------------------------------------------------------------------------
--- A padded spelling is the same device. The Data API is reachable directly, so
--- a client can send whitespace the app would have trimmed. It must collapse
--- onto the existing token rather than open a second, unowned lane to the same
--- phone. B currently owns the device; A re-registers with the padded form.
+-- Every ECMAScript trim spelling is the same device. The Data API is reachable
+-- directly, so a client can send whitespace the app would have trimmed. Each
+-- spelling must collapse onto its canonical token instead of opening a second,
+-- unowned lane to the same phone. B currently owns the shared device; A
+-- re-registers it with ASCII padding and registers four Unicode fixture tokens.
 -- ---------------------------------------------------------------------------
 select set_config('request.jwt.claim.sub', :user_a, false);
 set role authenticated;
@@ -179,6 +359,18 @@ values (:user_a, :spaced_token, 'ios', true)
 on conflict (user_id, expo_push_token)
 do update set platform = excluded.platform, active = true;
 
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values
+  (:user_a, U&'\FEFFExponentPushToken[fixture-leading-feff]', 'ios', true),
+  (:user_a, U&'ExponentPushToken[fixture-trailing-feff]\FEFF', 'ios', true),
+  (:user_a, U&'\00A0ExpoPushToken[fixture-nbsp]\00A0', 'ios', true),
+  (
+    :user_a,
+    U&'\FEFF\00A0ExponentPushToken[fixture-wrapped]\00A0\FEFF',
+    'ios',
+    true
+  );
+
 reset role;
 
 do $$
@@ -187,6 +379,7 @@ declare
   v_padded_rows integer;
   v_a_shared boolean;
   v_b_shared boolean;
+  v_unicode_tokens text[];
 begin
   select count(*) into v_rows_for_a
   from public.device_push_tokens
@@ -206,16 +399,35 @@ begin
   where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
     and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
 
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
+  into v_unicode_tokens
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000001'
+    and expo_push_token in (
+      'ExpoPushToken[fixture-nbsp]',
+      'ExponentPushToken[fixture-leading-feff]',
+      'ExponentPushToken[fixture-trailing-feff]',
+      'ExponentPushToken[fixture-wrapped]'
+    );
+
   if v_padded_rows <> 0 then
     raise exception 'FAIL: a padded token spelling was stored verbatim';
   end if;
-  if v_rows_for_a <> 2 then
-    raise exception 'FAIL: the padded spelling created a second row, % rows for the user', v_rows_for_a;
+  if v_rows_for_a <> 6 then
+    raise exception 'FAIL: token canonicalization left the wrong row count: %', v_rows_for_a;
   end if;
   if v_a_shared is not true or v_b_shared is not false then
     raise exception 'FAIL: the padded registration did not claim the device';
   end if;
-  raise notice 'ok: a padded token spelling collapses onto the canonical token and claims it';
+  if v_unicode_tokens <> array[
+    'ExpoPushToken[fixture-nbsp]',
+    'ExponentPushToken[fixture-leading-feff]',
+    'ExponentPushToken[fixture-trailing-feff]',
+    'ExponentPushToken[fixture-wrapped]'
+  ] then
+    raise exception 'FAIL: ECMAScript whitespace was not canonicalized: %', v_unicode_tokens;
+  end if;
+  raise notice 'ok: ASCII, U+FEFF, and U+00A0 padding canonicalize to one grammar';
 end;
 $$;
 
@@ -232,6 +444,24 @@ begin
   exception
     when invalid_parameter_value then
       raise notice 'ok: a value that is not an Expo token is refused';
+  end;
+
+  begin
+    insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+    values ('aaaaaaaa-2000-4000-8000-000000000001', 'ExpoPushToken[bad token]', 'ios', true);
+    raise exception 'FAIL: a token containing whitespace was accepted';
+  exception
+    when invalid_parameter_value then
+      null;
+  end;
+
+  begin
+    insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+    values ('aaaaaaaa-2000-4000-8000-000000000001', 'ExpoPushToken[closed]junk', 'ios', true);
+    raise exception 'FAIL: a token with trailing junk was accepted';
+  exception
+    when invalid_parameter_value then
+      null;
   end;
 end;
 $$;
@@ -282,7 +512,7 @@ begin
   end if;
 
   -- Read as the owner of the resolver rather than switching role mid-block.
-  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
   into v_a_tokens
   from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
 
@@ -378,7 +608,7 @@ do $$
 declare
   v_a_tokens text[];
 begin
-  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
   into v_a_tokens
   from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
 
@@ -407,7 +637,7 @@ do $$
 declare
   v_a_tokens text[];
 begin
-  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  select coalesce(array_agg(expo_push_token order by expo_push_token collate "C"), '{}')
   into v_a_tokens
   from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
 

--- a/scripts/local-db/push_token_ownership_fixture.sql
+++ b/scripts/local-db/push_token_ownership_fixture.sql
@@ -1,0 +1,298 @@
+-- Device push token ownership checks.
+-- Run only after scripts/local-db/verify-migrations.sh --keep:
+--   docker exec -i <container> psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+--     < scripts/local-db/push_token_ownership_fixture.sql
+-- Expected output: "ok: ..." notices followed by
+--   "PASS: push token ownership fixture assertions all held" and a ROLLBACK.
+--
+-- Proves the three clauses of the ownership rule:
+--   1. A device token belongs to the last user who registers it.
+--   2. A new registration deactivates prior owners' rows.
+--   3. A send never targets a token whose current owner is not the recipient.
+
+\set ON_ERROR_STOP on
+
+\set user_a '''aaaaaaaa-2000-4000-8000-000000000001'''
+\set user_b '''aaaaaaaa-2000-4000-8000-000000000002'''
+\set shared_token '''ExponentPushToken[fixture-shared-device]'''
+\set other_token '''ExponentPushToken[fixture-user-a-tablet]'''
+
+begin;
+
+-- The baseline snapshot is DDL-only and does not carry production's grant
+-- matrix (scripts/local-db/README.md), so restate the grants this table
+-- already has in production before simulating a client.
+grant select, insert, update, delete on public.device_push_tokens to authenticated;
+grant select on public.device_push_tokens to service_role;
+
+insert into auth.users (id, email) values
+  (:user_a, 'push-owner-a@example.test'),
+  (:user_b, 'push-owner-b@example.test');
+
+insert into public.users (id, email, name, role) values
+  (:user_a, 'push-owner-a@example.test', 'Push Owner A', 'employee'),
+  (:user_b, 'push-owner-b@example.test', 'Push Owner B', 'employee');
+
+-- ---------------------------------------------------------------------------
+-- Clause 1: registering a token claims it for the registering user.
+-- The insert shape matches the client upsert in src/services/notificationService.ts.
+-- ---------------------------------------------------------------------------
+select set_config('request.jwt.claim.sub', :user_a, false);
+set role authenticated;
+
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values (:user_a, :shared_token, 'ios', true)
+on conflict (user_id, expo_push_token)
+do update set platform = excluded.platform, active = true;
+
+-- A second device of the same user, to prove a claim is token-scoped.
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values (:user_a, :other_token, 'ios', true)
+on conflict (user_id, expo_push_token)
+do update set platform = excluded.platform, active = true;
+
+reset role;
+
+do $$
+declare
+  v_active boolean;
+  v_claimed_at timestamptz;
+begin
+  select active, claimed_at into v_active, v_claimed_at
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000001'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  if v_active is not true then
+    raise exception 'FAIL: the first registration did not leave the row active';
+  end if;
+  if v_claimed_at is null then
+    raise exception 'FAIL: the first registration did not stamp claimed_at';
+  end if;
+  raise notice 'ok: registering a token claims it for the registering user';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Clause 2: the next user to register the same token takes it over, and the
+-- prior owner's row is deactivated even though RLS forbids that user from
+-- touching it.
+-- ---------------------------------------------------------------------------
+select set_config('request.jwt.claim.sub', :user_b, false);
+set role authenticated;
+
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values (:user_b, :shared_token, 'ios', true)
+on conflict (user_id, expo_push_token)
+do update set platform = excluded.platform, active = true;
+
+reset role;
+
+do $$
+declare
+  v_a_shared boolean;
+  v_a_other boolean;
+  v_b_shared boolean;
+  v_a_claimed timestamptz;
+  v_b_claimed timestamptz;
+begin
+  select active, claimed_at into v_a_shared, v_a_claimed
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000001'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  select active into v_a_other
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000001'
+    and expo_push_token = 'ExponentPushToken[fixture-user-a-tablet]';
+
+  select active, claimed_at into v_b_shared, v_b_claimed
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  if v_a_shared is not false then
+    raise exception 'FAIL: the prior owner kept an active row on the shared device';
+  end if;
+  if v_b_shared is not true then
+    raise exception 'FAIL: the new registrant does not own the shared device';
+  end if;
+  if v_b_claimed <= v_a_claimed then
+    raise exception 'FAIL: the new claim did not sort after the prior claim';
+  end if;
+  if v_a_other is not true then
+    raise exception 'FAIL: the claim deactivated the prior owner''s other device';
+  end if;
+  raise notice 'ok: a new registration deactivates prior owners'' rows only for that token';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Clause 3: the send-side resolver never returns a token the recipient no
+-- longer owns. The reminder sender calls this function as the service role.
+-- ---------------------------------------------------------------------------
+set role service_role;
+
+do $$
+declare
+  v_a_tokens text[];
+  v_b_tokens text[];
+begin
+  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  into v_a_tokens
+  from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
+
+  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  into v_b_tokens
+  from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000002');
+
+  if v_a_tokens <> array['ExponentPushToken[fixture-user-a-tablet]'] then
+    raise exception 'FAIL: the prior owner is still targetable on the shared device: %', v_a_tokens;
+  end if;
+  if v_b_tokens <> array['ExponentPushToken[fixture-shared-device]'] then
+    raise exception 'FAIL: the current owner cannot be reached on the shared device: %', v_b_tokens;
+  end if;
+  raise notice 'ok: sends resolve only to tokens the recipient currently owns';
+end;
+$$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Handover is reversible: the original user reclaims the device on next login.
+-- ---------------------------------------------------------------------------
+select set_config('request.jwt.claim.sub', :user_a, false);
+set role authenticated;
+
+insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+values (:user_a, :shared_token, 'ios', true)
+on conflict (user_id, expo_push_token)
+do update set platform = excluded.platform, active = true;
+
+reset role;
+
+do $$
+declare
+  v_a_shared boolean;
+  v_b_shared boolean;
+begin
+  select active into v_a_shared
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000001'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  select active into v_b_shared
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
+    and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+  if v_a_shared is not true or v_b_shared is not false then
+    raise exception 'FAIL: re-registering did not hand the device back';
+  end if;
+  raise notice 'ok: ownership follows the most recent registration in both directions';
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Backstops, with the claim trigger disabled so the checks below stand on
+-- their own rather than on the trigger that normally prevents the state.
+-- ---------------------------------------------------------------------------
+alter table public.device_push_tokens disable trigger device_push_tokens_claim_device;
+
+do $$
+begin
+  begin
+    insert into public.device_push_tokens (user_id, expo_push_token, platform, active)
+    values (
+      'aaaaaaaa-2000-4000-8000-000000000002',
+      'ExponentPushToken[fixture-shared-device]',
+      'ios',
+      true
+    )
+    on conflict (user_id, expo_push_token)
+    do update set active = true;
+    raise exception 'FAIL: two users held the same device token active at once';
+  exception
+    when unique_violation then
+      raise notice 'ok: the database refuses two active owners for one token';
+  end;
+end;
+$$;
+
+alter table public.device_push_tokens enable trigger device_push_tokens_claim_device;
+
+-- A's row is active again after the reclaim above. Give B the newer claim
+-- without reactivating B: the shape left behind when the current owner signs
+-- out normally while an earlier owner's row was never retired. The stale
+-- active row must still not be targetable. B's row stays inactive, so this
+-- update does not fire the claim trigger.
+update public.device_push_tokens
+set claimed_at = clock_timestamp()
+where user_id = 'aaaaaaaa-2000-4000-8000-000000000002'
+  and expo_push_token = 'ExponentPushToken[fixture-shared-device]';
+
+set role service_role;
+
+do $$
+declare
+  v_a_tokens text[];
+begin
+  select coalesce(array_agg(expo_push_token order by expo_push_token), '{}')
+  into v_a_tokens
+  from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000001');
+
+  if 'ExponentPushToken[fixture-shared-device]' = any (v_a_tokens) then
+    raise exception 'FAIL: a stale active row outranked a later claim: %', v_a_tokens;
+  end if;
+  raise notice 'ok: a later claim beats a stale active row on the same token';
+end;
+$$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- RLS and grants around the rule.
+-- ---------------------------------------------------------------------------
+select set_config('request.jwt.claim.sub', :user_a, false);
+set role authenticated;
+
+do $$
+declare
+  v_visible integer;
+  v_updated integer;
+begin
+  select count(*) into v_visible
+  from public.device_push_tokens
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000002';
+  if v_visible <> 0 then
+    raise exception 'FAIL: an employee read another user''s device rows';
+  end if;
+
+  update public.device_push_tokens
+  set active = true
+  where user_id = 'aaaaaaaa-2000-4000-8000-000000000002';
+  get diagnostics v_updated = row_count;
+  if v_updated <> 0 then
+    raise exception 'FAIL: an employee wrote another user''s device rows';
+  end if;
+  raise notice 'ok: employees still cannot read or write another user''s device rows';
+end;
+$$;
+
+do $$
+begin
+  begin
+    perform * from public.active_device_push_tokens('aaaaaaaa-2000-4000-8000-000000000002');
+    raise exception 'FAIL: an employee executed the send-side token resolver';
+  exception
+    when insufficient_privilege then
+      raise notice 'ok: only the service role can resolve send-side tokens';
+  end;
+end;
+$$;
+
+reset role;
+
+do $$ begin raise notice 'PASS: push token ownership fixture assertions all held'; end $$;
+
+rollback;

--- a/scripts/local-db/verify-migrations.sh
+++ b/scripts/local-db/verify-migrations.sh
@@ -42,38 +42,38 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
-# Random free port on localhost.
-PORT="$(python3 - <<'PYEOF'
-import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()
-PYEOF
-)"
-
 CONTAINER="verify-migrations-$$-$RANDOM"
+PORT=""
+CONTAINER_STARTED=false
 
 cleanup() {
   local code=$?
-  if $KEEP; then
+  if $KEEP && $CONTAINER_STARTED; then
     echo ""
     echo "--keep: container '$CONTAINER' left running on 127.0.0.1:$PORT"
     echo "  connect: docker exec -it $CONTAINER psql -U postgres"
     echo "  or:      psql postgresql://postgres:postgres@127.0.0.1:$PORT/postgres"
     echo "  remove:  docker rm -f $CONTAINER"
-  else
+  elif $CONTAINER_STARTED; then
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
   fi
   exit $code
 }
 trap cleanup EXIT
 
-echo "==> Starting postgres:17 container '$CONTAINER' on 127.0.0.1:$PORT"
+echo "==> Starting postgres:17 container '$CONTAINER'"
 docker run -d --name "$CONTAINER" \
   -e POSTGRES_PASSWORD=postgres \
-  -p "127.0.0.1:$PORT:5432" \
+  -p "127.0.0.1::5432" \
+  -v "$REPO_ROOT:/workspace:ro" \
   postgres:17 >/dev/null
+CONTAINER_STARTED=true
+PORT="$(docker port "$CONTAINER" 5432/tcp | sed -n 's/.*://p' | head -1)"
+if [[ -z "$PORT" ]]; then
+  echo "ERROR: docker did not publish the postgres port" >&2
+  exit 1
+fi
+echo "    published on 127.0.0.1:$PORT"
 
 echo -n "==> Waiting for postgres to accept connections"
 for i in $(seq 1 60); do
@@ -97,7 +97,7 @@ docker exec "$CONTAINER" pg_isready -U postgres -d postgres >/dev/null
 run_sql_file() {
   local file="$1"
   docker exec -i "$CONTAINER" psql -U postgres -d postgres \
-    -v ON_ERROR_STOP=1 -q -X < "$file"
+    -v ON_ERROR_STOP=1 -q -X --single-transaction < "$file"
 }
 
 echo "==> Loading auth stub ($(basename "$AUTH_STUB"))"

--- a/supabase/functions/_shared/expoPushToken.test.ts
+++ b/supabase/functions/_shared/expoPushToken.test.ts
@@ -1,0 +1,44 @@
+import { canonicalizeExpoPushToken } from './expoPushToken.ts';
+
+const TOKEN = 'ExponentPushToken[fixture-device]';
+
+Deno.test('canonicalizeExpoPushToken strips the ECMAScript trim whitespace set', () => {
+  const fixtures = [
+    `\uFEFF${TOKEN}`,
+    `${TOKEN}\uFEFF`,
+    `\u00A0${TOKEN}\u00A0`,
+    `\uFEFF\u00A0${TOKEN}\u00A0\uFEFF`,
+    `\u2028\u1680${TOKEN}\u3000\u2029`,
+    `\t\n\v\f\r ${TOKEN} `,
+  ];
+
+  for (const fixture of fixtures) {
+    const actual = canonicalizeExpoPushToken(fixture);
+    if (actual !== TOKEN) {
+      throw new Error(`Expected canonical token, got ${String(actual)}`);
+    }
+  }
+});
+
+Deno.test('canonicalizeExpoPushToken enforces the complete token grammar', () => {
+  const invalid = [
+    null,
+    '',
+    'ExponentPushToken[]',
+    'ExponentPushToken[bad token]',
+    'ExponentPushToken[bad\ttoken]',
+    'ExponentPushToken[closed]junk',
+    'prefixExponentPushToken[token]',
+    'ExpoPushToken[token]]',
+  ];
+
+  for (const fixture of invalid) {
+    if (canonicalizeExpoPushToken(fixture) !== null) {
+      throw new Error(`Expected token to be rejected: ${String(fixture)}`);
+    }
+  }
+
+  if (canonicalizeExpoPushToken('ExpoPushToken[token]') !== 'ExpoPushToken[token]') {
+    throw new Error('Expected the ExpoPushToken form to be accepted');
+  }
+});

--- a/supabase/functions/_shared/expoPushToken.ts
+++ b/supabase/functions/_shared/expoPushToken.ts
@@ -1,0 +1,16 @@
+const CANONICAL_EXPO_PUSH_TOKEN = /^Expo(?:nent)?PushToken\[[^\]\s]+\]$/u;
+
+/**
+ * Return the one sender-safe spelling of an Expo push token.
+ *
+ * String.trim() removes the ECMAScript whitespace set, including U+FEFF,
+ * U+00A0, U+2028, U+2029, U+1680, U+2000 through U+200A, U+202F, U+205F,
+ * U+3000, and ASCII whitespace. The database migration applies the same set
+ * before enforcing the same token grammar.
+ */
+export function canonicalizeExpoPushToken(token: unknown): string | null {
+  if (typeof token !== 'string') return null;
+
+  const canonical = token.trim();
+  return CANONICAL_EXPO_PUSH_TOKEN.test(canonical) ? canonical : null;
+}

--- a/supabase/functions/_shared/reminders.test.ts
+++ b/supabase/functions/_shared/reminders.test.ts
@@ -1,30 +1,241 @@
-import {
-  buildChecklistOrderDayMessage,
-  isExpoDeviceNotRegistered,
-} from './reminderDelivery.ts';
+import { PushTokenResolutionError, sendEmployeeReminder } from "./reminders.ts";
 
-Deno.test('buildChecklistOrderDayMessage includes the server-computed unchecked count', () => {
-  const message = buildChecklistOrderDayMessage('sushi', 3);
-  if (message !== 'Fish order due today — 3 items unchecked') {
-    throw new Error(`Unexpected checklist reminder message: ${message}`);
+// Push token resolution failures in sendEmployeeReminder.
+//
+// Run from supabase/functions (the repo tsconfig is React Native, which Deno
+// rejects, so the existing edge function tests are run the same way):
+//   deno test --no-config --allow-all _shared/reminders.test.ts
+
+const EMPLOYEE_ID = "11111111-1111-4111-8111-111111111111";
+const MANAGER_ID = "22222222-2222-4222-8222-222222222222";
+
+type RecordedCall = { table: string; ops: string[] };
+
+const RESOLVER_FAILURE = {
+  data: null,
+  error: { message: "schema cache is reloading" },
+};
+
+/**
+ * Minimal stand-in for the supabase-js client. Every builder method returns the
+ * builder; awaiting it resolves to a canned answer for that table. Writes are
+ * recorded so a test can prove nothing was consumed.
+ */
+function makeClient(rpcResult?: unknown) {
+  const writes: RecordedCall[] = [];
+  const rpcCalls: { name: string; args: Record<string, unknown> }[] = [];
+
+  const reads: Record<string, unknown> = {
+    reminder_system_settings: {
+      data: {
+        overdue_threshold_days: 7,
+        reminder_rate_limit_minutes: 15,
+        recurring_window_minutes: 15,
+      },
+    },
+    users: {
+      data: {
+        id: EMPLOYEE_ID,
+        name: "Fixture Employee",
+        email: "employee@example.test",
+        role: "employee",
+        default_location_id: null,
+      },
+    },
+    profiles: { data: { notifications_enabled: true, is_suspended: false } },
+    orders: { data: null },
+    reminders: { data: null },
+  };
+
+  const writeResults: Record<string, unknown> = {
+    reminders: { data: { id: "reminder-1", reminder_count: 1 } },
+    notifications: { data: { id: "notification-1" } },
+    reminder_events: { data: { id: "event-1" } },
+  };
+
+  function resolve(call: RecordedCall): unknown {
+    const isWrite = call.ops.includes("insert") || call.ops.includes("update");
+    if (isWrite) {
+      writes.push(call);
+      return { error: null, ...(writeResults[call.table] as object ?? { data: null }) };
+    }
+    return { error: null, ...(reads[call.table] as object ?? { data: null }) };
+  }
+
+  function builder(table: string) {
+    const call: RecordedCall = { table, ops: [] };
+    // deno-lint-ignore no-explicit-any
+    const chain: any = new Proxy({}, {
+      get(_target, prop: string) {
+        if (prop === "then") {
+          // deno-lint-ignore no-explicit-any
+          return (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(resolve(call)).then(onFulfilled, onRejected);
+        }
+        return (..._args: unknown[]) => {
+          call.ops.push(prop);
+          return chain;
+        };
+      },
+    });
+    return chain;
+  }
+
+  const client = {
+    from: (table: string) => builder(table),
+    rpc: (name: string, args: Record<string, unknown>) => {
+      rpcCalls.push({ name, args });
+      return Promise.resolve(rpcResult ?? { data: [], error: null });
+    },
+    // deno-lint-ignore no-explicit-any
+  } as any;
+
+  return { client, writes, rpcCalls };
+}
+
+function baseInput(overrides: Record<string, unknown> = {}) {
+  return {
+    employeeId: EMPLOYEE_ID,
+    managerId: MANAGER_ID,
+    message: "Please submit your order.",
+    ...overrides,
+  };
+}
+
+function writtenTables(writes: RecordedCall[]): string {
+  return writes.map((write) => write.table).join(",");
+}
+
+Deno.test("a push-only reminder that cannot resolve tokens writes nothing", async () => {
+  const { client, writes, rpcCalls } = makeClient(RESOLVER_FAILURE);
+
+  let caught: unknown = null;
+  try {
+    await sendEmployeeReminder(
+      client,
+      baseInput({ channels: { push: true, in_app: false } }),
+    );
+  } catch (error) {
+    caught = error;
+  }
+
+  if (!(caught instanceof PushTokenResolutionError)) {
+    throw new Error(`Expected PushTokenResolutionError, got ${caught}`);
+  }
+  if (rpcCalls.length !== 1 || rpcCalls[0].name !== "active_device_push_tokens") {
+    throw new Error("Expected exactly one call to the ownership resolver");
+  }
+  if (rpcCalls[0].args.p_user_id !== EMPLOYEE_ID) {
+    throw new Error("The resolver was called for the wrong recipient");
+  }
+  if (writes.length !== 0) {
+    throw new Error(`Expected no writes, saw ${writtenTables(writes)}`);
   }
 });
 
-Deno.test('buildChecklistOrderDayMessage falls back to a generic message without a checklist', () => {
-  const message = buildChecklistOrderDayMessage('poki', null);
-  if (message !== 'Poki order due today') {
-    throw new Error(`Unexpected generic checklist reminder message: ${message}`);
+Deno.test("the recurring path throws too, so the rule is not marked triggered", async () => {
+  const { client, writes } = makeClient(RESOLVER_FAILURE);
+
+  let caught: unknown = null;
+  try {
+    await sendEmployeeReminder(
+      client,
+      baseInput({ source: "recurring", channels: { push: true, in_app: false } }),
+    );
+  } catch (error) {
+    caught = error;
+  }
+
+  if (!(caught instanceof PushTokenResolutionError)) {
+    throw new Error(`Expected PushTokenResolutionError, got ${caught}`);
+  }
+  if ((caught as Error).message !== "schema cache is reloading") {
+    throw new Error("Expected the resolver error to reach the caller");
+  }
+  // evaluate-recurring-reminders skips last_triggered_at on this error, so the
+  // reminder thread must not have advanced either.
+  if (writes.length !== 0) {
+    throw new Error(`Expected no writes, saw ${writtenTables(writes)}`);
   }
 });
 
-Deno.test('isExpoDeviceNotRegistered recognizes ticket and receipt errors', () => {
-  const ticketError = { details: { error: 'DeviceNotRegistered' } };
-  const receiptError = { error: 'DeviceNotRegistered' };
+Deno.test("in-app still lands and push records exactly one failure", async () => {
+  const { client, writes } = makeClient(RESOLVER_FAILURE);
 
-  if (!isExpoDeviceNotRegistered(ticketError) || !isExpoDeviceNotRegistered(receiptError)) {
-    throw new Error('Expected DeviceNotRegistered errors to be recognized.');
+  const result = await sendEmployeeReminder(
+    client,
+    baseInput({ source: "recurring", channels: { push: true, in_app: true } }),
+  );
+
+  if (result.push.status !== "failed" || result.push.deliveryOutcome !== "failed") {
+    throw new Error("Expected the push channel to be reported as failed");
   }
-  if (isExpoDeviceNotRegistered({ details: { error: 'MessageTooBig' } })) {
-    throw new Error('Expected unrelated Expo errors not to be treated as token invalidation.');
+  if (result.push.successCount !== 0 || result.push.failureCount !== 1) {
+    throw new Error(
+      `Expected 0 successes and 1 failure, got ${result.push.successCount}/${result.push.failureCount}`,
+    );
+  }
+  if (result.push.tokenCount !== 0) {
+    throw new Error("Expected no resolved tokens");
+  }
+  if (result.push.errorDetail !== "schema cache is reloading") {
+    throw new Error("Expected the resolver error to be reported");
+  }
+  if (result.inAppNotificationId !== "notification-1") {
+    throw new Error("Expected the in-app notification to still be delivered");
+  }
+  if (writtenTables(writes) !== "reminders,notifications,reminder_events") {
+    throw new Error(`Unexpected write sequence: ${writtenTables(writes)}`);
+  }
+});
+
+Deno.test("a recipient who owns no device is not a failure", async () => {
+  const { client, writes } = makeClient({ data: [], error: null });
+
+  const result = await sendEmployeeReminder(
+    client,
+    baseInput({ channels: { push: true, in_app: false } }),
+  );
+
+  if (result.push.status !== "no_tokens") {
+    throw new Error(`Expected no_tokens, got ${result.push.status}`);
+  }
+  if (result.push.failureCount !== 0 || result.push.deliveryOutcome !== null) {
+    throw new Error("An empty device list must not be reported as a delivery failure");
+  }
+  if (writtenTables(writes) !== "reminders,reminder_events") {
+    throw new Error(`Unexpected write sequence: ${writtenTables(writes)}`);
+  }
+});
+
+Deno.test("tokens the sender cannot use are dropped, not sent", async () => {
+  const { client } = makeClient({
+    data: [{ expo_push_token: "   " }, { expo_push_token: "not-a-token" }],
+    error: null,
+  });
+
+  const result = await sendEmployeeReminder(
+    client,
+    baseInput({ channels: { push: true, in_app: false } }),
+  );
+
+  if (result.push.status !== "no_tokens" || result.push.tokenCount !== 0) {
+    throw new Error("Expected unusable tokens to be discarded before sending");
+  }
+});
+
+Deno.test("no ownership lookup happens when push was not requested", async () => {
+  const { client, rpcCalls } = makeClient();
+
+  const result = await sendEmployeeReminder(
+    client,
+    baseInput({ channels: { push: false, in_app: true } }),
+  );
+
+  if (rpcCalls.length !== 0) {
+    throw new Error("The resolver ran for a reminder that did not request push");
+  }
+  if (result.push.status !== "not_requested") {
+    throw new Error(`Expected not_requested, got ${result.push.status}`);
   }
 });

--- a/supabase/functions/_shared/reminders.test.ts
+++ b/supabase/functions/_shared/reminders.test.ts
@@ -165,29 +165,27 @@ Deno.test("a push-only reminder that cannot resolve tokens writes nothing", asyn
   }
 });
 
-Deno.test("the recurring path throws too, so the rule is not marked triggered", async () => {
+Deno.test("a recurring push-only resolver failure is recorded as one failed push", async () => {
   const { client, writes } = makeClient(RESOLVER_FAILURE);
 
-  let caught: unknown = null;
-  try {
-    await sendEmployeeReminder(
-      client,
-      baseInput({ source: "recurring", channels: { push: true, in_app: false } }),
-    );
-  } catch (error) {
-    caught = error;
-  }
+  const result = await sendEmployeeReminder(
+    client,
+    baseInput({ source: "recurring", channels: { push: true, in_app: false } }),
+  );
 
-  if (!(caught instanceof PushTokenResolutionError)) {
-    throw new Error(`Expected PushTokenResolutionError, got ${caught}`);
+  if (result.push.status !== "failed" || result.push.deliveryOutcome !== "failed") {
+    throw new Error("Expected the recurring push attempt to be recorded as failed");
   }
-  if ((caught as Error).message !== "schema cache is reloading") {
-    throw new Error("Expected the resolver error to reach the caller");
+  if (result.push.successCount !== 0 || result.push.failureCount !== 1) {
+    throw new Error(
+      `Expected 0 successes and 1 failure, got ${result.push.successCount}/${result.push.failureCount}`,
+    );
   }
-  // evaluate-recurring-reminders skips last_triggered_at on this error, so the
-  // reminder thread must not have advanced either.
-  if (writes.length !== 0) {
-    throw new Error(`Expected no writes, saw ${writtenTables(writes)}`);
+  if (result.push.errorDetail !== "schema cache is reloading") {
+    throw new Error("Expected the resolver error to be stored on the push result");
+  }
+  if (writtenTables(writes) !== "reminders,reminder_events") {
+    throw new Error(`Unexpected write sequence: ${writtenTables(writes)}`);
   }
 });
 

--- a/supabase/functions/_shared/reminders.test.ts
+++ b/supabase/functions/_shared/reminders.test.ts
@@ -1,10 +1,42 @@
-import { PushTokenResolutionError, sendEmployeeReminder } from "./reminders.ts";
+import {
+  buildChecklistOrderDayMessage,
+  isExpoDeviceNotRegistered,
+} from './reminderDelivery.ts';
+import { PushTokenResolutionError, sendEmployeeReminder } from './reminders.ts';
 
+Deno.test('buildChecklistOrderDayMessage includes the server-computed unchecked count', () => {
+  const message = buildChecklistOrderDayMessage('sushi', 3);
+  if (message !== 'Fish order due today — 3 items unchecked') {
+    throw new Error(`Unexpected checklist reminder message: ${message}`);
+  }
+});
+
+Deno.test('buildChecklistOrderDayMessage falls back to a generic message without a checklist', () => {
+  const message = buildChecklistOrderDayMessage('poki', null);
+  if (message !== 'Poki order due today') {
+    throw new Error(`Unexpected generic checklist reminder message: ${message}`);
+  }
+});
+
+Deno.test('isExpoDeviceNotRegistered recognizes ticket and receipt errors', () => {
+  const ticketError = { details: { error: 'DeviceNotRegistered' } };
+  const receiptError = { error: 'DeviceNotRegistered' };
+
+  if (!isExpoDeviceNotRegistered(ticketError) || !isExpoDeviceNotRegistered(receiptError)) {
+    throw new Error('Expected DeviceNotRegistered errors to be recognized.');
+  }
+  if (isExpoDeviceNotRegistered({ details: { error: 'MessageTooBig' } })) {
+    throw new Error('Expected unrelated Expo errors not to be treated as token invalidation.');
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Push token resolution failures in sendEmployeeReminder.
 //
 // Run from supabase/functions (the repo tsconfig is React Native, which Deno
 // rejects, so the existing edge function tests are run the same way):
 //   deno test --no-config --allow-all _shared/reminders.test.ts
+// ---------------------------------------------------------------------------
 
 const EMPLOYEE_ID = "11111111-1111-4111-8111-111111111111";
 const MANAGER_ID = "22222222-2222-4222-8222-222222222222";

--- a/supabase/functions/_shared/reminders.ts
+++ b/supabase/functions/_shared/reminders.ts
@@ -68,6 +68,21 @@ export interface SendEmployeeReminderResult {
   settings: ReminderSystemSettings;
 }
 
+/**
+ * The recipient's push tokens could not be resolved. Raised before anything is
+ * written, so a caller can retry the whole reminder without having consumed
+ * it. Only thrown when push is the sole requested channel; when in-app was
+ * also requested the reminder still lands and push is recorded as failed.
+ */
+export class PushTokenResolutionError extends Error {
+  retryable = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'PushTokenResolutionError';
+  }
+}
+
 export class ReminderRateLimitError extends Error {
   retryAfterSeconds: number;
 
@@ -566,6 +581,39 @@ export async function sendEmployeeReminder(
     }
   }
 
+  const shouldAttemptInApp = input.channels?.in_app !== false;
+  const pushChannelRequested = input.channels?.push !== false;
+
+  // Resolved before anything is written. A push-only reminder whose tokens
+  // cannot be resolved must leave the reminder thread and the recurring rule
+  // untouched, so the next run retries it instead of the transient failure
+  // consuming the day's reminder.
+  //
+  // Ownership is checked server side here rather than by filtering the table:
+  // a shared phone belongs to the last user who registered it, so a token the
+  // recipient no longer owns must never be targeted.
+  let resolvedTokens: string[] = [];
+  let tokenResolutionError: string | null = null;
+
+  if (pushChannelRequested && notificationsEnabled) {
+    const { data: pushTokensRaw, error: pushTokenError } = await supabaseAdmin.rpc(
+      'active_device_push_tokens',
+      { p_user_id: employee.id }
+    );
+
+    if (pushTokenError) {
+      tokenResolutionError =
+        pushTokenError.message || 'Unable to resolve the recipient push tokens.';
+      if (!shouldAttemptInApp) {
+        throw new PushTokenResolutionError(tokenResolutionError);
+      }
+    } else {
+      resolvedTokens = (pushTokensRaw ?? [])
+        .map((row: any) => sanitizeExpoPushToken(row?.expo_push_token))
+        .filter((token: string | null): token is string => Boolean(token));
+    }
+  }
+
   let reminderRow: any = null;
   let eventType: 'sent' | 'reminded_again' = 'sent';
 
@@ -610,8 +658,6 @@ export async function sendEmployeeReminder(
     reminderRow = createdReminder;
   }
 
-  const shouldAttemptInApp = input.channels?.in_app !== false;
-  const pushChannelRequested = input.channels?.push !== false;
   const channelsAttempted: string[] = [];
 
   const reminderTitle = 'Order reminder';
@@ -666,27 +712,16 @@ export async function sendEmployeeReminder(
       channelsAttempted.push('push');
       pushResult.attempted = true;
 
-      // Resolved server side, and as late as possible: a shared phone belongs
-      // to the last user who registered it, so a token the recipient no longer
-      // owns must never be targeted, even while their row lingers.
-      const { data: pushTokensRaw, error: pushTokenError } = await supabaseAdmin.rpc(
-        'active_device_push_tokens',
-        { p_user_id: employee.id }
-      );
-
-      const tokens = pushTokenError
-        ? []
-        : (pushTokensRaw ?? [])
-            .map((row: any) => sanitizeExpoPushToken(row?.expo_push_token))
-            .filter((token: string | null): token is string => Boolean(token));
-
+      const tokens = resolvedTokens;
       pushResult.tokenCount = tokens.length;
 
-      if (pushTokenError) {
+      if (tokenResolutionError) {
+        // Reached only when in-app was also requested, so the reminder itself
+        // did land. One unresolvable push channel, counted as one failure.
         pushResult.status = 'failed';
         pushResult.deliveryOutcome = 'failed';
-        pushResult.errorDetail =
-          pushTokenError.message || 'Unable to resolve the recipient push tokens.';
+        pushResult.failureCount = 1;
+        pushResult.errorDetail = tokenResolutionError;
       } else if (tokens.length === 0) {
         pushResult.status = 'no_tokens';
       } else {

--- a/supabase/functions/_shared/reminders.ts
+++ b/supabase/functions/_shared/reminders.ts
@@ -6,6 +6,7 @@ import {
   type ChecklistLocationGroup,
   type ChecklistReminderMessage,
 } from './reminderDelivery.ts';
+import { canonicalizeExpoPushToken } from './expoPushToken.ts';
 
 export {
   buildChecklistOrderDayMessage,
@@ -69,10 +70,10 @@ export interface SendEmployeeReminderResult {
 }
 
 /**
- * The recipient's push tokens could not be resolved. Raised before anything is
- * written, so a caller can retry the whole reminder without having consumed
- * it. Only thrown when push is the sole requested channel; when in-app was
- * also requested the reminder still lands and push is recorded as failed.
+ * The recipient's push tokens could not be resolved. Manual push-only sends
+ * throw this before creating or updating reminder delivery records. Stale
+ * reminder cleanup may already have resolved an old thread. Recurring sends
+ * record the push failure and consume the recurring rule for the day.
  */
 export class PushTokenResolutionError extends Error {
   retryable = true;
@@ -104,16 +105,6 @@ function minutesBetween(nowIso: string, thenIso: string): number {
   const now = new Date(nowIso).getTime();
   const then = new Date(thenIso).getTime();
   return Math.max(0, Math.floor((now - then) / (1000 * 60)));
-}
-
-function sanitizeExpoPushToken(token: string): string | null {
-  if (typeof token !== 'string') return null;
-  const trimmed = token.trim();
-  if (!trimmed) return null;
-  if (!trimmed.startsWith('ExponentPushToken[') && !trimmed.startsWith('ExpoPushToken[')) {
-    return null;
-  }
-  return trimmed;
 }
 
 function chunkArray<T>(items: T[], size: number): T[][] {
@@ -584,16 +575,16 @@ export async function sendEmployeeReminder(
   const shouldAttemptInApp = input.channels?.in_app !== false;
   const pushChannelRequested = input.channels?.push !== false;
 
-  // Resolved before anything is written. A push-only reminder whose tokens
-  // cannot be resolved must leave the reminder thread and the recurring rule
-  // untouched, so the next run retries it instead of the transient failure
-  // consuming the day's reminder.
+  // Resolve before writing this delivery. Manual push-only sends fail before
+  // their reminder and event writes. Recurring sends record a failed push and
+  // still consume the rule, so another employee is not sent a duplicate.
+  // resolveStaleReminderIfNeeded may already have closed an old thread above.
   //
   // Ownership is checked server side here rather than by filtering the table:
   // a shared phone belongs to the last user who registered it, so a token the
   // recipient no longer owns must never be targeted.
   let resolvedTokens: string[] = [];
-  let tokenResolutionError: string | null = null;
+  let tokenResolutionError: PushTokenResolutionError | null = null;
 
   if (pushChannelRequested && notificationsEnabled) {
     const { data: pushTokensRaw, error: pushTokenError } = await supabaseAdmin.rpc(
@@ -602,14 +593,15 @@ export async function sendEmployeeReminder(
     );
 
     if (pushTokenError) {
-      tokenResolutionError =
-        pushTokenError.message || 'Unable to resolve the recipient push tokens.';
-      if (!shouldAttemptInApp) {
-        throw new PushTokenResolutionError(tokenResolutionError);
+      tokenResolutionError = new PushTokenResolutionError(
+        pushTokenError.message || 'Unable to resolve the recipient push tokens.',
+      );
+      if (!shouldAttemptInApp && input.source !== 'recurring') {
+        throw tokenResolutionError;
       }
     } else {
       resolvedTokens = (pushTokensRaw ?? [])
-        .map((row: any) => sanitizeExpoPushToken(row?.expo_push_token))
+        .map((row: any) => canonicalizeExpoPushToken(row?.expo_push_token))
         .filter((token: string | null): token is string => Boolean(token));
     }
   }
@@ -721,7 +713,7 @@ export async function sendEmployeeReminder(
         pushResult.status = 'failed';
         pushResult.deliveryOutcome = 'failed';
         pushResult.failureCount = 1;
-        pushResult.errorDetail = tokenResolutionError;
+        pushResult.errorDetail = tokenResolutionError.message;
       } else if (tokens.length === 0) {
         pushResult.status = 'no_tokens';
       } else {

--- a/supabase/functions/_shared/reminders.ts
+++ b/supabase/functions/_shared/reminders.ts
@@ -666,20 +666,28 @@ export async function sendEmployeeReminder(
       channelsAttempted.push('push');
       pushResult.attempted = true;
 
-      const { data: pushTokensRaw } = await supabaseAdmin
-        .from('device_push_tokens')
-        .select('expo_push_token')
-        .eq('user_id', employee.id)
-        .eq('active', true)
-        .order('updated_at', { ascending: false });
+      // Resolved server side, and as late as possible: a shared phone belongs
+      // to the last user who registered it, so a token the recipient no longer
+      // owns must never be targeted, even while their row lingers.
+      const { data: pushTokensRaw, error: pushTokenError } = await supabaseAdmin.rpc(
+        'active_device_push_tokens',
+        { p_user_id: employee.id }
+      );
 
-      const tokens = (pushTokensRaw ?? [])
-        .map((row: any) => sanitizeExpoPushToken(row?.expo_push_token))
-        .filter((token: string | null): token is string => Boolean(token));
+      const tokens = pushTokenError
+        ? []
+        : (pushTokensRaw ?? [])
+            .map((row: any) => sanitizeExpoPushToken(row?.expo_push_token))
+            .filter((token: string | null): token is string => Boolean(token));
 
       pushResult.tokenCount = tokens.length;
 
-      if (tokens.length === 0) {
+      if (pushTokenError) {
+        pushResult.status = 'failed';
+        pushResult.deliveryOutcome = 'failed';
+        pushResult.errorDetail =
+          pushTokenError.message || 'Unable to resolve the recipient push tokens.';
+      } else if (tokens.length === 0) {
         pushResult.status = 'no_tokens';
       } else {
         const pushDelivery = await sendExpoPush(

--- a/supabase/functions/_shared/reminders.ts
+++ b/supabase/functions/_shared/reminders.ts
@@ -62,6 +62,8 @@ export interface SendEmployeeReminderResult {
     successCount: number;
     failureCount: number;
     deliveryOutcome: 'accepted' | 'failed' | null;
+    /** The recipient's tokens could not be resolved, so nothing was sent. */
+    tokenResolutionFailed: boolean;
     receiptIds: string[];
     errorDetail: string | null;
     details?: any;
@@ -692,6 +694,7 @@ export async function sendEmployeeReminder(
     successCount: 0,
     failureCount: 0,
     deliveryOutcome: null,
+    tokenResolutionFailed: false,
     receiptIds: [],
     errorDetail: null,
   };
@@ -708,10 +711,13 @@ export async function sendEmployeeReminder(
       pushResult.tokenCount = tokens.length;
 
       if (tokenResolutionError) {
-        // Reached only when in-app was also requested, so the reminder itself
-        // did land. One unresolvable push channel, counted as one failure.
+        // Reached when in-app was also requested, and on the recurring path,
+        // which records the failure rather than throwing so one employee's
+        // resolver error cannot resend the rule to the rest. The caller has to
+        // surface tokenResolutionFailed; the reminder row was still written.
         pushResult.status = 'failed';
         pushResult.deliveryOutcome = 'failed';
+        pushResult.tokenResolutionFailed = true;
         pushResult.failureCount = 1;
         pushResult.errorDetail = tokenResolutionError.message;
       } else if (tokens.length === 0) {

--- a/supabase/functions/evaluate-recurring-reminders/evaluator.test.ts
+++ b/supabase/functions/evaluate-recurring-reminders/evaluator.test.ts
@@ -1,0 +1,95 @@
+// @ts-nocheck
+import { evaluateRecurringRule } from './evaluator.ts';
+
+const NOW = new Date('2026-09-05T17:05:00.000Z');
+const LOCATION_ID = '33333333-3333-4333-8333-333333333333';
+
+Deno.test('a location rule consumes mixed push results and does not resend next run', async () => {
+  const rule = {
+    id: 'rule-1',
+    scope: 'location',
+    location_id: LOCATION_ID,
+    employee_id: null,
+    created_by: null,
+    timezone: 'America/Los_Angeles',
+    time_of_day: '10:00',
+    days_of_week: [6],
+    last_triggered_at: null,
+    quiet_hours_enabled: false,
+    condition_type: 'no_order_today',
+    condition_value: null,
+    rule_kind: 'standard',
+    channels: { push: true, in_app: false },
+  };
+  const employees = [
+    { id: 'employee-a', default_location_id: LOCATION_ID },
+    { id: 'employee-b', default_location_id: LOCATION_ID },
+  ];
+  const deliveries: { employeeId: string; failureCount: number }[] = [];
+
+  const supabaseAdmin = {
+    from(table: string) {
+      if (table !== 'recurring_reminder_rules') {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+      return {
+        update(values: { last_triggered_at: string }) {
+          return {
+            async eq(column: string, value: string) {
+              if (column !== 'id' || value !== rule.id) {
+                throw new Error('The evaluator updated the wrong rule');
+              }
+              rule.last_triggered_at = values.last_triggered_at;
+              return { error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  const sendReminder = async (_client: unknown, input: { employeeId: string; source: string }) => {
+    if (input.source !== 'recurring') {
+      throw new Error(`Expected recurring source, got ${input.source}`);
+    }
+    const failureCount = input.employeeId === 'employee-b' ? 1 : 0;
+    deliveries.push({ employeeId: input.employeeId, failureCount });
+    return {
+      push: {
+        status: failureCount === 1 ? 'failed' : 'sent',
+        successCount: failureCount === 1 ? 0 : 1,
+        failureCount,
+      },
+    };
+  };
+
+  const input = {
+    supabaseAdmin,
+    rule,
+    settings: { recurringWindowMinutes: 120 },
+    now: NOW,
+    actorUserId: null,
+    dryRun: false,
+    employeeById: new Map(employees.map((employee) => [employee.id, employee])),
+    employeesByLocation: new Map([[LOCATION_ID, employees]]),
+    ordersByEmployeeId: new Map(),
+    locationGroupById: new Map(),
+    sendReminder,
+  };
+
+  const first = await evaluateRecurringRule(input);
+  if (!first.due || first.remindersSent !== 2) {
+    throw new Error(`Expected two reminder records on the first run: ${JSON.stringify(first)}`);
+  }
+  if (deliveries.length !== 2 || deliveries[0].failureCount !== 0 || deliveries[1].failureCount !== 1) {
+    throw new Error(`Expected one accepted and one failed push: ${JSON.stringify(deliveries)}`);
+  }
+  if (rule.last_triggered_at !== NOW.toISOString()) {
+    throw new Error('The mixed-result location rule was not consumed');
+  }
+
+  const second = await evaluateRecurringRule(input);
+  if (second.due || second.remindersSent !== 0 || deliveries.length !== 2) {
+    throw new Error('The next evaluation resent an already consumed location rule');
+  }
+});

--- a/supabase/functions/evaluate-recurring-reminders/evaluator.test.ts
+++ b/supabase/functions/evaluate-recurring-reminders/evaluator.test.ts
@@ -48,6 +48,8 @@ Deno.test('a location rule consumes mixed push results and does not resend next 
     },
   };
 
+  // employee-b's tokens cannot be resolved: the reminder row is still written,
+  // but nothing reached the phone.
   const sendReminder = async (_client: unknown, input: { employeeId: string; source: string }) => {
     if (input.source !== 'recurring') {
       throw new Error(`Expected recurring source, got ${input.source}`);
@@ -59,6 +61,8 @@ Deno.test('a location rule consumes mixed push results and does not resend next 
         status: failureCount === 1 ? 'failed' : 'sent',
         successCount: failureCount === 1 ? 0 : 1,
         failureCount,
+        tokenResolutionFailed: failureCount === 1,
+        errorDetail: failureCount === 1 ? 'schema cache is reloading' : null,
       },
     };
   };
@@ -78,11 +82,28 @@ Deno.test('a location rule consumes mixed push results and does not resend next 
   };
 
   const first = await evaluateRecurringRule(input);
-  if (!first.due || first.remindersSent !== 2) {
-    throw new Error(`Expected two reminder records on the first run: ${JSON.stringify(first)}`);
+  if (!first.due || first.remindersSent !== 1) {
+    throw new Error(
+      `Only the delivered reminder counts as sent: ${JSON.stringify(first)}`,
+    );
   }
   if (deliveries.length !== 2 || deliveries[0].failureCount !== 0 || deliveries[1].failureCount !== 1) {
     throw new Error(`Expected one accepted and one failed push: ${JSON.stringify(deliveries)}`);
+  }
+  // The run must not report success for an employee who received nothing.
+  if (first.errors.length !== 1) {
+    throw new Error(
+      `Expected exactly one error entry: ${JSON.stringify(first.errors)}`,
+    );
+  }
+  const [failure] = first.errors;
+  if (failure.ruleId !== rule.id || failure.employeeId !== 'employee-b') {
+    throw new Error(
+      `The error entry does not identify the rule and employee: ${JSON.stringify(failure)}`,
+    );
+  }
+  if (failure.message !== 'schema cache is reloading') {
+    throw new Error(`Expected the resolver error message: ${failure.message}`);
   }
   if (rule.last_triggered_at !== NOW.toISOString()) {
     throw new Error('The mixed-result location rule was not consumed');
@@ -91,5 +112,8 @@ Deno.test('a location rule consumes mixed push results and does not resend next 
   const second = await evaluateRecurringRule(input);
   if (second.due || second.remindersSent !== 0 || deliveries.length !== 2) {
     throw new Error('The next evaluation resent an already consumed location rule');
+  }
+  if (second.errors.length !== 0) {
+    throw new Error('A consumed rule reported errors on the next run');
   }
 });

--- a/supabase/functions/evaluate-recurring-reminders/evaluator.ts
+++ b/supabase/functions/evaluate-recurring-reminders/evaluator.ts
@@ -1,0 +1,274 @@
+// @ts-nocheck
+import {
+  getChecklistOrderDayReminderMessage,
+  ReminderRateLimitError,
+  sendEmployeeReminder,
+} from '../_shared/reminders.ts';
+import {
+  selectLatestOrderForReminder,
+  type ReminderLocationGroup,
+} from '../_shared/recurringReminderScope.ts';
+
+const WEEKDAY_MAP: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+export interface RecurringRuleEvaluation {
+  due: boolean;
+  remindersSent: number;
+  skippedByCondition: number;
+  skippedByRateLimit: number;
+  errors: { ruleId: string; employeeId?: string; message: string }[];
+}
+
+function getZonedParts(date: Date, timeZone: string) {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    weekday: 'short',
+  });
+
+  const parts = formatter.formatToParts(date);
+  const values: Record<string, string> = {};
+  parts.forEach((part) => {
+    values[part.type] = part.value;
+  });
+
+  const weekdayShort = values.weekday || 'Sun';
+
+  return {
+    year: Number(values.year),
+    month: Number(values.month),
+    day: Number(values.day),
+    hour: Number(values.hour),
+    minute: Number(values.minute),
+    weekday: WEEKDAY_MAP[weekdayShort] ?? 0,
+    dateKey: `${values.year}-${values.month}-${values.day}`,
+  };
+}
+
+function parseTimeToMinutes(value: string | null | undefined): number | null {
+  if (!value || typeof value !== 'string') return null;
+  const cleaned = value.trim();
+  const match = cleaned.match(/^(\d{1,2}):(\d{2})/);
+  if (!match) return null;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return hour * 60 + minute;
+}
+
+function isTimeInRange(nowMinutes: number, startMinutes: number, endMinutes: number): boolean {
+  if (startMinutes === endMinutes) return true;
+  if (startMinutes < endMinutes) {
+    return nowMinutes >= startMinutes && nowMinutes < endMinutes;
+  }
+  return nowMinutes >= startMinutes || nowMinutes < endMinutes;
+}
+
+function toDateKeyInTimezone(value: string | null | undefined, timeZone: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return getZonedParts(date, timeZone).dateKey;
+}
+
+function daysBetweenDateKeys(a: string, b: string): number {
+  const [aYear, aMonth, aDay] = a.split('-').map(Number);
+  const [bYear, bMonth, bDay] = b.split('-').map(Number);
+  const aMs = Date.UTC(aYear, aMonth - 1, aDay);
+  const bMs = Date.UTC(bYear, bMonth - 1, bDay);
+  return Math.max(0, Math.floor((aMs - bMs) / (1000 * 60 * 60 * 24)));
+}
+
+export async function evaluateRecurringRule({
+  supabaseAdmin,
+  rule,
+  settings,
+  now,
+  actorUserId,
+  dryRun,
+  employeeById,
+  employeesByLocation,
+  ordersByEmployeeId,
+  locationGroupById,
+  sendReminder = sendEmployeeReminder,
+  getChecklistMessage = getChecklistOrderDayReminderMessage,
+}: {
+  supabaseAdmin: any;
+  rule: any;
+  settings: any;
+  now: Date;
+  actorUserId: string | null;
+  dryRun: boolean;
+  employeeById: Map<string, any>;
+  employeesByLocation: Map<string, any[]>;
+  ordersByEmployeeId: Map<string, any[]>;
+  locationGroupById: Map<string, ReminderLocationGroup>;
+  sendReminder?: typeof sendEmployeeReminder;
+  getChecklistMessage?: typeof getChecklistOrderDayReminderMessage;
+}): Promise<RecurringRuleEvaluation> {
+  const result: RecurringRuleEvaluation = {
+    due: false,
+    remindersSent: 0,
+    skippedByCondition: 0,
+    skippedByRateLimit: 0,
+    errors: [],
+  };
+
+  const timezone = typeof rule.timezone === 'string' && rule.timezone
+    ? rule.timezone
+    : 'America/Los_Angeles';
+  const nowParts = getZonedParts(now, timezone);
+  const nowMinutes = nowParts.hour * 60 + nowParts.minute;
+  const scheduledMinutes = parseTimeToMinutes(rule.time_of_day);
+
+  if (scheduledMinutes == null) {
+    result.errors.push({ ruleId: rule.id, message: 'Invalid rule time_of_day' });
+    return result;
+  }
+
+  const daysOfWeek = Array.isArray(rule.days_of_week)
+    ? rule.days_of_week
+      .map((value: any) => Number(value))
+      .filter((value: number) => Number.isInteger(value))
+    : [];
+
+  if (!daysOfWeek.includes(nowParts.weekday)) return result;
+
+  const windowMinutes = Math.max(1, Number(settings.recurringWindowMinutes || 15));
+  if (!(nowMinutes >= scheduledMinutes && nowMinutes < scheduledMinutes + windowMinutes)) {
+    return result;
+  }
+
+  const lastTriggeredDateKey = toDateKeyInTimezone(rule.last_triggered_at, timezone);
+  if (lastTriggeredDateKey === nowParts.dateKey) return result;
+
+  if (rule.quiet_hours_enabled) {
+    const quietStart = parseTimeToMinutes(rule.quiet_hours_start);
+    const quietEnd = parseTimeToMinutes(rule.quiet_hours_end);
+    if (
+      quietStart != null &&
+      quietEnd != null &&
+      isTimeInRange(nowMinutes, quietStart, quietEnd)
+    ) {
+      return result;
+    }
+  }
+
+  result.due = true;
+
+  const candidateEmployees = rule.scope === 'employee'
+    ? (rule.employee_id && employeeById.has(rule.employee_id)
+      ? [employeeById.get(rule.employee_id)]
+      : [])
+    : employeesByLocation.get(rule.location_id || '__none__') || [];
+
+  for (const employee of candidateEmployees) {
+    if (!employee) continue;
+
+    const latestOrder = selectLatestOrderForReminder(
+      ordersByEmployeeId.get(employee.id) ?? [],
+      rule,
+      locationGroupById,
+    );
+    const lastOrderDateKey = toDateKeyInTimezone(latestOrder?.created_at, timezone);
+
+    let conditionMet = false;
+    if (rule.condition_type === 'no_order_today') {
+      conditionMet = !lastOrderDateKey || lastOrderDateKey !== nowParts.dateKey;
+    } else {
+      const thresholdDays = Math.max(0, Number(rule.condition_value ?? 0));
+      if (!lastOrderDateKey) {
+        conditionMet = true;
+      } else {
+        const elapsedDays = daysBetweenDateKeys(nowParts.dateKey, lastOrderDateKey);
+        conditionMet = elapsedDays >= thresholdDays;
+      }
+    }
+
+    if (!conditionMet) {
+      result.skippedByCondition += 1;
+      continue;
+    }
+
+    let checklistMessage: string | undefined;
+    if (rule.rule_kind === 'checklist_order_day') {
+      try {
+        const locationGroup = rule.location_group === 'poki' ? 'poki' : 'sushi';
+        const checklistContext = await getChecklistMessage(
+          supabaseAdmin,
+          employee.id,
+          locationGroup,
+        );
+        checklistMessage = checklistContext.body;
+      } catch (error: any) {
+        result.errors.push({
+          ruleId: rule.id,
+          employeeId: employee.id,
+          message: error?.message || 'Failed to resolve checklist reminder context',
+        });
+        continue;
+      }
+    }
+
+    if (dryRun) {
+      result.remindersSent += 1;
+      continue;
+    }
+
+    try {
+      const channelConfig = rule.channels && typeof rule.channels === 'object'
+        ? {
+            push: typeof rule.channels.push === 'boolean' ? rule.channels.push : true,
+            in_app: typeof rule.channels.in_app === 'boolean' ? rule.channels.in_app : true,
+          }
+        : { push: true, in_app: true };
+
+      await sendReminder(supabaseAdmin, {
+        employeeId: employee.id,
+        managerId: rule.created_by || actorUserId,
+        locationId: rule.scope === 'location'
+          ? rule.location_id
+          : employee.default_location_id,
+        source: 'recurring',
+        message: checklistMessage,
+        overrideRateLimit: false,
+        channels: channelConfig,
+      });
+      result.remindersSent += 1;
+    } catch (error: any) {
+      if (error instanceof ReminderRateLimitError) {
+        result.skippedByRateLimit += 1;
+        continue;
+      }
+
+      result.errors.push({
+        ruleId: rule.id,
+        employeeId: employee.id,
+        message: error?.message || 'Failed to send recurring reminder',
+      });
+    }
+  }
+
+  if (!dryRun) {
+    await supabaseAdmin
+      .from('recurring_reminder_rules')
+      .update({ last_triggered_at: now.toISOString() })
+      .eq('id', rule.id);
+  }
+
+  return result;
+}

--- a/supabase/functions/evaluate-recurring-reminders/evaluator.ts
+++ b/supabase/functions/evaluate-recurring-reminders/evaluator.ts
@@ -237,7 +237,7 @@ export async function evaluateRecurringRule({
           }
         : { push: true, in_app: true };
 
-      await sendReminder(supabaseAdmin, {
+      const sendResult = await sendReminder(supabaseAdmin, {
         employeeId: employee.id,
         managerId: rule.created_by || actorUserId,
         locationId: rule.scope === 'location'
@@ -248,6 +248,22 @@ export async function evaluateRecurringRule({
         overrideRateLimit: false,
         channels: channelConfig,
       });
+
+      // A resolver failure does not throw on the recurring path, because
+      // throwing would leave the rule unconsumed and resend it to the
+      // employees who did get their reminder. It still has to reach the run
+      // result: this employee received nothing, so it is not a reminder sent,
+      // and the cron output must say so rather than reporting success.
+      if (sendResult?.push?.tokenResolutionFailed) {
+        result.errors.push({
+          ruleId: rule.id,
+          employeeId: employee.id,
+          message: sendResult.push.errorDetail
+            || 'Unable to resolve the recipient push tokens.',
+        });
+        continue;
+      }
+
       result.remindersSent += 1;
     } catch (error: any) {
       if (error instanceof ReminderRateLimitError) {

--- a/supabase/functions/evaluate-recurring-reminders/index.ts
+++ b/supabase/functions/evaluate-recurring-reminders/index.ts
@@ -3,6 +3,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts
 import { corsHeaders } from '../_shared/cors.ts';
 import {
   getChecklistOrderDayReminderMessage,
+  PushTokenResolutionError,
   ReminderRateLimitError,
   getReminderSystemSettings,
   getRequesterFromToken,
@@ -254,6 +255,7 @@ Deno.serve(async (req) => {
   let remindersSent = 0;
   let skippedByCondition = 0;
   let skippedByRateLimit = 0;
+  let retryablePushFailures = 0;
   const errors: { ruleId: string; employeeId?: string; message: string }[] = [];
 
   for (const rule of enabledRules) {
@@ -296,6 +298,12 @@ Deno.serve(async (req) => {
     }
 
     dueRules += 1;
+
+    // A retryable failure must not consume the rule for the day: leaving
+    // last_triggered_at alone lets the next evaluation try the employees that
+    // failed, while the ones already reminded are held off by the per-employee
+    // rate limit.
+    let ruleHasRetryableFailure = false;
 
     const candidateEmployees =
       rule.scope === 'employee'
@@ -386,6 +394,17 @@ Deno.serve(async (req) => {
           continue;
         }
 
+        if (error instanceof PushTokenResolutionError) {
+          ruleHasRetryableFailure = true;
+          retryablePushFailures += 1;
+          errors.push({
+            ruleId: rule.id,
+            employeeId: employee.id,
+            message: error.message,
+          });
+          continue;
+        }
+
         errors.push({
           ruleId: rule.id,
           employeeId: employee.id,
@@ -394,7 +413,7 @@ Deno.serve(async (req) => {
       }
     }
 
-    if (!dryRun) {
+    if (!dryRun && !ruleHasRetryableFailure) {
       await supabaseAdmin
         .from('recurring_reminder_rules')
         .update({ last_triggered_at: new Date().toISOString() })
@@ -409,6 +428,7 @@ Deno.serve(async (req) => {
     remindersSent,
     skippedByCondition,
     skippedByRateLimit,
+    retryablePushFailures,
     errors,
     dryRun,
   });

--- a/supabase/functions/evaluate-recurring-reminders/index.ts
+++ b/supabase/functions/evaluate-recurring-reminders/index.ts
@@ -2,27 +2,11 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
-  getChecklistOrderDayReminderMessage,
-  PushTokenResolutionError,
-  ReminderRateLimitError,
   getReminderSystemSettings,
   getRequesterFromToken,
-  sendEmployeeReminder,
 } from '../_shared/reminders.ts';
-import {
-  selectLatestOrderForReminder,
-  type ReminderLocationGroup,
-} from '../_shared/recurringReminderScope.ts';
-
-const WEEKDAY_MAP: Record<string, number> = {
-  Sun: 0,
-  Mon: 1,
-  Tue: 2,
-  Wed: 3,
-  Thu: 4,
-  Fri: 5,
-  Sat: 6,
-};
+import type { ReminderLocationGroup } from '../_shared/recurringReminderScope.ts';
+import { evaluateRecurringRule } from './evaluator.ts';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
 const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
@@ -41,72 +25,6 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
     status,
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   });
-}
-
-function getZonedParts(date: Date, timeZone: string) {
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    hour12: false,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    weekday: 'short',
-  });
-
-  const parts = formatter.formatToParts(date);
-  const values: Record<string, string> = {};
-  parts.forEach((part) => {
-    values[part.type] = part.value;
-  });
-
-  const weekdayShort = values.weekday || 'Sun';
-
-  return {
-    year: Number(values.year),
-    month: Number(values.month),
-    day: Number(values.day),
-    hour: Number(values.hour),
-    minute: Number(values.minute),
-    weekday: WEEKDAY_MAP[weekdayShort] ?? 0,
-    dateKey: `${values.year}-${values.month}-${values.day}`,
-  };
-}
-
-function parseTimeToMinutes(value: string | null | undefined): number | null {
-  if (!value || typeof value !== 'string') return null;
-  const cleaned = value.trim();
-  const match = cleaned.match(/^(\d{1,2}):(\d{2})/);
-  if (!match) return null;
-  const hour = Number(match[1]);
-  const minute = Number(match[2]);
-  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
-  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
-  return hour * 60 + minute;
-}
-
-function isTimeInRange(nowMinutes: number, startMinutes: number, endMinutes: number): boolean {
-  if (startMinutes === endMinutes) return true;
-  if (startMinutes < endMinutes) {
-    return nowMinutes >= startMinutes && nowMinutes < endMinutes;
-  }
-  return nowMinutes >= startMinutes || nowMinutes < endMinutes;
-}
-
-function toDateKeyInTimezone(value: string | null | undefined, timeZone: string): string | null {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return getZonedParts(date, timeZone).dateKey;
-}
-
-function daysBetweenDateKeys(a: string, b: string): number {
-  const [aYear, aMonth, aDay] = a.split('-').map(Number);
-  const [bYear, bMonth, bDay] = b.split('-').map(Number);
-  const aMs = Date.UTC(aYear, aMonth - 1, aDay);
-  const bMs = Date.UTC(bYear, bMonth - 1, bDay);
-  return Math.max(0, Math.floor((aMs - bMs) / (1000 * 60 * 60 * 24)));
 }
 
 Deno.serve(async (req) => {
@@ -255,170 +173,28 @@ Deno.serve(async (req) => {
   let remindersSent = 0;
   let skippedByCondition = 0;
   let skippedByRateLimit = 0;
-  let retryablePushFailures = 0;
   const errors: { ruleId: string; employeeId?: string; message: string }[] = [];
 
   for (const rule of enabledRules) {
     evaluatedRules += 1;
+    const result = await evaluateRecurringRule({
+      supabaseAdmin,
+      rule,
+      settings,
+      now,
+      actorUserId,
+      dryRun,
+      employeeById,
+      employeesByLocation,
+      ordersByEmployeeId,
+      locationGroupById,
+    });
 
-    const timezone = typeof rule.timezone === 'string' && rule.timezone ? rule.timezone : 'America/Los_Angeles';
-    const nowParts = getZonedParts(now, timezone);
-    const nowMinutes = nowParts.hour * 60 + nowParts.minute;
-    const scheduledMinutes = parseTimeToMinutes(rule.time_of_day);
-
-    if (scheduledMinutes == null) {
-      errors.push({ ruleId: rule.id, message: 'Invalid rule time_of_day' });
-      continue;
-    }
-
-    const daysOfWeek = Array.isArray(rule.days_of_week)
-      ? rule.days_of_week.map((value: any) => Number(value)).filter((value: number) => Number.isInteger(value))
-      : [];
-
-    if (!daysOfWeek.includes(nowParts.weekday)) {
-      continue;
-    }
-
-    const windowMinutes = Math.max(1, Number(settings.recurringWindowMinutes || 15));
-    if (!(nowMinutes >= scheduledMinutes && nowMinutes < scheduledMinutes + windowMinutes)) {
-      continue;
-    }
-
-    const lastTriggeredDateKey = toDateKeyInTimezone(rule.last_triggered_at, timezone);
-    if (lastTriggeredDateKey === nowParts.dateKey) {
-      continue;
-    }
-
-    if (rule.quiet_hours_enabled) {
-      const quietStart = parseTimeToMinutes(rule.quiet_hours_start);
-      const quietEnd = parseTimeToMinutes(rule.quiet_hours_end);
-      if (quietStart != null && quietEnd != null && isTimeInRange(nowMinutes, quietStart, quietEnd)) {
-        continue;
-      }
-    }
-
-    dueRules += 1;
-
-    // A retryable failure must not consume the rule for the day: leaving
-    // last_triggered_at alone lets the next evaluation try the employees that
-    // failed, while the ones already reminded are held off by the per-employee
-    // rate limit.
-    let ruleHasRetryableFailure = false;
-
-    const candidateEmployees =
-      rule.scope === 'employee'
-        ? (rule.employee_id && employeeById.has(rule.employee_id) ? [employeeById.get(rule.employee_id)] : [])
-        : employeesByLocation.get(rule.location_id || '__none__') || [];
-
-    for (const employee of candidateEmployees) {
-      if (!employee) continue;
-
-      const latestOrder = selectLatestOrderForReminder(
-        ordersByEmployeeId.get(employee.id) ?? [],
-        rule,
-        locationGroupById,
-      );
-      const lastOrderDateKey = toDateKeyInTimezone(latestOrder?.created_at, timezone);
-
-      let conditionMet = false;
-      if (rule.condition_type === 'no_order_today') {
-        conditionMet = !lastOrderDateKey || lastOrderDateKey !== nowParts.dateKey;
-      } else {
-        const thresholdDays = Math.max(0, Number(rule.condition_value ?? 0));
-        if (!lastOrderDateKey) {
-          conditionMet = true;
-        } else {
-          const elapsedDays = daysBetweenDateKeys(nowParts.dateKey, lastOrderDateKey);
-          conditionMet = elapsedDays >= thresholdDays;
-        }
-      }
-
-      if (!conditionMet) {
-        skippedByCondition += 1;
-        continue;
-      }
-
-      let checklistMessage: string | undefined;
-      if (rule.rule_kind === 'checklist_order_day') {
-        try {
-          const locationGroup = rule.location_group === 'poki' ? 'poki' : 'sushi';
-          const checklistContext = await getChecklistOrderDayReminderMessage(
-            supabaseAdmin,
-            employee.id,
-            locationGroup
-          );
-          checklistMessage = checklistContext.body;
-        } catch (error: any) {
-          errors.push({
-            ruleId: rule.id,
-            employeeId: employee.id,
-            message: error?.message || 'Failed to resolve checklist reminder context',
-          });
-          continue;
-        }
-      }
-
-      if (dryRun) {
-        remindersSent += 1;
-        continue;
-      }
-
-      try {
-        const channelConfig =
-          rule.channels && typeof rule.channels === 'object'
-            ? {
-                push:
-                  typeof rule.channels.push === 'boolean'
-                    ? rule.channels.push
-                    : true,
-                in_app:
-                  typeof rule.channels.in_app === 'boolean'
-                    ? rule.channels.in_app
-                    : true,
-              }
-            : { push: true, in_app: true };
-
-        await sendEmployeeReminder(supabaseAdmin, {
-          employeeId: employee.id,
-          managerId: rule.created_by || actorUserId,
-          locationId: rule.scope === 'location' ? rule.location_id : employee.default_location_id,
-          source: 'recurring',
-          message: checklistMessage,
-          overrideRateLimit: false,
-          channels: channelConfig,
-        });
-        remindersSent += 1;
-      } catch (error: any) {
-        if (error instanceof ReminderRateLimitError) {
-          skippedByRateLimit += 1;
-          continue;
-        }
-
-        if (error instanceof PushTokenResolutionError) {
-          ruleHasRetryableFailure = true;
-          retryablePushFailures += 1;
-          errors.push({
-            ruleId: rule.id,
-            employeeId: employee.id,
-            message: error.message,
-          });
-          continue;
-        }
-
-        errors.push({
-          ruleId: rule.id,
-          employeeId: employee.id,
-          message: error?.message || 'Failed to send recurring reminder',
-        });
-      }
-    }
-
-    if (!dryRun && !ruleHasRetryableFailure) {
-      await supabaseAdmin
-        .from('recurring_reminder_rules')
-        .update({ last_triggered_at: new Date().toISOString() })
-        .eq('id', rule.id);
-    }
+    if (result.due) dueRules += 1;
+    remindersSent += result.remindersSent;
+    skippedByCondition += result.skippedByCondition;
+    skippedByRateLimit += result.skippedByRateLimit;
+    errors.push(...result.errors);
   }
 
   return jsonResponse({
@@ -428,7 +204,6 @@ Deno.serve(async (req) => {
     remindersSent,
     skippedByCondition,
     skippedByRateLimit,
-    retryablePushFailures,
     errors,
     dryRun,
   });

--- a/supabase/functions/send-reminder/index.ts
+++ b/supabase/functions/send-reminder/index.ts
@@ -135,7 +135,9 @@ Deno.serve(async (req) => {
     }
 
     if (error instanceof PushTokenResolutionError) {
-      // Nothing was written, so the caller can send the same reminder again.
+      // This delivery did not create or update its reminder records, so the
+      // caller can retry. Earlier stale-thread cleanup may have resolved an old
+      // reminder before token resolution failed.
       return jsonResponse(
         {
           error: error.message,

--- a/supabase/functions/send-reminder/index.ts
+++ b/supabase/functions/send-reminder/index.ts
@@ -2,6 +2,7 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.2?no-dts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
+  PushTokenResolutionError,
   ReminderRateLimitError,
   getRequesterFromToken,
   sendEmployeeReminder,
@@ -130,6 +131,18 @@ Deno.serve(async (req) => {
           code: 'RATE_LIMITED',
         },
         429
+      );
+    }
+
+    if (error instanceof PushTokenResolutionError) {
+      // Nothing was written, so the caller can send the same reminder again.
+      return jsonResponse(
+        {
+          error: error.message,
+          code: 'PUSH_TOKENS_UNAVAILABLE',
+          retryable: true,
+        },
+        503
       );
     }
 

--- a/supabase/functions/send-reminder/index.ts
+++ b/supabase/functions/send-reminder/index.ts
@@ -142,7 +142,7 @@ Deno.serve(async (req) => {
         {
           error: error.message,
           code: 'PUSH_TOKENS_UNAVAILABLE',
-          retryable: true,
+          retryable: error.retryable,
         },
         503
       );

--- a/supabase/migrations/20260905120000_device_push_token_ownership.sql
+++ b/supabase/migrations/20260905120000_device_push_token_ownership.sql
@@ -13,20 +13,31 @@
 -- Ownership comparisons are only sound on a single canonical spelling of a
 -- token, and only if the clock that orders claims is server controlled. Both
 -- are enforced here, on every write, for every caller.
+--
+-- Production had 0 rows in device_push_tokens on 2026-09-05. The repair,
+-- deduplication, and index builds therefore have no production data to scan.
+-- The migration still repairs populated local fixtures before adding its
+-- constraints.
+--
+-- There is a known row-lock versus advisory-lock inversion for direct active
+-- UPDATE statements. The only client registration path is a single-row upsert,
+-- and the only other client path is the deactivate UPDATE. In the rare cycle,
+-- PostgreSQL aborts one registration and the client repeats it on next launch.
+-- Moving registration behind a narrow RPC that takes the advisory lock before
+-- any row mutation is the follow-up; it requires an app contract change.
 
--- The table is small (at most one row per user per device) and every statement
--- below is bounded, so a lock wait is a bug rather than something to sit out.
+-- Bound both lock acquisition and total statement duration.
 set lock_timeout = '5s';
+set statement_timeout = '30s';
 
 -- ---------------------------------------------------------------------------
 -- Canonical token form.
 -- ---------------------------------------------------------------------------
 
--- Mirrors sanitizeExpoPushToken in supabase/functions/_shared/reminders.ts:
--- trim, then require an Expo token prefix. Kept immutable so the check
--- constraint below can use it. Postgres \s and JavaScript String.trim() differ
--- on exotic Unicode spaces; neither appears in an Expo token, and anything that
--- still disagrees is rejected outright by the prefix test.
+-- Mirrors canonicalizeExpoPushToken in the edge functions. btrim receives the
+-- complete ECMAScript trim set: ASCII whitespace, NBSP, the Unicode space
+-- separators, the two Unicode line separators, and BOM. The validator below
+-- then requires the exact Expo token grammar and rejects whitespace inside it.
 create or replace function public.canonical_expo_push_token(p_token text)
 returns text
 language sql
@@ -34,7 +45,13 @@ immutable
 parallel safe
 set search_path = ''
 as $$
-  select nullif(regexp_replace(coalesce(p_token, ''), '^\s+|\s+$', '', 'g'), '')
+  select nullif(
+    btrim(
+      coalesce(p_token, ''),
+      U&'\0009\000A\000B\000C\000D\0020\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF'
+    ),
+    ''
+  )
 $$;
 
 comment on function public.canonical_expo_push_token(text) is
@@ -48,7 +65,12 @@ parallel safe
 set search_path = ''
 as $$
   select p_token is not null
-     and (p_token like 'ExponentPushToken[%' or p_token like 'ExpoPushToken[%')
+     and p_token ~ '^Expo(nent)?PushToken\[[^]]+\]$'
+     and p_token = translate(
+       p_token,
+       U&'\0009\000A\000B\000C\000D\0020\00A0\1680\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A\2028\2029\202F\205F\3000\FEFF',
+       ''
+     )
 $$;
 
 comment on function public.is_expo_push_token(text) is
@@ -75,22 +97,22 @@ begin
     alter table public.device_push_tokens disable trigger set_device_push_tokens_updated_at;
   end if;
 
-  -- 1. Rows the sender could never have delivered to. sanitizeExpoPushToken
+  -- 1. Rows the sender could never deliver to. canonicalizeExpoPushToken
   --    drops them, so they hold no reachable device, but they would block the
   --    canonical-form constraint.
   delete from public.device_push_tokens
   where not public.is_expo_push_token(public.canonical_expo_push_token(expo_push_token));
 
   -- 2. Two spellings of one token by one user are one registration. Keep the
-  --    active row, then the most recently written, and drop the aliases so the
-  --    (user_id, expo_push_token) unique constraint survives canonicalization.
+  --    most recently written row, then prefer active only as a tie-breaker.
+  --    This preserves a newer logout over an older active padded spelling.
   delete from public.device_push_tokens as t
   using (
     select
       id,
       row_number() over (
         partition by user_id, public.canonical_expo_push_token(expo_push_token)
-        order by active desc, updated_at desc, created_at desc, id desc
+        order by updated_at desc, active desc, created_at desc, id desc
       ) as alias_rank
     from public.device_push_tokens
   ) as ranked
@@ -160,7 +182,7 @@ end;
 $$;
 
 comment on column public.device_push_tokens.claimed_at is
-  'Server-stamped time of this user''s last registration of this token. Among rows sharing a token, the newest claimed_at is the current owner.';
+  'Server-stamped time of this user''s last activation of this token. Inactive updates preserve it, and inactive inserts are rejected.';
 
 -- NOT NULL through a validated check: VALIDATE takes only SHARE UPDATE
 -- EXCLUSIVE, so registrations keep running, and SET NOT NULL then skips its
@@ -216,12 +238,10 @@ alter table public.device_push_tokens
 --
 -- Not CREATE INDEX CONCURRENTLY: it cannot run inside a transaction block, and
 -- both of this repo's runners wrap a migration in one (scripts/local-db/
--- full-stack.sh applies with --single-transaction, and the Supabase CLI does
--- the same on push). The production row count is unknown from this worktree,
--- which has no read access to the production database, but the table holds at
--- most one row per user per device for a single-restaurant tenant, so both
--- builds are expected to be sub-second. lock_timeout above bounds the damage
--- if that assumption is wrong.
+-- full-stack.sh and verify-migrations.sh apply with --single-transaction, and
+-- the Supabase CLI does the same on push). Production had 0 rows on 2026-09-05,
+-- so the builds have no production data to scan. The timeouts above still
+-- protect other environments and future replays.
 -- ---------------------------------------------------------------------------
 create unique index if not exists device_push_tokens_one_active_owner_idx
   on public.device_push_tokens (expo_push_token)
@@ -252,6 +272,11 @@ as $$
 declare
   v_token text;
 begin
+  if tg_op = 'INSERT' and new.active is not true then
+    raise exception 'inactive device push token inserts are not allowed; deactivate an existing row with UPDATE'
+      using errcode = '22023';
+  end if;
+
   -- A non-activating update is a deactivation, not a registration. The
   -- ownership clock and the token identity are server owned, so pin them back
   -- rather than raising: sign-out must never fail because the client sent a
@@ -271,12 +296,6 @@ begin
   end if;
 
   new.expo_push_token := v_token;
-
-  if new.active is not true then
-    -- An inactive insert claims nothing, but its clock is still server owned.
-    new.claimed_at := clock_timestamp();
-    return new;
-  end if;
 
   -- Serialize claims on one token. Without this, two first-time registrations
   -- of the same token race: both see no active row, and the unique index below
@@ -316,7 +335,8 @@ execute function public.claim_device_push_token();
 
 -- security invoker: the only caller is the service role, which already reads
 -- this table, so there is nothing to elevate. Rows are returned only when the
--- recipient is still the token's current owner.
+-- recipient is still the token's current owner. Every claimed_at considered
+-- here was stamped by an activation or reconstructed from legacy history.
 create or replace function public.active_device_push_tokens(p_user_id uuid)
 returns table (expo_push_token text, platform text, updated_at timestamptz)
 language sql

--- a/supabase/migrations/20260905120000_device_push_token_ownership.sql
+++ b/supabase/migrations/20260905120000_device_push_token_ownership.sql
@@ -14,10 +14,13 @@
 -- token, and only if the clock that orders claims is server controlled. Both
 -- are enforced here, on every write, for every caller.
 --
--- Production had 0 rows in device_push_tokens on 2026-09-05. The repair,
--- deduplication, and index builds therefore have no production data to scan.
--- The migration still repairs populated local fixtures before adding its
--- constraints.
+-- Production held 0 rows in device_push_tokens when the count was taken on
+-- 2026-09-05, during round 3 of review, by the only party here with production
+-- read access. It has not been re-taken since and cannot be from a worktree.
+-- If it is ever non-zero, the repair UPDATE, the two index builds and the
+-- DISABLE TRIGGER window hold locks for their duration; lock_timeout bounds
+-- the wait to acquire a lock but not how long it is then held. The migration
+-- repairs populated local fixtures either way, before adding its constraints.
 --
 -- There is a known row-lock versus advisory-lock inversion for direct active
 -- UPDATE statements. The only client registration path is a single-row upsert,
@@ -26,9 +29,12 @@
 -- Moving registration behind a narrow RPC that takes the advisory lock before
 -- any row mutation is the follow-up; it requires an app contract change.
 
--- Bound both lock acquisition and total statement duration.
-set lock_timeout = '5s';
-set statement_timeout = '30s';
+-- Bound both lock acquisition and total statement duration. SET LOCAL, not
+-- SET: both runners wrap this file in a transaction, and a plain SET would
+-- survive the commit and silently apply to every later migration pushed over
+-- the same connection. Outside a transaction this warns and does nothing.
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
 
 -- ---------------------------------------------------------------------------
 -- Canonical token form.
@@ -182,7 +188,7 @@ end;
 $$;
 
 comment on column public.device_push_tokens.claimed_at is
-  'Server-stamped time of this user''s last activation of this token. Inactive updates preserve it, and inactive inserts are rejected.';
+  'Server-stamped time of this user''s last activation of this token. Among rows sharing a token, the newest claimed_at is the current owner. Clients cannot set it: a PostgREST upsert must send active = true, and deactivation is UPDATE only.';
 
 -- NOT NULL through a validated check: VALIDATE takes only SHARE UPDATE
 -- EXCLUSIVE, so registrations keep running, and SET NOT NULL then skips its
@@ -262,12 +268,16 @@ create index if not exists device_push_tokens_token_claimed_idx
 -- security definer: the row-level policies deliberately confine a user to
 -- their own rows, so the departing user's row can only be retired by the
 -- database on the claimant's behalf.
+--
+-- Client contract: a PostgREST upsert must send active = true. BEFORE INSERT
+-- fires before ON CONFLICT arbitration, so an upsert carrying active = false
+-- raises 22023 instead of becoming an update. Deactivate with UPDATE only.
 -- ---------------------------------------------------------------------------
 create or replace function public.claim_device_push_token()
 returns trigger
 language plpgsql
 security definer
-set search_path = public
+set search_path = ''
 as $$
 declare
   v_token text;
@@ -342,7 +352,7 @@ returns table (expo_push_token text, platform text, updated_at timestamptz)
 language sql
 stable
 security invoker
-set search_path = public
+set search_path = ''
 as $$
   select t.expo_push_token, t.platform, t.updated_at
   from public.device_push_tokens as t

--- a/supabase/migrations/20260905120000_device_push_token_ownership.sql
+++ b/supabase/migrations/20260905120000_device_push_token_ownership.sql
@@ -1,0 +1,165 @@
+-- Device push token ownership.
+--
+-- A device token belongs to the last user who registers it:
+--   1. Registering a token claims it for the registering user.
+--   2. A claim deactivates every other user's row for the same token.
+--   3. A send never targets a token whose current owner is not the recipient.
+--
+-- Offline logout cannot deactivate the departing user's row from the client
+-- (docs/release-readiness/code-audit.md), so the shared-device handover has to
+-- be enforced in the database at the moment the next user registers the same
+-- token, not at the moment the previous user signs out.
+
+-- ---------------------------------------------------------------------------
+-- claimed_at: when this user last registered this token.
+-- ---------------------------------------------------------------------------
+alter table public.device_push_tokens
+  add column if not exists claimed_at timestamptz;
+
+alter table public.device_push_tokens
+  alter column claimed_at set default now();
+
+-- Backfill from updated_at, the closest existing record of the last
+-- registration write. The updated_at trigger is suspended for the backfill so
+-- historic rows do not all look freshly written afterwards, which would defer
+-- the client's staleness-based re-registration by a week.
+do $$
+declare
+  has_updated_at_trigger boolean := exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.device_push_tokens'::regclass
+      and tgname = 'set_device_push_tokens_updated_at'
+      and not tgisinternal
+  );
+begin
+  if has_updated_at_trigger then
+    alter table public.device_push_tokens disable trigger set_device_push_tokens_updated_at;
+  end if;
+
+  update public.device_push_tokens
+  set claimed_at = updated_at
+  where claimed_at is null;
+
+  if has_updated_at_trigger then
+    alter table public.device_push_tokens enable trigger set_device_push_tokens_updated_at;
+  end if;
+end;
+$$;
+
+alter table public.device_push_tokens
+  alter column claimed_at set not null;
+
+comment on column public.device_push_tokens.claimed_at is
+  'When this user last registered this device token. Among rows sharing a token, the newest claimed_at is the current owner.';
+
+-- ---------------------------------------------------------------------------
+-- One active owner per token.
+-- ---------------------------------------------------------------------------
+
+-- Existing data predates the rule, so a token may already have several active
+-- rows. Keep the newest claim and retire the rest before the index lands.
+with ranked as (
+  select
+    id,
+    row_number() over (
+      partition by expo_push_token
+      order by claimed_at desc, updated_at desc, created_at desc, id desc
+    ) as claim_rank
+  from public.device_push_tokens
+  where active
+)
+update public.device_push_tokens as t
+set active = false
+from ranked
+where ranked.id = t.id
+  and ranked.claim_rank > 1;
+
+create unique index if not exists device_push_tokens_one_active_owner_idx
+  on public.device_push_tokens (expo_push_token)
+  where active;
+
+-- Supports the ownership lookup below, which has to consider inactive rows of
+-- other users, so the partial index above cannot serve it.
+create index if not exists device_push_tokens_token_claimed_idx
+  on public.device_push_tokens (expo_push_token, claimed_at desc);
+
+-- ---------------------------------------------------------------------------
+-- The claim itself.
+-- ---------------------------------------------------------------------------
+
+-- security definer: the row-level policies deliberately confine a user to
+-- their own rows, so the departing user's row can only be retired by the
+-- database on the claimant's behalf.
+create or replace function public.claim_device_push_token()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.active is not true then
+    return new;
+  end if;
+
+  -- clock_timestamp(), not now(): two claims inside one transaction must still
+  -- order, otherwise the later claimant cannot be told from the earlier one.
+  new.claimed_at := clock_timestamp();
+
+  -- The recursive fire on these rows exits at the guard above, because they
+  -- are being deactivated.
+  update public.device_push_tokens as prior
+  set active = false
+  where prior.expo_push_token = new.expo_push_token
+    and prior.user_id <> new.user_id
+    and prior.active;
+
+  return new;
+end;
+$$;
+
+comment on function public.claim_device_push_token() is
+  'Claims a device token for the registering user and deactivates every other user''s row for the same token.';
+
+drop trigger if exists device_push_tokens_claim_device on public.device_push_tokens;
+create trigger device_push_tokens_claim_device
+before insert or update on public.device_push_tokens
+for each row
+when (new.active)
+execute function public.claim_device_push_token();
+
+-- ---------------------------------------------------------------------------
+-- The send-side filter.
+-- ---------------------------------------------------------------------------
+
+-- security invoker: the only caller is the service role, which already reads
+-- this table, so there is nothing to elevate. Rows are returned only when the
+-- recipient is still the token's current owner.
+create or replace function public.active_device_push_tokens(p_user_id uuid)
+returns table (expo_push_token text, platform text, updated_at timestamptz)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select t.expo_push_token, t.platform, t.updated_at
+  from public.device_push_tokens as t
+  where t.user_id = p_user_id
+    and t.active
+    and not exists (
+      select 1
+      from public.device_push_tokens as other
+      where other.expo_push_token = t.expo_push_token
+        and other.user_id <> t.user_id
+        and (other.active or other.claimed_at > t.claimed_at)
+    )
+  order by t.updated_at desc;
+$$;
+
+comment on function public.active_device_push_tokens(uuid) is
+  'Push tokens that are safe to send to for this user: active, and not claimed by a later owner.';
+
+revoke all on function public.active_device_push_tokens(uuid) from public, anon, authenticated;
+grant execute on function public.active_device_push_tokens(uuid) to service_role;
+
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20260905120000_device_push_token_ownership.sql
+++ b/supabase/migrations/20260905120000_device_push_token_ownership.sql
@@ -9,20 +9,58 @@
 -- (docs/release-readiness/code-audit.md), so the shared-device handover has to
 -- be enforced in the database at the moment the next user registers the same
 -- token, not at the moment the previous user signs out.
+--
+-- Ownership comparisons are only sound on a single canonical spelling of a
+-- token, and only if the clock that orders claims is server controlled. Both
+-- are enforced here, on every write, for every caller.
+
+-- The table is small (at most one row per user per device) and every statement
+-- below is bounded, so a lock wait is a bug rather than something to sit out.
+set lock_timeout = '5s';
 
 -- ---------------------------------------------------------------------------
--- claimed_at: when this user last registered this token.
+-- Canonical token form.
 -- ---------------------------------------------------------------------------
-alter table public.device_push_tokens
-  add column if not exists claimed_at timestamptz;
 
-alter table public.device_push_tokens
-  alter column claimed_at set default now();
+-- Mirrors sanitizeExpoPushToken in supabase/functions/_shared/reminders.ts:
+-- trim, then require an Expo token prefix. Kept immutable so the check
+-- constraint below can use it. Postgres \s and JavaScript String.trim() differ
+-- on exotic Unicode spaces; neither appears in an Expo token, and anything that
+-- still disagrees is rejected outright by the prefix test.
+create or replace function public.canonical_expo_push_token(p_token text)
+returns text
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  select nullif(regexp_replace(coalesce(p_token, ''), '^\s+|\s+$', '', 'g'), '')
+$$;
 
--- Backfill from updated_at, the closest existing record of the last
--- registration write. The updated_at trigger is suspended for the backfill so
--- historic rows do not all look freshly written afterwards, which would defer
--- the client's staleness-based re-registration by a week.
+comment on function public.canonical_expo_push_token(text) is
+  'The single spelling of an Expo push token that ownership is compared on.';
+
+create or replace function public.is_expo_push_token(p_token text)
+returns boolean
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  select p_token is not null
+     and (p_token like 'ExponentPushToken[%' or p_token like 'ExpoPushToken[%')
+$$;
+
+comment on function public.is_expo_push_token(text) is
+  'True when the value is a canonical Expo push token the sender would accept.';
+
+-- ---------------------------------------------------------------------------
+-- Data repair, ahead of the constraints that will forbid the old shapes.
+--
+-- The updated_at trigger stays off for the whole repair: these statements
+-- rewrite history rather than record activity, and the claim order below is
+-- read from updated_at.
+-- ---------------------------------------------------------------------------
 do $$
 declare
   has_updated_at_trigger boolean := exists (
@@ -37,9 +75,83 @@ begin
     alter table public.device_push_tokens disable trigger set_device_push_tokens_updated_at;
   end if;
 
+  -- 1. Rows the sender could never have delivered to. sanitizeExpoPushToken
+  --    drops them, so they hold no reachable device, but they would block the
+  --    canonical-form constraint.
+  delete from public.device_push_tokens
+  where not public.is_expo_push_token(public.canonical_expo_push_token(expo_push_token));
+
+  -- 2. Two spellings of one token by one user are one registration. Keep the
+  --    active row, then the most recently written, and drop the aliases so the
+  --    (user_id, expo_push_token) unique constraint survives canonicalization.
+  delete from public.device_push_tokens as t
+  using (
+    select
+      id,
+      row_number() over (
+        partition by user_id, public.canonical_expo_push_token(expo_push_token)
+        order by active desc, updated_at desc, created_at desc, id desc
+      ) as alias_rank
+    from public.device_push_tokens
+  ) as ranked
+  where ranked.id = t.id
+    and ranked.alias_rank > 1;
+
   update public.device_push_tokens
-  set claimed_at = updated_at
+  set expo_push_token = public.canonical_expo_push_token(expo_push_token)
+  where expo_push_token is distinct from public.canonical_expo_push_token(expo_push_token);
+
+  -- 3. claimed_at: when this user last registered this token.
+  alter table public.device_push_tokens
+    add column if not exists claimed_at timestamptz;
+
+  alter table public.device_push_tokens
+    alter column claimed_at set default now();
+
+  -- An active row's updated_at is its last registration write, so it is the
+  -- best available claim. An inactive row's updated_at may instead be a late
+  -- sign-out landing after the current owner registered, which must never be
+  -- read as the newer claim. Inactive rows fall back to their own creation
+  -- time, clamped below the active owner's claim on the same token.
+  update public.device_push_tokens as t
+  set claimed_at = case
+    when t.active then t.updated_at
+    else least(
+      t.created_at,
+      t.updated_at,
+      coalesce(owner.owner_claim - interval '1 microsecond', 'infinity'::timestamptz)
+    )
+  end
+  from (
+    select expo_push_token, max(updated_at) as owner_claim
+    from public.device_push_tokens
+    where active
+    group by expo_push_token
+  ) as owner
+  where owner.expo_push_token = t.expo_push_token
+    and t.claimed_at is null;
+
+  -- Tokens with no active row at all have no owner to stay under.
+  update public.device_push_tokens
+  set claimed_at = case when active then updated_at else least(created_at, updated_at) end
   where claimed_at is null;
+
+  -- 4. One active owner per token. Existing data predates the rule, so keep
+  --    the newest claim and retire the rest before the index lands.
+  update public.device_push_tokens as t
+  set active = false
+  from (
+    select
+      id,
+      row_number() over (
+        partition by expo_push_token
+        order by claimed_at desc, updated_at desc, created_at desc, id desc
+      ) as claim_rank
+    from public.device_push_tokens
+    where active
+  ) as ranked
+  where ranked.id = t.id
+    and ranked.claim_rank > 1;
 
   if has_updated_at_trigger then
     alter table public.device_push_tokens enable trigger set_device_push_tokens_updated_at;
@@ -47,34 +159,70 @@ begin
 end;
 $$;
 
+comment on column public.device_push_tokens.claimed_at is
+  'Server-stamped time of this user''s last registration of this token. Among rows sharing a token, the newest claimed_at is the current owner.';
+
+-- NOT NULL through a validated check: VALIDATE takes only SHARE UPDATE
+-- EXCLUSIVE, so registrations keep running, and SET NOT NULL then skips its
+-- own table scan because the proven constraint already implies it.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.device_push_tokens'::regclass
+      and conname = 'device_push_tokens_claimed_at_present'
+  ) then
+    alter table public.device_push_tokens
+      add constraint device_push_tokens_claimed_at_present
+      check (claimed_at is not null) not valid;
+  end if;
+end;
+$$;
+
+alter table public.device_push_tokens
+  validate constraint device_push_tokens_claimed_at_present;
+
 alter table public.device_push_tokens
   alter column claimed_at set not null;
 
-comment on column public.device_push_tokens.claimed_at is
-  'When this user last registered this device token. Among rows sharing a token, the newest claimed_at is the current owner.';
+-- The column constraint now carries the rule; the check has done its job.
+alter table public.device_push_tokens
+  drop constraint device_push_tokens_claimed_at_present;
+
+-- Canonical form, declared rather than only enforced by the trigger, so a
+-- future trigger change cannot quietly reintroduce alias rows.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.device_push_tokens'::regclass
+      and conname = 'device_push_tokens_expo_push_token_canonical'
+  ) then
+    alter table public.device_push_tokens
+      add constraint device_push_tokens_expo_push_token_canonical
+      check (
+        expo_push_token = public.canonical_expo_push_token(expo_push_token)
+        and public.is_expo_push_token(expo_push_token)
+      ) not valid;
+  end if;
+end;
+$$;
+
+alter table public.device_push_tokens
+  validate constraint device_push_tokens_expo_push_token_canonical;
 
 -- ---------------------------------------------------------------------------
--- One active owner per token.
+-- Indexes.
+--
+-- Not CREATE INDEX CONCURRENTLY: it cannot run inside a transaction block, and
+-- both of this repo's runners wrap a migration in one (scripts/local-db/
+-- full-stack.sh applies with --single-transaction, and the Supabase CLI does
+-- the same on push). The production row count is unknown from this worktree,
+-- which has no read access to the production database, but the table holds at
+-- most one row per user per device for a single-restaurant tenant, so both
+-- builds are expected to be sub-second. lock_timeout above bounds the damage
+-- if that assumption is wrong.
 -- ---------------------------------------------------------------------------
-
--- Existing data predates the rule, so a token may already have several active
--- rows. Keep the newest claim and retire the rest before the index lands.
-with ranked as (
-  select
-    id,
-    row_number() over (
-      partition by expo_push_token
-      order by claimed_at desc, updated_at desc, created_at desc, id desc
-    ) as claim_rank
-  from public.device_push_tokens
-  where active
-)
-update public.device_push_tokens as t
-set active = false
-from ranked
-where ranked.id = t.id
-  and ranked.claim_rank > 1;
-
 create unique index if not exists device_push_tokens_one_active_owner_idx
   on public.device_push_tokens (expo_push_token)
   where active;
@@ -86,31 +234,66 @@ create index if not exists device_push_tokens_token_claimed_idx
 
 -- ---------------------------------------------------------------------------
 -- The claim itself.
--- ---------------------------------------------------------------------------
-
+--
+-- One trigger, not two, and no WHEN clause: canonicalization has to run on
+-- every write, and splitting it into a second trigger would make correctness
+-- depend on trigger name ordering.
+--
 -- security definer: the row-level policies deliberately confine a user to
 -- their own rows, so the departing user's row can only be retired by the
 -- database on the claimant's behalf.
+-- ---------------------------------------------------------------------------
 create or replace function public.claim_device_push_token()
 returns trigger
 language plpgsql
 security definer
 set search_path = public
 as $$
+declare
+  v_token text;
 begin
-  if new.active is not true then
+  -- A non-activating update is a deactivation, not a registration. The
+  -- ownership clock and the token identity are server owned, so pin them back
+  -- rather than raising: sign-out must never fail because the client sent a
+  -- stale or invented value alongside active = false. Checked before
+  -- canonicalization for the same reason.
+  if tg_op = 'UPDATE' and new.active is not true then
+    new.expo_push_token := old.expo_push_token;
+    new.claimed_at := old.claimed_at;
     return new;
   end if;
 
+  v_token := public.canonical_expo_push_token(new.expo_push_token);
+
+  if not public.is_expo_push_token(v_token) then
+    raise exception 'expo_push_token is not an Expo push token'
+      using errcode = '22023';
+  end if;
+
+  new.expo_push_token := v_token;
+
+  if new.active is not true then
+    -- An inactive insert claims nothing, but its clock is still server owned.
+    new.claimed_at := clock_timestamp();
+    return new;
+  end if;
+
+  -- Serialize claims on one token. Without this, two first-time registrations
+  -- of the same token race: both see no active row, and the unique index below
+  -- rejects the second with a unique violation instead of letting the later
+  -- registration win.
+  perform pg_advisory_xact_lock(hashtext(v_token));
+
   -- clock_timestamp(), not now(): two claims inside one transaction must still
   -- order, otherwise the later claimant cannot be told from the earlier one.
+  -- Assigned here, so a client-supplied claimed_at is always discarded.
   new.claimed_at := clock_timestamp();
 
   -- The recursive fire on these rows exits at the guard above, because they
   -- are being deactivated.
   update public.device_push_tokens as prior
   set active = false
-  where prior.expo_push_token = new.expo_push_token
+  where prior.expo_push_token = v_token
     and prior.user_id <> new.user_id
     and prior.active;
 
@@ -119,13 +302,12 @@ end;
 $$;
 
 comment on function public.claim_device_push_token() is
-  'Claims a device token for the registering user and deactivates every other user''s row for the same token.';
+  'Canonicalizes a device token, stamps the claim server side, and deactivates every other user''s row for the same token.';
 
 drop trigger if exists device_push_tokens_claim_device on public.device_push_tokens;
 create trigger device_push_tokens_claim_device
 before insert or update on public.device_push_tokens
 for each row
-when (new.active)
 execute function public.claim_device_push_token();
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #45

## What changed

A device token belongs to the last user who registers it, enforced in the database rather than by the departing client.

- `supabase/migrations/20260905120000_device_push_token_ownership.sql`
  - `canonical_expo_push_token(text)` and `is_expo_push_token(text)`: one canonical spelling of a token, mirroring `sanitizeExpoPushToken` in the sender. Enforced by the trigger on every write and declared as a validated check constraint.
  - `device_push_tokens.claimed_at`: server-stamped ownership clock. A client-supplied value is always discarded.
  - `claim_device_push_token()` (BEFORE INSERT OR UPDATE, security definer) canonicalizes, rejects non-tokens, takes `pg_advisory_xact_lock(hashtext(token))`, stamps the claim, and deactivates every other user's row for the same token. A non-activating update cannot move `claimed_at` or the token identity.
  - Partial unique index `device_push_tokens_one_active_owner_idx on (expo_push_token) where active`: one active owner per token, enforced even if the trigger were bypassed.
  - `active_device_push_tokens(uuid)` (security invoker, service_role only) returns the tokens a recipient may be sent to: active, and not claimed by a later owner.
  - Data repair for existing rows: undeliverable junk deleted, alias spellings collapsed, `claimed_at` backfilled so an inactive row can never outrank the active owner, and duplicate active owners retired.
- `supabase/functions/_shared/reminders.ts`: the sender resolves tokens through that RPC. Resolution happens before any write, so a push-only reminder that cannot resolve throws `PushTokenResolutionError` and consumes nothing.
- `supabase/functions/evaluate-recurring-reminders/`: ~~that error leaves `last_triggered_at` alone, so the next run retries~~. **Superseded by round 3:** the rule is consumed, and round 4 makes the failure visible in the run's `errors` output instead of counting it as sent.
- `supabase/functions/send-reminder/index.ts`: returns 503 `PUSH_TOKENS_UNAVAILABLE` instead of a flat 500.
- `supabase/functions/_shared/reminders.test.ts`: 6 new Deno tests. `scripts/local-db/push_token_ownership_fixture.sql` (12 assertions), `scripts/local-db/push_token_concurrency_check.sh`, README.

## Review response

Codex Sol adversarial review on `21ceff8`, plus one Codex bot inline P2.

| Finding | Status | Where |
| --- | --- | --- |
| 1. Send-time race, ownership can change before Expo receives the push | **Deferred, not fixed.** The real fix is generic or data-only push content, which is a product decision and app-side work. Orchestrator is taking it to David. | design note below |
| 2. Raw token equality disagrees with the sender's canonicalization | Fixed | `8f9531d` |
| 3. Clients can rewrite the ownership clock or reactivate a stale claim | Fixed for the clock and token identity; reactivation is intended, see below | `8f9531d` |
| 4. Concurrent first claims do not implement last-writer-wins | Fixed | `8f9531d` |
| 5. Resolver error consumes the recurring reminder | Fixed | `8f9531d` |
| 6. Migration locking | Fixed as far as this repo's runners allow, see below | `8f9531d` |
| Codex bot P2: backfill from deactivation timestamps | Fixed | `8f9531d` |

Notes on the partial answers:

**Finding 3.** `claimed_at` and `expo_push_token` are now server owned: a write that does not leave the row active has both pinned back to their stored values, so the `claimed_at = 'infinity'` lockout is gone. Reactivating a stale row is *not* blocked, because under this issue's rule a former owner re-registering the device is a registration and should win it back. The pin-back overwrites rather than raising, so a sign-out never fails because the client sent a stale or invented value alongside `active = false`. The narrow register/deactivate RPCs Sol suggested would need the app to change, which is outside this issue's owned folders; the trigger holds the same invariants for every writer, including direct Data API calls.

**Finding 6.** `set lock_timeout = '5s'` at the top. `NOT NULL` now goes on through a `NOT VALID` check that is then validated under `SHARE UPDATE EXCLUSIVE`, so `SET NOT NULL` skips its own scan. The indexes are **not** built concurrently: `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block, and both runners for this repo wrap a migration in one (`scripts/local-db/full-stack.sh` applies with `--single-transaction`, and the Supabase CLI does the same on push). ~~Production row count is **unknown**~~. **Superseded by round 3:** the count was taken on 2026-09-05 and was 0. It was taken by the only party here with production read access, and this worktree still cannot verify it. `statement_timeout = '30s'` was added beside `lock_timeout` in round 3. The table holds at most one row per user per device for a single-restaurant tenant, so the builds are expected to be sub-second; `lock_timeout` bounds the damage if that is wrong.

## Design note

**Trigger, not RPC.** Registration today is a client upsert straight into `device_push_tokens` (`src/services/notificationService.ts`), and the app is out of scope for this issue. A registration RPC would leave the table's INSERT and UPDATE policies as an unguarded second door, so the rule would only hold for callers who chose the front one. A trigger holds for every writer, including PostgREST, the service role, and any future path. The RLS policies are unchanged: a user still cannot touch another user's row. The trigger is security definer precisely because the claimant must not be able to write the departing user's row directly.

**One trigger, no WHEN clause.** Canonicalization has to run on every write, including deactivations, so splitting it into a second trigger would make correctness depend on trigger name ordering.

**The partial unique index is the backstop.** If the trigger were dropped or disabled, two users could otherwise hold the same phone active. The fixture proves it with the trigger disabled.

**The advisory lock is load-bearing.** Two first-time registrations of one token otherwise both see no active row, and the second dies on the unique index instead of winning. Verified both ways: with the lock, the second session waits 1.99s and takes the token; with the lock removed, it fails with `duplicate key value violates unique constraint "device_push_tokens_one_active_owner_idx"`.

**`clock_timestamp()`, not `now()`.** Two claims inside one transaction must still order, otherwise the later claimant cannot be told from the earlier one.

**In-flight sends.** The resolver runs immediately before the reminder is written and the Expo call is made, so the exposure window is one database round trip plus the call to Expo. It cannot be closed completely: once a payload is handed to Expo, no database state can recall it. If a handover lands inside that window the previous user can still receive one notification on the device. **The residual is one notification inside the Expo round trip.** The token is retired for every subsequent send. Expo's own `DeviceNotRegistered` handling is unchanged and still scoped to the recipient's rows.

Resolution moved from "immediately before the Expo call" to "immediately before the reminder write" so that a push-only failure consumes nothing (finding 5). That widens the window by the reminder and notification inserts, a few milliseconds against an external HTTP call.

**Known residual, not introduced here.** An authenticated user can still insert a token string they do not own. Under the new rule that also deactivates the real owner's row, so the failure mode shifts from "attacker receives their own pushes on a stranger's phone" to "and the stranger stops receiving theirs". Closing it needs registration to move behind an edge function with device attestation, which is app-side work and outside this issue's owned folders.

## Validation

Exact commands and honest results, all re-run on `a9999b2`.

| Command | Result |
| --- | --- |
| `npm run typecheck` | pass, clean |
| `npm run lint` | pass, 0 errors, 90 warnings, all pre-existing (issue #43); unchanged count, none in the touched files |
| `npm run test:ci` | **fails to collect: "No tests found"**. The worktree sits under `.claude/`, which jest's `testPathIgnorePatterns` excludes, so all 68 suites are skipped. Not a code failure. |
| `npx jest --runInBand --watchman=false --testPathIgnorePatterns=/node_modules/` | pass, 67 passed / 1 skipped, 1031 tests passed, 14 skipped |
| `deno test --no-config --allow-all _shared/` from `supabase/functions` | pass, 33 passed / 0 failed (9 in `reminders.test.ts`) |
| `deno check --no-config send-reminder/index.ts evaluate-recurring-reminders/index.ts` | pass |
| `scripts/local-db/verify-migrations.sh --keep` | `PASS: 30 migration(s) applied cleanly on top of the production baseline.` |
| `docker exec -i <container> psql ... < scripts/local-db/push_token_ownership_fixture.sql` | 12 `ok:` assertions, `PASS: push token ownership fixture assertions all held` |
| `scripts/local-db/push_token_concurrency_check.sh <container>` | `PASS: concurrent claims serialized, the later registration won, no unique violation.` |
| `FULL_STACK_PORT_BASE=54530 scripts/local-db/full-stack.sh up` | `PASS: schema loaded.` |

Fixture assertions:

```
ok: registering a token claims it for the registering user
ok: a new registration deactivates prior owners' rows only for that token
ok: sends resolve only to tokens the recipient currently owns
ok: a padded token spelling collapses onto the canonical token and claims it
ok: a value that is not an Expo token is refused
ok: a non-activating write cannot move the clock or the token
ok: ownership follows the most recent registration in both directions
ok: the database refuses two active owners for one token
ok: a newer deactivation does not outrank the active owner
ok: a later claim beats a stale active row on the same token
ok: employees still cannot read or write another user's device rows
ok: only the service role can resolve send-side tokens
PASS: push token ownership fixture assertions all held
```

**Legacy data.** On a kept verify container I rewound to the pre-migration shape, seeded every broken state the migration has to repair, and re-applied it. Results:

| Seeded | After the migration |
| --- | --- |
| Three users active on `legacy-shared` | Newest write (`2026-03-09`) kept, other two retired |
| Active owner on `legacy-late-signout` claimed `2026-04-01`; inactive row `updated_at 2026-05-20` (Codex P2) | Inactive row's `claimed_at` backfilled to `2026-03-01`, below the owner's claim; resolver still returns the token for the active owner |
| One user holding both `ExponentPushToken[legacy-alias]` and a padded spelling | Alias row deleted, one row kept |
| A second user holding a padded spelling of the same token | Canonicalized; the newer write took the token, the older owner retired |
| `not-an-expo-token` | Deleted, undeliverable by the sender either way |
| Clean single-owner row | Untouched, `updated_at` preserved |

**End to end through PostgREST**, on the full stack at 54530, which is the path the edge function actually takes:

- User A registered `ExponentPushToken[fs-shared]`.
- User B upserted `"  ExponentPushToken[fs-shared] "` with a real GoTrue JWT. It was stored canonically, A's row flipped inactive, and no second row appeared.
- `POST /rest/v1/rpc/active_device_push_tokens` as the service role returned `[]` for A and the token for B.
- A reclaimed the device. B then PATCHed their own inactive row with `claimed_at: "infinity"`; the stored value came back as their real claim time, and the resolver still returned the token for A.
- An insert of `"nope"` was refused with `22023 expo_push_token is not an Expo push token`.
- The same RPC with B's authenticated JWT returned `42501 permission denied for function active_device_push_tokens`.

No remote or production database was touched. No edge function was deployed.

## Not done

- Finding 1 is open by direction, pending David's decision on generic push content.
- `supabase/functions/_shared/reminders.test.ts` runs under Deno, matching the four existing edge function test files. None of them are wired into CI: `.github/workflows/ci.yml` runs jest only. Adding a `deno test` step is a repo-wide change outside this issue's owned folders.
- No simulator run: this change has no app-side surface.


# Review response, round 3

Base: `issue/45-push-token-ownership`, fix commit 6f56811. Implemented by Codex Sol; verified, committed and pushed by the orchestrator. One fixture ordering bug (array comparison under the container collation) was fixed by the orchestrator with a collate "C" sort.

| Second-pass finding | Response | Commit or reason |
| --- | --- | --- |
| 1. Database and sender canonicalization differ | Fixed. PostgreSQL trims the complete ECMAScript set with an explicit character list, then requires the exact Expo token grammar. The sender uses `canonicalizeExpoPushToken` in `_shared` with `String.trim()` and the same grammar. Migration and sender tests cover leading U+FEFF, trailing U+FEFF, U+00A0, both wrapped around a valid token, internal whitespace, empty payloads, and trailing junk. | Fixed in 6f56811. |
| 2. Inactive insert creates a later claim | Fixed. The trigger rejects inactive inserts with SQLSTATE `22023` and tells callers to deactivate with UPDATE. Only activation stamps `claimed_at`; inactive updates preserve the prior activation timestamp. The fixture inserts user B's inactive row for user A's token, expects rejection, and checks that the resolver still returns user A. | Fixed in 6f56811. |
| 3. Row-lock and advisory-lock inversion | Documented without a code change, as directed. The migration header and PR body explain the inversion, the single-row registration upsert and deactivate UPDATE client paths, PostgreSQL aborting one registration in the rare cycle, the next-launch retry, and the narrow registration RPC follow-up. | Documented reason. The RPC requires an app contract change and is out of scope for this fix round. |
| 4. Alias cleanup keeps stale active spelling | Fixed. Alias ranking now sorts by `updated_at DESC`, then `active DESC`, followed by deterministic tie-breakers. The migration fixture seeds an older active padded row and a newer inactive canonical row, reapplies the migration, and requires the newer inactive row to survive. | Fixed in 6f56811. |
| 5. Location-rule retry duplicates successful sends | Fixed without per-employee tracking. A recurring push-token resolution error writes one failed push result with `successCount: 0` and `failureCount: 1`. The evaluator advances `last_triggered_at` for the rule. A two-employee evaluator test records one accepted push and one failed push, then proves the next run sends neither again. Manual push-only sends still throw before reminder delivery writes; comments now note that stale-thread cleanup can happen earlier. | Fixed in 6f56811. |
| 6. Timeout and partial verification migration | Fixed. The migration now sets `statement_timeout = '30s'` beside `lock_timeout = '5s'` and records the verified production row count of 0 on 2026-09-05. `verify-migrations.sh` applies each SQL file with `--single-transaction`. Docker now allocates the local port, and the read-only worktree mount lets the fixture reapply the checked-in migration. | Fixed in 6f56811. |

## Regression evidence

Before the sender fix:

```text
deno test --no-config --allow-all _shared/reminders.test.ts
a recurring push-only resolver failure is recorded as one failed push ... FAILED
error: PushTokenResolutionError: schema cache is reloading
FAILED | 8 passed | 1 failed
```

After the fix, the evaluator and sender suite passes with 36 tests.

## Validation

| Command | Result |
| --- | --- |
| `npm run typecheck` | Pass. Exit 0. `tsc --noEmit` produced no diagnostics. |
| `npm run lint` | Pass. Exit 0. 0 errors and 90 existing warnings. |
| `npx jest --runInBand --watchman=false --testPathIgnorePatterns=/node_modules/` | Pass. 67 suites passed, 1 skipped. 1031 tests passed, 14 skipped. |
| `cd supabase/functions && deno test --no-config --allow-all _shared/ evaluate-recurring-reminders/ 2>&1 \| tail -3` | Pass. `ok \| 36 passed \| 0 failed (473ms)`. |
| `cd supabase/functions && deno check --no-config send-reminder/index.ts evaluate-recurring-reminders/index.ts` | Pass. Both entrypoints checked. |
| `bash -n scripts/local-db/verify-migrations.sh scripts/local-db/push_token_concurrency_check.sh` | Pass. Exit 0. |
| `git diff --check` | Pass. Exit 0. |
| `scripts/local-db/verify-migrations.sh --keep` | Rerun by the orchestrator on 6f56811: `PASS: 30 migration(s) applied cleanly on top of the production baseline.` |
| `docker exec -i <container> psql -U postgres -d postgres -v ON_ERROR_STOP=1 < scripts/local-db/push_token_ownership_fixture.sql` | Rerun by the orchestrator on 6f56811: 16 `ok:` assertions, `PASS: push token ownership fixture assertions all held`. |
| `scripts/local-db/push_token_concurrency_check.sh <container>` | Rerun by the orchestrator on 6f56811: `PASS: concurrent claims serialized, the later registration won, no unique violation.` |
| `docker rm -f <container>` | Container removed after the rerun. |

No app or `src` files changed. No remote database was read or written. No push,
PR mutation, deployment, or edge-function deployment was attempted.



# Deploy order

Do not deploy the edge functions before the migration. `send-reminder` and
`evaluate-recurring-reminders` call `active_device_push_tokens`, and calling it
before it exists returns `PGRST202` on every send.

1. **Production is at migration `20260828100000`.** Apply
   `20260831120000_kitchen_requests.sql` first; it belongs to PR #28 and is not
   part of this change, but it sits between production and this migration.
2. Apply `20260905120000_device_push_token_ownership.sql`.
3. Confirm `active_device_push_tokens` is in the PostgREST schema cache. The
   migration ends with `notify pgrst, 'reload schema'`; verify with a
   service-role `POST /rest/v1/rpc/active_device_push_tokens` before moving on.
4. Deploy `send-reminder`, then `evaluate-recurring-reminders`.

Rolling the functions back is safe. Rolling the migration back is not: it
deletes undeliverable rows and collapses alias spellings.

Nothing here has been deployed.

# Review response, round 4

Opus adversarial review of round 3 (`6f56811`). Fix commit `b84a04f`.

| Finding | Response | Commit or reason |
| --- | --- | --- |
| 1. [blocker] A recurring push-only resolver failure is consumed, counted as sent, and never surfaced | Fixed. `sendEmployeeReminder` now sets `push.tokenResolutionFailed`, an explicit flag rather than a string match on `errorDetail`. The evaluator does not count that employee in `remindersSent` and pushes `{ ruleId, employeeId, message }` into `result.errors`, so the cron response reports the failure. The rule is still consumed, per direction. Deploy order added above. | Fixed in `b84a04f`. |
| 2. [major] Consuming the rule on a resolver failure is a product fork | Stated, not decided. Round 3 chose "drop, do not duplicate" and the orchestrator has confirmed it stays. **Owner decision for David:** on a partial failure a location rule is consumed for the day, so the employees whose resolution failed get nothing until the next day. The alternative is a `recurring_rule_deliveries (rule_id, employee_id, date_key)` table so only the failed employees retry. Round 4 at least makes the drop visible in the cron output. | Deferred, product decision. |
| 3. [minor] An upsert carrying `active = false` always raises | Documented. The trigger comment block and the `claimed_at` column comment now state the client contract: a PostgREST upsert must send `active = true`, and deactivation is `UPDATE` only, because `BEFORE INSERT` fires before `ON CONFLICT` arbitration. No behaviour change; no current caller is affected. | Fixed in `b84a04f`. |
| 4. [minor] The zero-row production claim is load-bearing and contradicts the PR body | Fixed. The migration header now attributes the count, dates it, says it has not been re-taken and cannot be from a worktree, and states plainly that `lock_timeout` bounds the wait to acquire a lock but not how long it is held. The stale round 2 note above is struck through and corrected. | Fixed in `b84a04f`. |
| 5. [minor] `set lock_timeout` and `set statement_timeout` are session settings | Fixed. Both are now `set local`, with a comment saying it is a no-op with a warning if a runner ever applies the file outside a transaction. | Fixed in `b84a04f`. |
| 6. [minor] No round 3 finding table; second-pass finding 3 deferred only in a code comment | Fixed. The round 3 table exists above; this table records the deferral of the advisory-lock inversion, and the two stale round 2 notes are struck through. **Deferred, round 3 finding 3:** a multi-row activating `UPDATE`, which RLS still permits over the Data API, can form a row-lock versus advisory-lock cycle. No live app path can: the client's deactivate `UPDATE` returns before the lock, and registration is a single-row upsert. In the rare cycle PostgreSQL aborts one registration and the client repeats it on next launch. The follow-up is a narrow registration RPC that takes the advisory lock before any row mutation, which needs an app contract change. | Fixed in `b84a04f`; the underlying inversion stays deferred. |
| 7. [nit] Wrong comment on the resolver failure branch | Fixed. The comment now says the branch is also reached on the recurring path, and points at `tokenResolutionFailed` as the thing the caller must surface. | Fixed in `b84a04f`. |
| 8. [nit] `search_path` inconsistent across the three new functions | Fixed. `claim_device_push_token` and `active_device_push_tokens` now use `set search_path = ''`, matching the two helpers. Every reference in both bodies was already schema qualified; the fixture exercises the trigger on every assertion and still passes. | Fixed in `b84a04f`. |
| 9. [nit] `PushTokenResolutionError.retryable` is never read | Fixed. `send-reminder` now returns `retryable: error.retryable` instead of a hardcoded `true`. | Fixed in `b84a04f`. |
| 10. [nit] The fixture only runs against a `verify-migrations.sh` container | Fixed. The README now says so, and why: the fixture `\i`s the migration from `/workspace`, a bind mount only that runner creates. | Fixed in `b84a04f`. |
| 11. [nit] `--single-transaction` is not universal | Fixed. The README's atomicity claim now names the exception, the older files that open and commit their own transaction. | Fixed in `b84a04f`. |

Nothing was skipped.

## Validation, round 4

All re-run on `b84a04f`.

| Command | Result |
| --- | --- |
| `npm run typecheck` | Pass, clean. |
| `npm run lint` | Pass. `0 errors, 90 warnings`, all pre-existing, count unchanged. |
| `npx jest --runInBand --watchman=false --testPathIgnorePatterns=/node_modules/` | Pass. 67 suites passed, 1 skipped. 1031 tests passed, 14 skipped. |
| `cd supabase/functions && deno test --no-config --allow-all _shared/ evaluate-recurring-reminders/` | Pass. `ok \| 36 passed \| 0 failed`. |
| `cd supabase/functions && deno check --no-config send-reminder/index.ts evaluate-recurring-reminders/index.ts` | Pass. Both entrypoints checked. |
| `scripts/local-db/verify-migrations.sh --keep` | `PASS: 30 migration(s) applied cleanly on top of the production baseline.` |
| `docker exec -i <container> psql -U postgres -d postgres -v ON_ERROR_STOP=1 < scripts/local-db/push_token_ownership_fixture.sql` | 15 `ok:` assertions, `PASS: push token ownership fixture assertions all held`. |
| `scripts/local-db/push_token_concurrency_check.sh <container>` | `PASS: concurrent claims serialized, the later registration won, no unique violation.` |
| `docker rm -f <container>` | Container removed. |

`npm run test:ci` is still red in this worktree, unchanged and not a code
failure: the worktree lives under `.claude/`, which jest's
`testPathIgnorePatterns` excludes, so it exits 1 with "No tests found". The
override row above is the real result.

The evaluator test now asserts the blocker directly: two employees, one
resolver failure, `remindersSent` must be 1 and `errors` must carry one entry
naming the rule, the employee and the resolver message.

No remote or production database was read or written. Nothing was deployed.
