### PR TITLE
docs: fix stale simulator UDID in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,13 @@ Rules for every agent (Claude, Codex, or other) working in this repo.
 This Mac runs a second project (Nellit) with its own booted simulator. Two
 simulators are typically booted at once.
 
-- Target device: iPhone 17 Pro Max, iOS 26.2, UDID
-  `FCADAB49-3A22-4167-B3EB-F794BEB32D9E`.
+- Target device: Smelter Release QA iPhone 17 Pro Max, iOS 26.2, UDID
+  `EF05F833-2AC4-4383-8688-36C51B956BCF`. This is what `scripts/sim.sh` pins.
+- The old target UDID `FCADAB49-3A22-4167-B3EB-F794BEB32D9E` no longer exists
+  on this Mac. Do not use it.
+- A second free device, iPhone 17 Pro Max UDID
+  `493660C2-D09B-4B39-AC50-705FFD205948`, may be used by explicit UDID if
+  the primary target is busy with another worker.
 - Forbidden device: UDID `7C0CA22A-4895-44BA-BF7E-F53BB5CAF7F8` (Nellit).
   It also carries a stale `com.babytuna.systems` build, so launching there
   looks plausible and produces garbage results.


### PR DESCRIPTION
Closes #57

## What changed
AGENTS.md pinned the simulator target to UDID `FCADAB49-3A22-4167-B3EB-F794BEB32D9E`, which no longer exists on this Mac. `scripts/sim.sh` had already moved to a different UDID with a comment noting the old one was historical. Workers reading AGENTS.md were wasting time on a device that doesn't exist (per issue #44).

Updated the simulator section to:
- Point the target device at `EF05F833-2AC4-4383-8688-36C51B956BCF` (Smelter Release QA iPhone 17 Pro Max, iOS 26.2), matching what `scripts/sim.sh` actually pins.
- Note the old UDID no longer exists and should not be used.
- Document a second free device, `493660C2-D09B-4B39-AC50-705FFD205948` (iPhone 17 Pro Max), usable by explicit UDID when the primary target is busy with another worker.
- Kept the Nellit UDID (`7C0CA22A-4895-44BA-BF7E-F53BB5CAF7F8`) forbidden, unchanged.

## Evidence
Confirmed both UDIDs are live on this Mac before editing:

\`\`\`
$ xcrun simctl list devices | grep -E 'iPhone 17 Pro Max|Smelter'
    iPhone 17 Pro Max (493660C2-D09B-4B39-AC50-705FFD205948) (Booted)
    Smelter Release QA iPhone 17 Pro Max (EF05F833-2AC4-4383-8688-36C51B956BCF) (Booted)
\`\`\`

Also read `scripts/sim.sh`, which pins `EF05F833-2AC4-4383-8688-36C51B956BCF` and already carries a comment saying the FCADAB49 UDID is historical.

## Validation
Docs-only change to AGENTS.md. Skipped `npm ci` / `npm run typecheck` / `npm run lint` / `npm run test:ci` as agreed for a docs-only diff — no code paths touched.

## Scope
Owned only AGENTS.md, as specified in the issue. No other files touched.