### PR TITLE
Hygiene: apply the two safe npm audit mitigations

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,26 @@
 const { getDefaultConfig } = require("expo/metro-config");
 const { withNativeWind } = require("nativewind/metro");
 
-const config = getDefaultConfig(__dirname);
+const config = withNativeWind(getDefaultConfig(__dirname), {
+  input: "./global.css",
+});
 
-module.exports = withNativeWind(config, { input: "./global.css" });
+// Harden Metro's image parser against the image-size ICNS/JXL/HEIF infinite
+// loop advisories. See metro.transformer.js for the detail.
+//
+// Metro parses assets in its transform worker processes, so the mitigation has
+// to load there, not just here. We insert metro.transformer.js as the
+// transformerPath and hand it the transformer it replaced. Worker processes
+// inherit process.env, so they resolve the same upstream module.
+//
+// Read transformerPath after withNativeWind: nativewind swaps in its own
+// transformer, and we must chain to whatever ends up configured.
+// Keep this env var name in sync with metro.transformer.js.
+process.env.SMELTER_METRO_UPSTREAM_TRANSFORMER = config.transformerPath;
+config.transformerPath = require.resolve("./metro.transformer.js");
+
+// Load it here too, after the env var is set, so this process gets the same
+// protection and so an in-band transform reuses the fully initialised module.
+require("./metro.transformer.js");
+
+module.exports = config;

--- a/metro.transformer.js
+++ b/metro.transformer.js
@@ -1,0 +1,43 @@
+/**
+ * Metro transformer wrapper that hardens the bundler's image parser.
+ *
+ * Advisories GHSA-w3rx-r6r6-pgpr (ICNS) and GHSA-5p2g-fcmc-qvqq (JXL/HEIF)
+ * describe infinite loops in image-size, which Metro uses to read asset
+ * dimensions. image-size detects a file's type from its content, not its
+ * extension, so a malformed ICNS/JXL/HEIF file renamed to .png still reaches
+ * the vulnerable decoder and can hang a developer or CI bundling process.
+ *
+ * Metro parses assets inside its transform worker processes, so calling
+ * disableTypes() in metro.config.js alone leaves the workers unprotected.
+ * Metro requires this module in every worker (it is the configured
+ * transformerPath), so the call below runs everywhere assets are parsed.
+ * An asset plugin would run after image-size has already parsed the file.
+ *
+ * Smelter ships no ICNS, JXL or HEIF assets, so rejecting those types costs
+ * nothing. A disabled type raises "disabled file type: <type>" before the
+ * affected parser runs.
+ */
+
+const imageSize = require("image-size");
+
+const DISABLED_IMAGE_TYPES = ["icns", "jxl", "jxl-stream", "heif"];
+
+// Name of the env var metro.config.js uses to hand us the real transformer.
+// Keep this string in sync with metro.config.js.
+const UPSTREAM_ENV_VAR = "SMELTER_METRO_UPSTREAM_TRANSFORMER";
+
+imageSize.disableTypes(DISABLED_IMAGE_TYPES);
+
+const upstreamPath = process.env[UPSTREAM_ENV_VAR];
+
+if (!upstreamPath) {
+  throw new Error(
+    `${UPSTREAM_ENV_VAR} is not set, so the real Metro transformer cannot be ` +
+      `resolved. metro.config.js sets it before handing this file to Metro as ` +
+      `transformerPath. Start the bundler through metro.config.js.`
+  );
+}
+
+// Delegate every transformer method to the upstream transformer that
+// metro.config.js replaced. Only the image-size hardening above is ours.
+module.exports = require(upstreamPath);

--- a/metro.transformer.js
+++ b/metro.transformer.js
@@ -22,19 +22,19 @@ const imageSize = require("image-size");
 
 const DISABLED_IMAGE_TYPES = ["icns", "jxl", "jxl-stream", "heif"];
 
-// Name of the env var metro.config.js uses to hand us the real transformer.
-// Keep this string in sync with metro.config.js.
-const UPSTREAM_ENV_VAR = "SMELTER_METRO_UPSTREAM_TRANSFORMER";
-
 imageSize.disableTypes(DISABLED_IMAGE_TYPES);
 
-const upstreamPath = process.env[UPSTREAM_ENV_VAR];
+// metro.config.js hands us the transformer we replaced through this env var.
+// Metro's workers inherit process.env, so they resolve the same module.
+// Keep the name in sync with metro.config.js.
+const upstreamPath = process.env.SMELTER_METRO_UPSTREAM_TRANSFORMER;
 
 if (!upstreamPath) {
   throw new Error(
-    `${UPSTREAM_ENV_VAR} is not set, so the real Metro transformer cannot be ` +
-      `resolved. metro.config.js sets it before handing this file to Metro as ` +
-      `transformerPath. Start the bundler through metro.config.js.`
+    "SMELTER_METRO_UPSTREAM_TRANSFORMER is not set, so the real Metro " +
+      "transformer cannot be resolved. metro.config.js sets it before handing " +
+      "this file to Metro as transformerPath. Start the bundler through " +
+      "metro.config.js."
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15609,12 +15609,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,10 @@
   "overrides": {
     "shell-quote": "1.10.0",
     "brace-expansion@^1.0.0": "1.1.18",
-    "postcss": "8.5.28"
+    "postcss": "8.5.28",
+    "xcode": {
+      "uuid": "11.1.1"
+    }
   },
   "expo": {
     "doctor": {


### PR DESCRIPTION
Closes #44

Applies the two mitigations specified in `docs/release-readiness/dependency-audit.md`. No major upgrades, no source changes, no deploys. `decode-uri-component` is left as the documented residual.

## Changes

| File | Change |
| --- | --- |
| `package.json` | Scoped override `"xcode": { "uuid": "11.1.1" }` |
| `package-lock.json` | `uuid` 7.0.3 to 11.1.1 (single entry, the only change) |
| `metro.transformer.js` | New. Calls `image-size` `disableTypes(["icns","jxl","jxl-stream","heif"])`, then delegates to the transformer it replaced |
| `metro.config.js` | Inserts the wrapper as `transformerPath` and hands it the upstream path |

## `npm audit --omit=dev` before and after

Before (`origin/main`):

```
uuid  <11.1.1
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
node_modules/uuid
  xcode  >=0.9.2
  Depends on vulnerable versions of uuid

29 vulnerabilities (21 moderate, 8 high)
```

After (this branch):

```
16 vulnerabilities (8 moderate, 8 high)
```

The `uuid` advisory and its 13 dependent entries are gone. The two remaining advisories are the expected ones: `decode-uri-component` (documented residual, deliberately untouched) and `image-size` (mitigated at runtime, so `npm audit` still flags the version — there is no patched release, and the project is archived).

## Mitigation 1: scoped uuid override

`xcode@3.0.1` is the only `uuid` dependent in the lockfile, and it calls `uuid.v4()` with no output buffer, so the v3/v5/v6 buffer advisory never applied to this caller. uuid 11.1.1 keeps a CommonJS `require` export and `v4()` still returns a string, so the contract holds.

Parse, generate, write, reparse against a copy of the real `ios/Babytuna.xcodeproj/project.pbxproj`:

```
uuid version: 11.1.1
typeof uuid.v4: function
uuid.v4() -> 3fa2385d-59b1-4fe1-8a02-6e1760a8b714 | typeof: string
parse OK. native target entries: 2
generated 200 uuids, malformed: 0 | unique: 200
addSourceFile OK. uuid: 3D27BF93F29D41FDB204253B fileRef: 65A8E1D1E86C4CE4BF8FAFF4
addPbxGroup OK. uuid: 7489A7F54E434940BC881D5E
addToPbxGroup OK
write OK. bytes: 25244
reparse OK. native target entries: 2
added file and group survive reparse: OK
RESULT: PASS
```

### Prebuild: the native diff is pre-existing, not caused by the override

`npx expo prebuild --platform ios --no-install` rewrites 12 files regardless of this change, so `git status` is **not** clean after it. That drift already exists on `origin/main`. Proof: I ran the same prebuild twice from clean checkouts, one at `origin/main` with uuid 7.0.3 and one at this branch with uuid 11.1.1, and diffed both against the checked-in `ios/`.

The changed-file lists are identical, and the generated `project.pbxproj` files are byte-identical to each other:

```
=== prebuilt pbxproj: uuid 7.0.3 vs uuid 11.1.1 ===
IDENTICAL
```

The whole pbxproj delta against the checked-in tree is app.json drift with no new UUIDs in it:

```
372c372
< 				PRODUCT_NAME = Babytuna;
---
> 				PRODUCT_NAME = "Smelter";
376c376
< 				TARGETED_DEVICE_FAMILY = 1;
---
> 				TARGETED_DEVICE_FAMILY = "1";
(same two changes again for the Release config)
```

Plus regenerated splash/icon assets and plists. I reverted `ios/` afterwards; this PR touches no native files. The `PRODUCT_NAME` drift looks like a real, separate issue worth its own ticket: the checked-in project still says `Babytuna` while `app.json` says `Smelter`.

## Mitigation 2: image-size disableTypes in every transform worker

`metro.config.js` alone is not enough, because Metro parses assets inside forked transform workers. The wrapper is installed as `transformerPath`, which Metro `require`s in every worker, so `disableTypes()` runs there.

Two details worth review:

- Nativewind replaces `transformerPath` with `react-native-css-interop`'s transformer, so the wrapper reads `config.transformerPath` **after** `withNativeWind` and chains to whatever ended up configured rather than hardcoding Expo's.
- The upstream path is passed through `SMELTER_METRO_UPSTREAM_TRANSFORMER`. Metro's `WorkerFarm` spawns workers with `{...process.env}`, so the workers resolve the same module. `metro.config.js` also requires the wrapper itself, after setting the env var, so the parent process is protected and an in-band transform reuses the initialised module.

### Verification

`npx expo export --platform ios` succeeds, and the bundle is unchanged:

```
› ios bundles (1):
_expo/static/js/ios/entry-104f1e480aaf02f925e6d5d16d85aefa.hbc (8.25 MB)

Exported: dist
```

That hash is identical to the `origin/main` export, so the mitigation changes no shipped output.

I also proved the block actually fires in a worker, rather than only asserting the call exists. I planted a 64-byte malformed ICNS file named `hostile-probe.png` (image-size sniffs content, not extension) whose first image entry declares length 0, so the ICNS cursor never advances, and imported it from `app/_layout.tsx`:

- **With the mitigation**: export fails in 1777 ms with `SyntaxError: assets/images/hostile-probe.png: disabled file type: icns`.
- **Without it (`origin/main`)**: export wedges at `99.9% (2363/2364)` with a `jest-worker/build/workers/processChild.js` child pinned at 133% CPU. I killed it after about 2.5 minutes; it was not going to finish.

So the advisory is genuinely reachable through a build asset, it hangs a worker, and this change stops it. The probe and the temporary import were made in a throwaway copy and are not in this branch.

## Validation

Run from the branch. Exact commands and honest results:

| Command | Result |
| --- | --- |
| `npm run typecheck` | Pass (exit 0) |
| `npm run lint` | Pass (exit 0). 90 warnings, all pre-existing, none in the changed files |
| `npm run test:ci` | Pass. 67 suites passed, 1 skipped, 1031 tests passed, 14 skipped |
| `npm audit --omit=dev` | Red, as expected: 16 vulnerabilities, down from 29 |
| `npx expo export --platform ios` | Pass, identical bundle hash |
| `npx expo prebuild --platform ios --no-install` | Pass, drift identical to `origin/main` |
| xcode parse/generate/write/reparse | Pass |
| `npx expo run:ios --configuration Release` | Pass. `Build Succeeded`, installed and launched |

`npm run lint` initially failed with one error that was mine (`expo/no-dynamic-env-var` on `process.env[VAR]`); fixed in 3488b05 by reading the literal.

### Release simulator build

```
› Build Succeeded
› Installing .../Build/Products/Release-iphonesimulator/Babytuna.app
› Installing on iPhone 17 Pro Max
› Opening on iPhone 17 Pro Max (com.babytuna.systems)
```

The app launched and rendered its own React Native UI, which is the point of the check for a bundler change: the Release JS bundle loaded and executed on device.

It landed on the **App Configuration Required** screen (`app/_layout.tsx:125`). That is the app's honest missing-config state, not a regression: this worktree has no `.env` or `.env.local`, only the two `.example` files, so `EXPO_PUBLIC_*` Supabase values are unset. Any fresh checkout without local env behaves the same. I did not copy anyone's secrets in to get past it.

What to look for if you re-run this with a real `.env`: the login screen instead of the config screen. Everything up to and including JS execution is already proven.

## Two environment notes for the reviewer

Neither is caused by this PR, but both blocked validation and cost time.

**1. A worktree under `.claude/` cannot run Metro or Jest.** This worktree was created at `.claude/worktrees/agent-…`. Two repo settings key off that path:

- `jest.config.js` sets `testPathIgnorePatterns: ['/node_modules/', '/\\.claude/']`, so `npm run test:ci` inside the worktree reports `No tests found` and exits 1, silently skipping all 68 suites.
- Metro fails to resolve `react-native` from any project root under a dot-directory: `the package ... specifies a main module field that could not be resolved (.../react-native/index.js)`, although the file exists.

I confirmed both are pre-existing by reproducing the Metro failure on an unmodified `origin/main` checkout in the same location. Everything that needs Metro or Jest was therefore run from a clean copy of this branch at `/tmp/i44/mitigated`. Issue #44 asks for worktrees at `.worktrees/issue-N`, which would have avoided this; worth making that path mandatory.

**2. The simulator UDID in my instructions does not exist.** I was told `scripts/sim.sh` pins `FCADAB49-3A22-4167-B3EB-F794BEB32D9E` and to avoid `EF05F833-…` because another worker holds it. In fact `FCADAB49` is not on this Mac (`scripts/sim.sh` even says so in a comment), and the script hardcodes `EF05F833` — the busy one. `AGENTS.md` still documents `FCADAB49` as the target device, so `AGENTS.md` and `scripts/sim.sh` disagree.

I did not take over `EF05F833`. I booted the free, empty `iPhone 17 Pro Max 493660C2-D09B-4B39-AC50-705FFD205948` (iOS 26.2) and targeted it explicitly by UDID, per the rule about booting a second simulator rather than disrupting another agent. I never passed `booted`, never targeted Nellit's UDID, and never shut down or erased anything. `EF05F833` stayed booted and untouched throughout.

Because `scripts/sim.sh` hardcodes a single UDID and is outside this PR's scope, I could not route this through it. Reconciling `AGENTS.md`, `scripts/sim.sh`, and the real device set needs a separate decision.
