### PR TITLE
Harden Advanced ordering send against rehydrated carts with unresolved units

### DIFF
--- a/app/(manager)/fulfillment-history.tsx
+++ b/app/(manager)/fulfillment-history.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Redirect, useFocusEffect, router } from 'expo-router';
+import { useShallow } from 'zustand/react/shallow';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/constants';
 import { ManagerScaleContainer } from '@/components/ManagerScaleContainer';
@@ -107,8 +108,14 @@ export default function FulfillmentHistoryRoute() {
 }
 
 function FulfillmentHistoryScreen() {
-  const { user } = useAuthStore();
-  const { pastOrders, fetchPastOrders, flushPendingPastOrderSync } = useOrderStore();
+  const user = useAuthStore((state) => state.user);
+  const { pastOrders, fetchPastOrders, flushPendingPastOrderSync } = useOrderStore(
+    useShallow((state) => ({
+      pastOrders: state.pastOrders,
+      fetchPastOrders: state.fetchPastOrders,
+      flushPendingPastOrderSync: state.flushPendingPastOrderSync,
+    })),
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [dateFilter, setDateFilter] = useState<DateFilter>('all');
   const [supplierById, setSupplierById] = useState<Record<string, SupplierLookupRow>>({});

--- a/app/(manager)/inventory.tsx
+++ b/app/(manager)/inventory.tsx
@@ -17,6 +17,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import * as Haptics from 'expo-haptics';
+import { useShallow } from 'zustand/react/shallow';
 import { useAuthStore, useInventoryStore, useOrderStore, useSettingsStore } from '@/store';
 import {
   InventoryItem,
@@ -30,6 +31,12 @@ import { useStockNetworkStatus } from '@/hooks';
 import { useManagedRefresh } from '@/hooks/useManagedRefresh';
 import { useScaledStyles } from '@/hooks/useScaledStyles';
 import { normalizeInventoryPackSize } from '@/lib/inventoryUnits';
+import {
+  ManagerInventoryRow,
+  type ManagerInventoryStatus as InventoryStatus,
+  type ManagerInventoryStockItem as InventoryStockItem,
+} from '@/features/inventory/ManagerInventoryRow';
+import { selectManagerInventoryOrderState } from '@/features/inventory/managerInventorySelectors';
 
 
 const categories = [...KNOWN_ITEM_CATEGORIES];
@@ -54,21 +61,6 @@ const REORDER_BAR_HEIGHT = 72;
 const BULK_BAR_HEIGHT = 88;
 
 const ADD_EMOJIS = ['🐟', '🥩', '🥬', '🧊', '❄️', '🍶', '🍺', '📦', '🥗', '🍜'];
-
-const STATUS_COLORS = {
-  critical: colors.error,
-  low: colors.warning,
-  good: colors.success,
-} as const;
-
-type InventoryStatus = 'critical' | 'low' | 'good';
-
-type InventoryStockItem = InventoryWithStock & {
-  status: InventoryStatus;
-  overdue: boolean;
-  fillPercent: number;
-  areaLabel: string;
-};
 
 interface AreaItemEdit {
   id: string;
@@ -105,17 +97,6 @@ const initialForm: NewItemForm = {
   pack_size: '1',
 };
 
-const getRelativeTime = (timestamp: string | null) => {
-  if (!timestamp) return 'Never updated';
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return 'Never updated';
-  const diffMs = Date.now() - date.getTime();
-  const hours = Math.round(diffMs / (1000 * 60 * 60));
-  const days = Math.round(diffMs / (1000 * 60 * 60 * 24));
-  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
-  return `${days} day${days === 1 ? '' : 's'} ago`;
-};
-
 const getStatus = (item: InventoryWithStock): InventoryStatus => {
   if (item.current_quantity <= 0) return 'critical';
   if (item.current_quantity < item.min_quantity) return 'critical';
@@ -123,14 +104,26 @@ const getStatus = (item: InventoryWithStock): InventoryStatus => {
   return 'good';
 };
 
+const getInventoryItemKey = (item: InventoryStockItem) => item.id;
+
 export default function ManagerInventoryScreen() {
   const ds = useScaledStyles();
-  const { user, locations } = useAuthStore();
-  const { addItem, fetchItems } = useInventoryStore();
-  const { addToCart, getTotalCartCount } = useOrderStore();
-  const { inventoryView, setInventoryView } = useSettingsStore();
+  const { user, locations } = useAuthStore(
+    useShallow((state) => ({ user: state.user, locations: state.locations })),
+  );
+  const { addItem, fetchItems } = useInventoryStore(
+    useShallow((state) => ({ addItem: state.addItem, fetchItems: state.fetchItems })),
+  );
+  const { addToCart, cartCount } = useOrderStore(
+    useShallow(selectManagerInventoryOrderState),
+  );
+  const { inventoryView, setInventoryView } = useSettingsStore(
+    useShallow((state) => ({
+      inventoryView: state.inventoryView,
+      setInventoryView: state.setInventoryView,
+    })),
+  );
   useStockNetworkStatus();
-  const cartCount = getTotalCartCount('manager');
 
   const headerIconSize = Math.max(44, ds.icon(40));
   const badgeSize = Math.max(18, ds.icon(20));
@@ -1304,211 +1297,36 @@ export default function ManagerInventoryScreen() {
     showToastMessage,
   ]);
 
-  const renderListItem = ({ item }: { item: InventoryStockItem }) => {
-    const statusColor = STATUS_COLORS[item.status];
-    const reorderQty = Math.max(item.max_quantity - item.current_quantity, 0);
-    const key = `${item.inventory_item.id}-${item.location.id}`;
-    const added = addedKeys[key];
-    const isSelected = !!bulkSelectedIds[item.id];
-    const relativeTime = getRelativeTime(item.last_updated_at);
+  const renderInventoryItem = useCallback(
+    ({ item }: { item: InventoryStockItem }) => {
+      const key = `${item.inventory_item.id}-${item.location.id}`;
+      return (
+        <ManagerInventoryRow
+          item={item}
+          variant={inventoryView}
+          added={Boolean(addedKeys[key])}
+          isBulkMode={isBulkMode}
+          isSelected={Boolean(bulkSelectedIds[item.id])}
+          onOpen={openEditModal}
+          onEnterBulk={enterBulkMode}
+          onToggleBulk={toggleBulkSelection}
+          onAddToReorder={handleAddToReorder}
+        />
+      );
+    },
+    [
+      addedKeys,
+      bulkSelectedIds,
+      enterBulkMode,
+      handleAddToReorder,
+      inventoryView,
+      isBulkMode,
+      openEditModal,
+      toggleBulkSelection,
+    ],
+  );
 
-    return (
-      <TouchableOpacity
-        activeOpacity={0.9}
-        style={{ marginBottom: ds.spacing(12) }}
-        onPress={() => (isBulkMode ? toggleBulkSelection(item.id) : openEditModal(item))}
-        onLongPress={() => {
-          if (!isBulkMode) enterBulkMode(item);
-        }}
-      >
-        <View
-          className="bg-white rounded-2xl border border-gray-100"
-          style={{
-            paddingHorizontal: ds.spacing(16),
-            paddingVertical: ds.spacing(14),
-            shadowColor: colors.background,
-            shadowOffset: { width: 0, height: 1 },
-            shadowOpacity: 0.05,
-            shadowRadius: 2,
-            elevation: 1,
-          }}
-        >
-          <View className="flex-row items-start justify-between">
-            <View className="flex-row items-center flex-1" style={{ paddingRight: ds.spacing(8) }}>
-              {isBulkMode && (
-                <Ionicons
-                  name={isSelected ? 'checkbox' : 'square-outline'}
-                  size={ds.icon(20)}
-                  color={isSelected ? colors.primary[500] : colors.gray[400]}
-                  style={{ marginRight: ds.spacing(8) }}
-                />
-              )}
-              <Text style={{ fontSize: ds.fontSize(18), marginRight: ds.spacing(8) }}>
-                {CATEGORY_EMOJI[item.inventory_item.category] ?? '📦'}
-              </Text>
-              <Text
-                className="font-semibold text-gray-900"
-                style={{ fontSize: ds.fontSize(15) }}
-                numberOfLines={1}
-              >
-                {item.inventory_item.name}
-              </Text>
-            </View>
-            <View
-              className="rounded-full"
-              style={{
-                width: ds.spacing(10),
-                height: ds.spacing(10),
-                backgroundColor: statusColor,
-                marginTop: ds.spacing(4),
-              }}
-            />
-          </View>
-
-          <Text
-            className="text-gray-500"
-            style={{
-              fontSize: ds.fontSize(12),
-              marginTop: ds.spacing(4),
-            }}
-          >
-            {item.areaLabel} • {item.location.name}
-          </Text>
-
-          <View style={{ marginTop: ds.spacing(12) }}>
-            <View
-              className="rounded-full bg-gray-200 overflow-hidden"
-              style={{ height: ds.spacing(6) }}
-            >
-              <View
-                className="h-full rounded-full"
-                style={{ width: `${Math.round(item.fillPercent)}%`, backgroundColor: statusColor }}
-              />
-            </View>
-            <View className="flex-row justify-between" style={{ marginTop: ds.spacing(6) }}>
-              <Text className="text-gray-600" style={{ fontSize: ds.fontSize(12) }}>
-                {item.current_quantity} {item.unit_type}
-              </Text>
-              <Text className="text-gray-500" style={{ fontSize: ds.fontSize(12) }}>
-                Min {item.min_quantity} • Max {item.max_quantity}
-              </Text>
-            </View>
-          </View>
-
-          <View
-            className="flex-row items-center justify-between"
-            style={{ marginTop: ds.spacing(10) }}
-          >
-            <Text className="text-gray-400" style={{ fontSize: ds.fontSize(11) }}>
-              {relativeTime === 'Never updated' ? relativeTime : `Updated ${relativeTime}`}
-            </Text>
-            {item.status === 'critical' && reorderQty > 0 && !isBulkMode ? (
-              <TouchableOpacity
-                className={`rounded-full border ${added ? 'border-green-500' : 'border-orange-500'}`}
-                style={{
-                  paddingHorizontal: ds.spacing(12),
-                  paddingVertical: ds.spacing(6),
-                  minHeight: Math.max(32, ds.icon(28)),
-                  justifyContent: 'center',
-                }}
-                onPress={(event) => {
-                  event.stopPropagation?.();
-                  handleAddToReorder(item);
-                }}
-              >
-                <Text
-                  className={`font-semibold ${added ? 'text-green-600' : 'text-orange-600'}`}
-                  style={{ fontSize: ds.fontSize(12) }}
-                >
-                  {added ? '✓ Added' : `Reorder ${reorderQty}`}
-                </Text>
-              </TouchableOpacity>
-            ) : null}
-          </View>
-        </View>
-      </TouchableOpacity>
-    );
-  };
-
-  const renderCompactItem = ({ item }: { item: InventoryStockItem }) => {
-    const statusColor = STATUS_COLORS[item.status];
-    const reorderQty = Math.max(item.max_quantity - item.current_quantity, 0);
-    const key = `${item.inventory_item.id}-${item.location.id}`;
-    const added = addedKeys[key];
-    const isSelected = !!bulkSelectedIds[item.id];
-
-    return (
-      <TouchableOpacity
-        activeOpacity={0.9}
-        className="bg-white border border-gray-100 rounded-2xl overflow-hidden"
-        style={{ marginBottom: ds.spacing(8) }}
-        onPress={() => (isBulkMode ? toggleBulkSelection(item.id) : openEditModal(item))}
-        onLongPress={() => {
-          if (!isBulkMode) enterBulkMode(item);
-        }}
-      >
-        <View
-          className="flex-row items-center"
-          style={{
-            paddingHorizontal: ds.spacing(16),
-            paddingVertical: ds.spacing(12),
-          }}
-        >
-          {isBulkMode && (
-            <Ionicons
-              name={isSelected ? 'checkbox' : 'square-outline'}
-              size={ds.icon(18)}
-              color={isSelected ? colors.primary[500] : colors.gray[400]}
-              style={{ marginRight: ds.spacing(8) }}
-            />
-          )}
-          <Text style={{ fontSize: ds.fontSize(18), marginRight: ds.spacing(8) }}>
-            {CATEGORY_EMOJI[item.inventory_item.category] ?? '📦'}
-          </Text>
-          <View className="flex-1">
-            <Text
-              className="font-semibold text-gray-900"
-              style={{ fontSize: ds.fontSize(14) }}
-              numberOfLines={1}
-            >
-              {item.inventory_item.name}
-            </Text>
-            <Text className="text-gray-500" style={{ fontSize: ds.fontSize(12) }}>
-              {item.current_quantity} / {item.max_quantity} {item.unit_type}
-            </Text>
-          </View>
-          <View className="flex-row items-center">
-            <View
-              className="rounded-full"
-              style={{
-                width: ds.spacing(10),
-                height: ds.spacing(10),
-                backgroundColor: statusColor,
-                marginRight: ds.spacing(8),
-              }}
-            />
-            {item.status === 'critical' && reorderQty > 0 && !isBulkMode ? (
-              <TouchableOpacity
-                className={`rounded-full items-center justify-center border ${added ? 'border-green-500' : 'border-orange-500'}`}
-                style={{
-                  width: Math.max(36, ds.icon(32)),
-                  height: Math.max(36, ds.icon(32)),
-                }}
-                onPress={(event) => {
-                  event.stopPropagation?.();
-                  handleAddToReorder(item);
-                }}
-              >
-                <Ionicons name={added ? 'checkmark' : 'add'} size={ds.icon(16)} color={added ? colors.success : colors.primary[500]} />
-              </TouchableOpacity>
-            ) : null}
-          </View>
-        </View>
-      </TouchableOpacity>
-    );
-  };
-
-  const renderEmptyState = () => {
+  const renderEmptyState = useCallback(() => {
     let icon = '🎉';
     let title = 'All items are well stocked!';
     let subtitle = 'No items need reordering at this time.';
@@ -1544,7 +1362,44 @@ export default function ManagerInventoryScreen() {
         </Text>
       </View>
     );
-  };
+  }, [categoryFilter, debouncedQuery, ds, selectedStat]);
+
+  const renderListEmpty = useCallback(
+    () =>
+      isStockLoading ? (
+        <View className="items-center justify-center" style={{ paddingVertical: ds.spacing(48) }}>
+          <Text className="text-gray-400" style={{ fontSize: ds.fontSize(14) }}>
+            Loading inventory...
+          </Text>
+        </View>
+      ) : (
+        renderEmptyState()
+      ),
+    [ds, isStockLoading, renderEmptyState],
+  );
+
+  const inventoryListContentStyle = useMemo(
+    () => ({
+      paddingHorizontal: ds.spacing(16),
+      paddingBottom: isBulkMode
+        ? BULK_BAR_HEIGHT + ds.spacing(16)
+        : stats.reorder > 0
+          ? REORDER_BAR_HEIGHT + ds.spacing(16)
+          : ds.spacing(24),
+    }),
+    [ds, isBulkMode, stats.reorder],
+  );
+
+  const inventoryRefreshControl = useMemo(
+    () => (
+      <RefreshControl
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        tintColor={colors.primary[500]}
+      />
+    ),
+    [onRefresh, refreshing],
+  );
 
   const bulkItemCount = parseBulkInput().length;
 
@@ -1873,28 +1728,11 @@ export default function ManagerInventoryScreen() {
 
         <FlatList
           data={sortedItems}
-          renderItem={inventoryView === 'list' ? renderListItem : renderCompactItem}
-          keyExtractor={(item) => item.id}
-          contentContainerStyle={{
-            paddingHorizontal: ds.spacing(16),
-            paddingBottom: isBulkMode
-              ? BULK_BAR_HEIGHT + ds.spacing(16)
-              : stats.reorder > 0
-                ? REORDER_BAR_HEIGHT + ds.spacing(16)
-                : ds.spacing(24),
-          }}
-          ListEmptyComponent={() => (isStockLoading ? (
-            <View className="items-center justify-center" style={{ paddingVertical: ds.spacing(48) }}>
-              <Text className="text-gray-400" style={{ fontSize: ds.fontSize(14) }}>Loading inventory...</Text>
-            </View>
-          ) : renderEmptyState())}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={onRefresh}
-              tintColor={colors.primary[500]}
-            />
-          }
+          renderItem={renderInventoryItem}
+          keyExtractor={getInventoryItemKey}
+          contentContainerStyle={inventoryListContentStyle}
+          ListEmptyComponent={renderListEmpty}
+          refreshControl={inventoryRefreshControl}
         />
 
         {!isBulkMode && stats.reorder > 0 && (

--- a/app/(tabs)/draft.tsx
+++ b/app/(tabs)/draft.tsx
@@ -9,6 +9,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { Redirect, router } from 'expo-router';
+import { useShallow } from 'zustand/react/shallow';
 import {
   triggerImpactHaptic,
   triggerNotificationHaptic,
@@ -53,20 +54,46 @@ export default function DraftRoute() {
 
 function DraftScreen() {
   const ds = useScaledStyles();
-  const { locations } = useAuthStore();
+  const locations = useAuthStore((state) => state.locations);
   const {
-    getItems,
+    itemsByLocation,
     updateItem,
     removeItem,
     clearLocationDraft,
     clearAllDrafts,
-    getTotalItemCount,
-    getAllLocationIds,
-  } = useDraftStore();
-  const { addToCart } = useOrderStore();
+  } = useDraftStore(
+    useShallow((state) => ({
+      itemsByLocation: state.itemsByLocation,
+      updateItem: state.updateItem,
+      removeItem: state.removeItem,
+      clearLocationDraft: state.clearLocationDraft,
+      clearAllDrafts: state.clearAllDrafts,
+    })),
+  );
+  const addToCart = useOrderStore((state) => state.addToCart);
 
-  const totalItemCount = getTotalItemCount();
-  const locationIdsWithItems = getAllLocationIds();
+  const totalItemCount = useMemo(
+    () =>
+      Object.values(itemsByLocation).reduce(
+        (total, items) => total + Object.keys(items).length,
+        0,
+      ),
+    [itemsByLocation],
+  );
+  const locationIdsWithItems = useMemo(
+    () =>
+      Object.keys(itemsByLocation).filter(
+        (locationId) => Object.keys(itemsByLocation[locationId]).length > 0,
+      ),
+    [itemsByLocation],
+  );
+  const getItems = useCallback(
+    (locationId: string) =>
+      Object.values(itemsByLocation[locationId] ?? {}).sort(
+        (left, right) => right.addedAt - left.addedAt,
+      ),
+    [itemsByLocation],
+  );
 
   // Get locations that have items
   const locationsWithItems = useMemo(() => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   LogBox,
   View,
@@ -10,6 +10,7 @@ import {
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { useShallow } from "zustand/react/shallow";
 import { useAuthStore, useDisplayStore } from "@/store";
 import { useInventorySubscription, useOrderSubscription } from "@/hooks";
 import { supabase, supabaseConfigError } from "@/lib/supabase";
@@ -53,7 +54,13 @@ function ThemeManager() {
 }
 
 export default function RootLayout() {
-  const { initialize, isInitialized, session } = useAuthStore();
+  const { initialize, isInitialized, session } = useAuthStore(
+    useShallow((state) => ({
+      initialize: state.initialize,
+      isInitialized: state.isInitialized,
+      session: state.session,
+    })),
+  );
   const theme = useDisplayStore((state) => state.theme);
   const reduceMotion = useDisplayStore((state) => state.reduceMotion);
 

--- a/app/orders/[id].tsx
+++ b/app/orders/[id].tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, router, Stack } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
+import { useShallow } from 'zustand/react/shallow';
 import { useOrderStore, useAuthStore } from '@/store';
 import { OrderItemWithInventory } from '@/types';
 import { statusColors, ORDER_STATUS_LABELS, getCategoryLabel, categoryColors, colors } from '@/constants';
@@ -25,7 +26,9 @@ export default function OrderDetailScreen() {
   const ds = useScaledStyles();
   const params = useLocalSearchParams<{ id?: string | string[] }>();
   const orderId = Array.isArray(params.id) ? params.id[0] : params.id;
-  const { user, viewMode } = useAuthStore();
+  const { user, viewMode } = useAuthStore(
+    useShallow((state) => ({ user: state.user, viewMode: state.viewMode })),
+  );
   const {
     currentOrder,
     fetchOrder,
@@ -33,7 +36,16 @@ export default function OrderDetailScreen() {
     updateOrderStatus,
     cancelOrder,
     isLoading,
-  } = useOrderStore();
+  } = useOrderStore(
+    useShallow((state) => ({
+      currentOrder: state.currentOrder,
+      fetchOrder: state.fetchOrder,
+      submitOrder: state.submitOrder,
+      updateOrderStatus: state.updateOrderStatus,
+      cancelOrder: state.cancelOrder,
+      isLoading: state.isLoading,
+    })),
+  );
   const [isUpdating, setIsUpdating] = useState(false);
   const [fulfilledByUser, setFulfilledByUser] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);

--- a/app/orders/history.tsx
+++ b/app/orders/history.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect, router, type Href, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { RealtimeChannel } from '@supabase/supabase-js';
+import { useShallow } from 'zustand/react/shallow';
 import { useOrderStore, useAuthStore } from '@/store';
 import { supabase } from '@/lib/supabase';
 import { OrderWithDetails, OrderStatus } from '@/types';
@@ -118,8 +119,13 @@ function OrderListCard({ order }: { order: OrderWithDetails }) {
 export default function OrdersScreen() {
   const ds = useScaledStyles();
   const params = useLocalSearchParams<{ backTo?: string | string[] }>();
-  const { user } = useAuthStore();
-  const { orders, fetchUserOrders } = useOrderStore();
+  const user = useAuthStore((state) => state.user);
+  const { orders, fetchUserOrders } = useOrderStore(
+    useShallow((state) => ({
+      orders: state.orders,
+      fetchUserOrders: state.fetchUserOrders,
+    })),
+  );
   const [selectedStatus, setSelectedStatus] = useState<OrderStatus | null>(null);
   const realtimeChannelRef = useRef<RealtimeChannel | null>(null);
   const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/docs/performance-2026-09-07.md
+++ b/docs/performance-2026-09-07.md
@@ -13,7 +13,7 @@ Ten targeted changes to reduce repeated requests, allocations, and React renders
 1. Cache cart normalization by immutable input and location.
 2. Share concurrent inventory loads and retain forced follow-up refreshes.
 3. Reuse the known session user ID during module bootstrap.
-4. Batch and paginate stock-area item reads.
+4. Skip serialization and storage writes when persisted inventory data has not changed.
 5. Share concurrent location catalog loads.
 6. Update the Quick Order scrollbar with Reanimated shared values.
 7. Stabilize `useScaledStyles` and its subscriptions.
@@ -49,7 +49,29 @@ Measured with `node scripts/measure-performance-work.cjs`. The script loads the 
 
 Search ranking and result limits also match the baseline. These are counts of avoided work, not production frame-rate or latency measurements.
 
-Integrated checks and remaining request/render measurements are pending.
+| Integrated command | Result |
+| --- | --- |
+| `npm run typecheck` | Passed. |
+| `npm run lint` | Passed, zero warnings allowed. |
+| `npm run test:ci` | Passed: 74 suites, 1,082 tests. One existing suite/test skipped. |
+| `node scripts/measure-performance-work.cjs` | Passed baseline equivalence and work-count assertions. |
+| `git diff --check` | Passed. |
+| `scripts/sim.sh assert` | Passed for the pinned Smelter QA device. |
+| `scripts/sim.sh io screenshot /private/tmp/smelter-perf-final.png` | Passed; final app welcome screen visually inspected. |
+
+The root-layout regression test was also run against actual baseline source. A location-catalog update produced two total navigation renders before the change and one afterward. The updated test verifies that sign-in still mounts subscriptions and sign-out cleans them up. Request tests cover coalescing, forced follow-up refreshes, and account transitions. Persistence tests cover failed writes, retries, hydration, and conflicting pending writes.
+
+The integrated Release build passed with compiler/bundler warnings using XcodeBuildMCP, which ran:
+
+```sh
+/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -workspace /private/tmp/smelter-performance/ios/Babytuna.xcworkspace -scheme Babytuna -configuration Release -skipMacroValidation -destination "platform=iOS Simulator,id=EF05F833-2AC4-4383-8688-36C51B956BCF" -collect-test-diagnostics never -derivedDataPath /private/tmp/smelter-performance/ios/build build
+```
+
+Artifact: `/private/tmp/smelter-performance/ios/build/Build/Products/Release-iphonesimulator/Babytuna.app`.
+
+The app was installed and launched through `scripts/sim.sh` on Smelter QA, then left running for testing. The final JavaScript bundle SHA-256 is `f7809114ece330d0155ea02bff786256a181c47dc5d24b68c25b2c8ce434b33d`. OTA updates were disabled only in this generated simulator artifact, which was ad hoc signed and verified, so a cached update cannot replace the branch under test. No tracked native configuration changed. No Metro or background test runner remains.
+
+There was no signed-in simulator session. Authenticated inventory, ordering, and account-switch flows remain manual validation items; no device latency or frame-rate improvement is claimed. The live recognition audit remains blocked as described above. An additional independent relaunch was rejected by automatic approval review because it would interrupt the running app. Read-only screenshot, artifact hash, plist, and code-signature checks succeeded instead.
 
 ## Test before merging
 
@@ -59,7 +81,7 @@ Use the Release simulator build from this worktree and sign in with an existing 
 - Type name and alias searches. Confirm the same results and prefix ranking, then change location and search again.
 - Open manager inventory in both list and compact views. Check row actions, bulk selection, reorder feedback, and search.
 - In Quick Order, create enough local lines to scroll the order card. Check the scrollbar, edit/remove actions, and Dynamic Type.
-- Open a stock location with several areas. Check every area's items and refresh after a count changes. Verify offline counts still restore.
+- Refresh inventory, go offline, and reopen it. Confirm cached inventory still restores and new inventory edits still persist.
 - Change display settings, switch employee/manager views, and sign out and back in. Confirm styles update and no prior account's inventory or locations appear.
 
 Do not send real supplier orders or change production stock solely for this test.

--- a/docs/performance-2026-09-07.md
+++ b/docs/performance-2026-09-07.md
@@ -40,7 +40,16 @@ Baseline Release build and launch passed on the repo's pinned Smelter QA simulat
 
 ## Final measurements and checks
 
-Pending integrated verification. Operation and render counts will be reported separately from native timings. Unit tests with synthetic catalog fixtures do not establish production frame-rate or latency improvements.
+Measured with `node scripts/measure-performance-work.cjs`. The script loads the actual baseline helpers from Git and compares them with the worktree, including output equivalence checks.
+
+| Synthetic workload | Baseline | Updated |
+| --- | --- | --- |
+| 1,000 catalog items, 20 full-scan searches | 20,000 name reads and 20,000 alias reads | 1,000 of each, including index construction |
+| 200 cart lines, 100 reads without changing the cart | 100 arrays and 20,000 distinct item objects | One array and 200 distinct item objects |
+
+Search ranking and result limits also match the baseline. These are counts of avoided work, not production frame-rate or latency measurements.
+
+Integrated checks and remaining request/render measurements are pending.
 
 ## Test before merging
 

--- a/docs/performance-2026-09-07.md
+++ b/docs/performance-2026-09-07.md
@@ -1,0 +1,60 @@
+# App performance validation
+
+Worktree: `/private/tmp/smelter-performance`
+
+Branch: `perf/ten-high-impact-improvements`
+
+Base: `550f25092594de73cf8522f5f576f033ebfd9258`, the fetched `origin/main` when this work started. The main checkout was 47 commits behind and was left untouched.
+
+## Scope
+
+Ten targeted changes to reduce repeated requests, allocations, and React renders. Screen appearance, ordering rules, authorization, and persistence formats stay the same. No production dependencies, migrations, deployments, or remote database writes are part of this PR.
+
+1. Cache cart normalization by immutable input and location.
+2. Share concurrent inventory loads and retain forced follow-up refreshes.
+3. Reuse the known session user ID during module bootstrap.
+4. Batch and paginate stock-area item reads.
+5. Share concurrent location catalog loads.
+6. Update the Quick Order scrollbar with Reanimated shared values.
+7. Stabilize `useScaledStyles` and its subscriptions.
+8. Memoize manager inventory rows with stable callbacks.
+9. Narrow broad store subscriptions in navigation and frequently used screens.
+10. Prepare catalog search text when the catalog changes.
+
+## Baseline
+
+Executed in the worktree before implementation:
+
+| Command | Result |
+| --- | --- |
+| `npm ci --offline --ignore-scripts --no-audit --no-fund` | Passed, 1,121 packages installed. |
+| `npm run typecheck` | Passed. |
+| `npm run lint` | Passed, zero warnings allowed. |
+| `npm run test:ci` | Passed, 69 suites and 1,051 tests. One existing suite/test skipped. |
+| `npm run verify:submit-order-rpc` | Passed after copying the existing ignored public app configuration and allowing network access. The unauthenticated probe resolved the eight-parameter RPC and received its expected authorization denial. This does not test submission. |
+| `npm run audit:quick-order-recognition` | Blocked. No inventory rows are visible to the configured public key. Empty results do not count as a passing recognition audit. |
+
+Initial live-check attempts without configuration failed. Sandboxed attempts with configuration failed to reach the network. The table records the later network-enabled outcomes.
+
+Baseline Release build and launch passed on the repo's pinned Smelter QA simulator, `EF05F833-2AC4-4383-8688-36C51B956BCF`, iOS 26.2. Welcome and sign-in screens were inspected. No credentials were entered.
+
+## Final measurements and checks
+
+Pending integrated verification. Operation and render counts will be reported separately from native timings. Unit tests with synthetic catalog fixtures do not establish production frame-rate or latency improvements.
+
+## Test before merging
+
+Use the Release simulator build from this worktree and sign in with an existing test account.
+
+- Open inventory, browse, and cart. Add an item, change its quantity, move it between locations, and verify cart badges and totals update.
+- Type name and alias searches. Confirm the same results and prefix ranking, then change location and search again.
+- Open manager inventory in both list and compact views. Check row actions, bulk selection, reorder feedback, and search.
+- In Quick Order, create enough local lines to scroll the order card. Check the scrollbar, edit/remove actions, and Dynamic Type.
+- Open a stock location with several areas. Check every area's items and refresh after a count changes. Verify offline counts still restore.
+- Change display settings, switch employee/manager views, and sign out and back in. Confirm styles update and no prior account's inventory or locations appear.
+
+Do not send real supplier orders or change production stock solely for this test.
+
+## References used during review
+
+React Native documents the interaction between stable list callbacks and memoized rows in [Optimizing FlatList configuration](https://reactnative.dev/docs/optimizing-flatlist-configuration). React documents the limits of prop comparison in [memo](https://react.dev/reference/react/memo).

--- a/scripts/measure-performance-work.cjs
+++ b/scripts/measure-performance-work.cjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global __dirname */
 
 // Deterministic work counts on synthetic fixtures, not device timing claims.
 const assert = require('node:assert/strict');

--- a/scripts/measure-performance-work.cjs
+++ b/scripts/measure-performance-work.cjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+// Deterministic work counts on synthetic fixtures, not device timing claims.
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+
+const baseline = process.argv[2] || '550f25092594de73cf8522f5f576f033ebfd9258';
+const root = path.resolve(__dirname, '..');
+
+function loadPureModule(relativePath, revision, modules = new Map()) {
+  if (modules.has(relativePath)) return modules.get(relativePath);
+  const source = revision
+    ? execFileSync('git', ['show', `${revision}:${relativePath}`], {
+        cwd: root,
+        encoding: 'utf8',
+      })
+    : fs.readFileSync(path.join(root, relativePath), 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    fileName: relativePath,
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  });
+  const loaded = { exports: {} };
+  const requireRelative = (specifier) => {
+    assert.ok(specifier.startsWith('.'), 'Measurement modules must stay pure and local');
+    const dependency = path.posix.normalize(
+      path.posix.join(path.posix.dirname(relativePath), `${specifier}.ts`),
+    );
+    return loadPureModule(dependency, revision, modules);
+  };
+  new Function('require', 'module', 'exports', outputText)(
+    requireRelative, loaded, loaded.exports,
+  );
+  modules.set(relativePath, loaded.exports);
+  return loaded.exports;
+}
+
+function catalogWork(api, indexed) {
+  let nameReads = 0;
+  let aliasReads = 0;
+  const items = Array.from({ length: 1000 }, (_, index) => ({
+    id: `synthetic-${index}`,
+    get name() { nameReads += 1; return `Ingredient ${index}`; },
+    get aliases() { aliasReads += 1; return [`Alias ${index}`]; },
+  }));
+  const searchIndex = indexed ? api.buildCatalogSearchIndex(items) : null;
+  const results = Array.from({ length: 20 }, (_, index) => {
+    const query = `absent-query-${index}`;
+    const matches = indexed
+      ? api.filterCatalogSearchIndex(searchIndex, query)
+      : api.filterCatalogItems(items, query);
+    return matches.map((item) => item.id);
+  });
+  return { nameReads, aliasReads, results };
+}
+
+function cartWork(api) {
+  const items = Array.from({ length: 200 }, (_, index) => ({
+    id: `synthetic-cart-${index}`,
+    inventoryItemId: `synthetic-${index}`,
+    unitType: 'pack',
+    inputMode: 'quantity',
+    quantity: 1,
+    quantityRequested: 1,
+    remainingReported: null,
+    decidedQuantity: null,
+    decidedBy: null,
+    decidedAt: null,
+    note: null,
+    wasSuggested: false,
+    originalSuggestedQty: null,
+  }));
+  const carts = { fixture: items };
+  const arrays = new Set();
+  const objects = new Set();
+  let finalCart;
+  for (let count = 0; count < 100; count += 1) {
+    finalCart = api.getLocationCart(carts, 'fixture');
+    arrays.add(finalCart);
+    finalCart.forEach((item) => objects.add(item));
+  }
+  return { arrays: arrays.size, itemObjects: objects.size, finalCart };
+}
+
+const catalogPath = 'src/features/simpleOrder/catalogSearch.ts';
+const cartPath = 'src/store/helpers/cartHelpers.ts';
+const oldCatalog = loadPureModule(catalogPath, baseline);
+const newCatalog = loadPureModule(catalogPath, null);
+const oldSearch = catalogWork(oldCatalog, false);
+const newSearch = catalogWork(newCatalog, true);
+assert.deepEqual(newSearch.results, oldSearch.results);
+assert.ok(newSearch.nameReads < oldSearch.nameReads);
+assert.ok(newSearch.aliasReads < oldSearch.aliasReads);
+
+// Compare ranked results as well as the deliberately full-scan workload.
+const rankingFixture = [
+  { id: 'substring', name: 'Fresh salmon', aliases: [] },
+  { id: 'alias', name: 'Fish', aliases: ['salmon'] },
+  { id: 'prefix', name: 'Salmon fillet', aliases: [] },
+];
+for (const query of ['', ' salmon ', 'fresh', 'fillet', 'fish', 'missing']) {
+  for (const limit of [0, 1, 2, 30]) {
+    const before = oldCatalog.filterCatalogItems(rankingFixture, query, limit);
+    const after = newCatalog.filterCatalogSearchIndex(
+      newCatalog.buildCatalogSearchIndex(rankingFixture), query, limit,
+    );
+    assert.deepEqual(after, before);
+  }
+}
+
+const oldCart = cartWork(loadPureModule(cartPath, baseline));
+const newCart = cartWork(loadPureModule(cartPath, null));
+assert.deepEqual(newCart.finalCart, oldCart.finalCart);
+assert.equal(newCart.arrays, 1);
+assert.equal(newCart.itemObjects, 200);
+
+console.log(JSON.stringify({
+  baseline,
+  catalog: {
+    workload: '1,000 synthetic items, 20 full-scan queries, index build included',
+    before: { nameReads: oldSearch.nameReads, aliasReads: oldSearch.aliasReads },
+    after: { nameReads: newSearch.nameReads, aliasReads: newSearch.aliasReads },
+    resultEquivalence: 'passed, including ranked and limited results',
+  },
+  cart: {
+    workload: '200 synthetic cart lines, 100 reads of unchanged cart',
+    before: { arrays: oldCart.arrays, itemObjects: oldCart.itemObjects },
+    after: { arrays: newCart.arrays, itemObjects: newCart.itemObjects },
+    resultEquivalence: 'passed',
+  },
+}, null, 2));

--- a/src/__tests__/authStore.signOut.test.ts
+++ b/src/__tests__/authStore.signOut.test.ts
@@ -19,8 +19,15 @@ const refreshSessionMock = jest.fn();
 const onAuthStateChangeMock = jest.fn();
 const removeChannelMock = jest.fn();
 
+type MockLocationRow = { id: string; name: string; short_code?: string };
+
 const invalidatePendingOrderRequestsMock = jest.fn();
+const invalidatePendingInventoryRequestsMock = jest.fn();
 const invalidatePendingStockRequestsMock = jest.fn();
+const locationsResponseMock = jest.fn<
+  Promise<{ data: MockLocationRow[] }>,
+  []
+>(async () => ({ data: [] }));
 
 const orderStoreMock = {
   getInitialState: jest.fn(() => ({})),
@@ -56,7 +63,7 @@ const tunaSpecialistStoreMock = {
 function createLocationsQuery() {
   return {
     eq: jest.fn(() => ({
-      order: jest.fn(async () => ({ data: [] })),
+      order: locationsResponseMock,
     })),
   };
 }
@@ -104,7 +111,10 @@ jest.mock('@/lib/supabase', () => ({
 
 jest.mock('../store/orderStore', () => ({ useOrderStore: orderStoreMock, invalidatePendingOrderRequests: invalidatePendingOrderRequestsMock }));
 jest.mock('../store/draftStore', () => ({ useDraftStore: draftStoreMock }));
-jest.mock('../store/inventoryStore', () => ({ useInventoryStore: inventoryStoreMock }));
+jest.mock('../store/inventoryStore', () => ({
+  useInventoryStore: inventoryStoreMock,
+  invalidatePendingInventoryRequests: invalidatePendingInventoryRequestsMock,
+}));
 jest.mock('../store/stockStore', () => ({ useStockStore: stockStoreMock, invalidatePendingStockRequests: invalidatePendingStockRequestsMock }));
 jest.mock('../store/fulfillmentStore', () => ({ useFulfillmentStore: fulfillmentStoreMock }));
 jest.mock('../store/tunaSpecialistStore', () => ({ useTunaSpecialistStore: tunaSpecialistStoreMock }));
@@ -121,6 +131,14 @@ async function flushMicrotasks(iterations = 8) {
   for (let index = 0; index < iterations; index += 1) {
     await Promise.resolve();
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 describe('useAuthStore sign-out flow', () => {
@@ -142,6 +160,7 @@ describe('useAuthStore sign-out flow', () => {
     getSessionMock.mockResolvedValue({ data: { session: null } });
     setSessionMock.mockResolvedValue({ data: { session: null }, error: null });
     refreshSessionMock.mockResolvedValue({ data: { session: null }, error: null });
+    locationsResponseMock.mockResolvedValue({ data: [] });
     onAuthStateChangeMock.mockImplementation((callback: (event: string, session: any) => void) => {
       authChangeCallback = callback;
       return {
@@ -160,6 +179,50 @@ describe('useAuthStore sign-out flow', () => {
     consoleWarnSpy.mockRestore();
     consoleErrorSpy.mockRestore();
     jest.useRealTimers();
+  });
+
+  test('shares one location request across concurrent callers', async () => {
+    const response = deferred<{ data: { id: string; name: string }[] }>();
+    locationsResponseMock.mockReturnValueOnce(response.promise);
+
+    const first = useAuthStore.getState().fetchLocations();
+    const second = useAuthStore.getState().fetchLocations();
+    await Promise.resolve();
+    expect(locationsResponseMock).toHaveBeenCalledTimes(1);
+
+    response.resolve({ data: [{ id: 'location-1', name: 'Sushi' }] });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      [{ id: 'location-1', name: 'Sushi' }],
+      [{ id: 'location-1', name: 'Sushi' }],
+    ]);
+  });
+
+  test('does not join or publish a location request from before sign-out', async () => {
+    const oldResponse = deferred<{ data: MockLocationRow[] }>();
+    const newResponse = deferred<{ data: MockLocationRow[] }>();
+    locationsResponseMock
+      .mockReturnValueOnce(oldResponse.promise)
+      .mockReturnValueOnce(newResponse.promise);
+    useAuthStore.setState({
+      session: { user: { id: 'old-user' } } as any,
+    });
+
+    const oldLoad = useAuthStore.getState().fetchLocations();
+    await Promise.resolve();
+    const signingOut = useAuthStore.getState().signOut();
+    const newLoad = useAuthStore.getState().fetchLocations();
+    await Promise.resolve();
+
+    expect(locationsResponseMock).toHaveBeenCalledTimes(2);
+    newResponse.resolve({ data: [{ id: 'new-location', name: 'Poki' }] });
+    await newLoad;
+    oldResponse.resolve({ data: [{ id: 'old-location', name: 'Sushi' }] });
+    await expect(oldLoad).resolves.toEqual([]);
+    await signingOut;
+
+    expect(useAuthStore.getState().locations).toEqual([
+      { id: 'new-location', name: 'Poki' },
+    ]);
   });
 
   test('clears local auth state and resolves even if Supabase signOut never resolves', async () => {
@@ -206,9 +269,12 @@ describe('useAuthStore sign-out flow', () => {
     expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('babytuna-auth');
     expect(mockAsyncStorage.multiRemove).toHaveBeenCalled();
     expect(invalidatePendingOrderRequestsMock).toHaveBeenCalledTimes(1);
+    expect(invalidatePendingInventoryRequestsMock).toHaveBeenCalledTimes(1);
     expect(invalidatePendingStockRequestsMock).toHaveBeenCalledTimes(1);
     expect(invalidatePendingOrderRequestsMock.mock.invocationCallOrder[0])
       .toBeLessThan(orderStoreMock.setState.mock.invocationCallOrder[0]);
+    expect(invalidatePendingInventoryRequestsMock.mock.invocationCallOrder[0])
+      .toBeLessThan(inventoryStoreMock.setState.mock.invocationCallOrder[0]);
     expect(invalidatePendingStockRequestsMock.mock.invocationCallOrder[0])
       .toBeLessThan(stockStoreMock.setState.mock.invocationCallOrder[0]);
     expect(clearSupabaseStoredSessionMock).toHaveBeenCalledTimes(1);

--- a/src/__tests__/cartHelpers.test.ts
+++ b/src/__tests__/cartHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   isSubmittableCartItem,
   normalizeCartItem,
   normalizeLocationCart,
+  getLocationCart,
   normalizeCartByLocation,
   normalizeCartContext,
   mergeCartItem,
@@ -249,6 +250,69 @@ describe('normalizeLocationCart', () => {
     expect(result).toHaveLength(2);
     expect(result[0].inventoryItemId).toBe('abc');
     expect(result[1].inventoryItemId).toBe('def');
+  });
+});
+
+describe('getLocationCart', () => {
+  test('normalizes each cart reference once and reuses the safe result', () => {
+    const cart = [
+      makeCartItem({ id: 'cart-1', inventoryItemId: 'item-1' }),
+      makeCartItem({ id: 'cart-2', inventoryItemId: 'item-2' }),
+    ];
+    const cartByLocation = { 'location-1': cart };
+
+    const first = getLocationCart(cartByLocation, 'location-1');
+    const second = getLocationCart(cartByLocation, 'location-1');
+
+    expect(first).not.toBe(cart);
+    expect(second).toBe(first);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first[0])).toBe(true);
+    expect(first).toEqual(cart);
+  });
+
+  test('keeps location-specific legacy IDs when one raw cart is reused', () => {
+    const sharedLegacyCart = [
+      { inventoryItemId: 'item-1', quantity: 2 },
+    ] as unknown as CartItem[];
+
+    const firstLocation = getLocationCart(
+      { 'location-a': sharedLegacyCart },
+      'location-a',
+    );
+    const secondLocation = getLocationCart(
+      { 'location-b': sharedLegacyCart },
+      'location-b',
+    );
+
+    expect(firstLocation[0].id).toContain('location-a');
+    expect(secondLocation[0].id).toContain('location-b');
+    expect(firstLocation[0].id).not.toBe(secondLocation[0].id);
+  });
+
+  test('keeps legacy validation when reading a new cart reference', () => {
+    const legacyCart = [
+      { inventoryItemId: 'valid', quantity: 2 },
+      { inventoryItemId: '', quantity: 4 },
+      { inventoryItemId: 'zero', quantity: 0 },
+    ] as unknown as CartItem[];
+
+    const result = getLocationCart({ location: legacyCart }, 'location');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      inventoryItemId: 'valid',
+      inputMode: 'quantity',
+      quantityRequested: 2,
+    });
+  });
+
+  test('returns the same stable empty cart for a missing location', () => {
+    const first = getLocationCart({}, 'missing-1');
+    const second = getLocationCart({}, 'missing-2');
+
+    expect(first).toBe(second);
+    expect(first).toEqual([]);
   });
 });
 

--- a/src/__tests__/equalityGatedJSONStorage.test.ts
+++ b/src/__tests__/equalityGatedJSONStorage.test.ts
@@ -10,10 +10,31 @@ interface PersistedState {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
+}
+
+function lastWrittenItems(
+  setItemMock: jest.Mock<Promise<void>, [string, string]>,
+): PersistedState['items'] {
+  const lastCall = setItemMock.mock.calls[setItemMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('Expected at least one native write.');
+  const parsed: unknown = JSON.parse(lastCall[1]);
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('state' in parsed) ||
+    typeof parsed.state !== 'object' ||
+    parsed.state === null ||
+    !('items' in parsed.state)
+  ) {
+    throw new Error('Unexpected persisted payload shape.');
+  }
+  return parsed.state.items as PersistedState['items'];
 }
 
 function setupStorage(initialValue: string | null = null) {
@@ -100,9 +121,86 @@ describe('createEqualityGatedJSONStorage', () => {
       state: { items: itemsA, isLoading: true, error: null },
     });
 
-    expect(rawStorage.setItem).toHaveBeenCalledTimes(3);
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
     pendingWrite.resolve();
     await Promise.all([writeB, writeA]);
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(3);
+    expect(lastWrittenItems(setItemMock)).toEqual(itemsA);
+  });
+
+  test('the newest value is on disk when the older write settles last', async () => {
+    // Regression for PR #75 P1: without serialized writes, an older write that
+    // completed after a newer one left stale inventory as the final value.
+    const { rawStorage, setItemMock, storage } = setupStorage();
+    const itemsOld = [{ id: 'item-old' }];
+    const itemsNew = [{ id: 'item-new' }];
+    const oldWrite = deferred<void>();
+    setItemMock.mockReturnValueOnce(oldWrite.promise);
+
+    const writeOld = storage.setItem('inventory', {
+      state: { items: itemsOld, isLoading: false, error: null },
+    });
+    const writeNew = storage.setItem('inventory', {
+      state: { items: itemsNew, isLoading: false, error: null },
+    });
+
+    // The newer write waits for the older one instead of racing it.
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(1);
+    oldWrite.resolve();
+    await Promise.all([writeOld, writeNew]);
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+    expect(lastWrittenItems(setItemMock)).toEqual(itemsNew);
+
+    // Nothing further is written for the value already on disk.
+    await storage.setItem('inventory', {
+      state: { items: itemsNew, isLoading: true, error: null },
+    });
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  test('coalesces values requested behind an in-flight write into one write', async () => {
+    const { rawStorage, setItemMock, storage } = setupStorage();
+    const first = deferred<void>();
+    setItemMock.mockReturnValueOnce(first.promise);
+    const itemsC = [{ id: 'item-c' }];
+
+    const writeA = storage.setItem('inventory', {
+      state: { items: [{ id: 'item-a' }], isLoading: false, error: null },
+    });
+    const writeB = storage.setItem('inventory', {
+      state: { items: [{ id: 'item-b' }], isLoading: false, error: null },
+    });
+    const writeC = storage.setItem('inventory', {
+      state: { items: itemsC, isLoading: false, error: null },
+    });
+
+    first.resolve();
+    await Promise.all([writeA, writeB, writeC]);
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+    expect(lastWrittenItems(setItemMock)).toEqual(itemsC);
+  });
+
+  test('a queued write still runs after the in-flight write fails', async () => {
+    const { rawStorage, setItemMock, storage } = setupStorage();
+    const failing = deferred<void>();
+    setItemMock.mockReturnValueOnce(failing.promise);
+    const itemsNew = [{ id: 'item-new' }];
+
+    const writeOld = storage.setItem('inventory', {
+      state: { items: [{ id: 'item-old' }], isLoading: false, error: null },
+    });
+    const writeNew = storage.setItem('inventory', {
+      state: { items: itemsNew, isLoading: false, error: null },
+    });
+
+    failing.reject(new Error('disk unavailable'));
+    await expect(writeOld).rejects.toThrow('disk unavailable');
+    await expect(writeNew).resolves.toBeUndefined();
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+    expect(lastWrittenItems(setItemMock)).toEqual(itemsNew);
   });
 
   test('persists a version change even when the selected state is unchanged', async () => {

--- a/src/__tests__/equalityGatedJSONStorage.test.ts
+++ b/src/__tests__/equalityGatedJSONStorage.test.ts
@@ -1,0 +1,182 @@
+import type { StateStorage } from 'zustand/middleware';
+
+import { createEqualityGatedJSONStorage } from '../lib/equalityGatedJSONStorage';
+
+interface PersistedState {
+  items: { id: string }[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function setupStorage(initialValue: string | null = null) {
+  const setItemMock = jest.fn(
+    async (_name: string, _value: string): Promise<void> => undefined,
+  );
+  const rawStorage: StateStorage = {
+    getItem: jest.fn(async () => initialValue),
+    setItem: setItemMock,
+    removeItem: jest.fn(async () => undefined),
+  };
+  const storage = createEqualityGatedJSONStorage<PersistedState, PersistedState['items']>(
+    () => rawStorage,
+    (state) => state.items,
+  );
+  if (!storage) throw new Error('Expected test storage to be available.');
+  return { rawStorage, setItemMock, storage };
+}
+
+describe('createEqualityGatedJSONStorage', () => {
+  test('skips serialization and native writes when only non-persisted state changes', async () => {
+    const { rawStorage, storage } = setupStorage();
+    const items = [{ id: 'item-1' }];
+    const stringifySpy = jest.spyOn(JSON, 'stringify');
+
+    await storage.setItem('inventory', {
+      state: { items, isLoading: false, error: null },
+    });
+    await storage.setItem('inventory', {
+      state: { items, isLoading: true, error: null },
+    });
+    await storage.setItem('inventory', {
+      state: { items, isLoading: false, error: 'network down' },
+    });
+
+    expect(stringifySpy).toHaveBeenCalledTimes(1);
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(1);
+
+    const changedItems = [...items, { id: 'item-2' }];
+    await storage.setItem('inventory', {
+      state: { items: changedItems, isLoading: false, error: null },
+    });
+
+    expect(stringifySpy).toHaveBeenCalledTimes(2);
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+    stringifySpy.mockRestore();
+  });
+
+  test('retries the same state after a failed native write', async () => {
+    const { rawStorage, setItemMock, storage } = setupStorage();
+    setItemMock
+      .mockRejectedValueOnce(new Error('disk unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const value = {
+      state: {
+        items: [{ id: 'item-1' }],
+        isLoading: false,
+        error: null,
+      },
+    };
+
+    await expect(storage.setItem('inventory', value)).rejects.toThrow(
+      'disk unavailable',
+    );
+    await expect(storage.setItem('inventory', value)).resolves.toBeUndefined();
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  test('writes the current value behind a conflicting pending write', async () => {
+    const { rawStorage, setItemMock, storage } = setupStorage();
+    const itemsA = [{ id: 'item-a' }];
+    const itemsB = [{ id: 'item-b' }];
+    await storage.setItem('inventory', {
+      state: { items: itemsA, isLoading: false, error: null },
+    });
+    const pendingWrite = deferred<void>();
+    setItemMock.mockReturnValueOnce(pendingWrite.promise);
+
+    const writeB = storage.setItem('inventory', {
+      state: { items: itemsB, isLoading: false, error: null },
+    });
+    const writeA = storage.setItem('inventory', {
+      state: { items: itemsA, isLoading: true, error: null },
+    });
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(3);
+    pendingWrite.resolve();
+    await Promise.all([writeB, writeA]);
+  });
+
+  test('persists a version change even when the selected state is unchanged', async () => {
+    const { rawStorage, storage } = setupStorage();
+    const items = [{ id: 'item-1' }];
+
+    await storage.setItem('inventory', { state: { items, isLoading: false, error: null } });
+    await storage.setItem('inventory', {
+      state: { items, isLoading: false, error: null },
+      version: 1,
+    });
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  test('can retry after a synchronous storage failure', async () => {
+    const { rawStorage, setItemMock, storage } = setupStorage();
+    const value = {
+      state: {
+        items: [{ id: 'item-1' }],
+        isLoading: false,
+        error: null,
+      },
+    };
+    setItemMock.mockImplementationOnce(() => {
+      throw new Error('storage unavailable');
+    });
+
+    expect(() => storage.setItem('inventory', value)).toThrow(
+      'storage unavailable',
+    );
+    await expect(storage.setItem('inventory', value)).resolves.toBeUndefined();
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  test('removeItem clears the equality state so the same data is durable again', async () => {
+    const { rawStorage, storage } = setupStorage();
+    const value = {
+      state: {
+        items: [{ id: 'item-1' }],
+        isLoading: false,
+        error: null,
+      },
+    };
+
+    await storage.setItem('inventory', value);
+    await storage.setItem('inventory', value);
+    await storage.removeItem('inventory');
+    await storage.setItem('inventory', value);
+
+    expect(rawStorage.removeItem).toHaveBeenCalledTimes(1);
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  test('hydration does not suppress a later update with a new items reference', async () => {
+    const hydratedItems = [{ id: 'item-1' }];
+    const storedValue = JSON.stringify({
+      state: { items: hydratedItems, isLoading: false, error: null },
+    });
+    const { rawStorage, storage } = setupStorage(storedValue);
+
+    await expect(storage.getItem('inventory')).resolves.toEqual({
+      state: { items: hydratedItems, isLoading: false, error: null },
+    });
+
+    await storage.setItem('inventory', {
+      state: {
+        items: [{ id: 'item-1' }, { id: 'item-2' }],
+        isLoading: false,
+        error: null,
+      },
+    });
+
+    expect(rawStorage.setItem).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/inventoryStore.test.ts
+++ b/src/__tests__/inventoryStore.test.ts
@@ -26,7 +26,35 @@ jest.mock('../store/authStore', () => ({
 }));
 
 // eslint-disable-next-line import/first -- must load after the jest.mock() calls above so their mock vars are initialized first
-import { useInventoryStore } from '../store/inventoryStore';
+import {
+  invalidatePendingInventoryRequests,
+  useInventoryStore,
+} from '../store/inventoryStore';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function inventoryItem(id: string, name: string) {
+  return {
+    id,
+    name,
+    category: 'fish',
+    supplier_category: 'fish_supplier',
+    supplier_id: 'supplier-1',
+    location_id: null,
+    base_unit: 'lb',
+    pack_unit: 'case',
+    pack_size: 1,
+    active: true,
+    created_at: '2026-03-23T00:00:00.000Z',
+    created_by: 'user-1',
+  };
+}
 
 function createInventoryQueryResult(result: { data: unknown; error: unknown }) {
   const query: {
@@ -50,6 +78,7 @@ describe('useInventoryStore.fetchItems', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    invalidatePendingInventoryRequests();
     listInventoryMock.mockReset();
     signOutMock.mockReset();
     supabaseMock.from.mockReset();
@@ -145,5 +174,81 @@ describe('useInventoryStore.fetchItems', () => {
       },
     ]);
     expect(useInventoryStore.getState().error).toBeNull();
+  });
+
+  test('shares one inventory request across concurrent callers', async () => {
+    const request = deferred<{ data: ReturnType<typeof inventoryItem>[]; error: null }>();
+    listInventoryMock.mockReturnValue(request.promise);
+
+    const first = useInventoryStore.getState().fetchItems();
+    const second = useInventoryStore.getState().fetchItems();
+
+    await Promise.resolve();
+    expect(listInventoryMock).toHaveBeenCalledTimes(1);
+
+    request.resolve({ data: [inventoryItem('item-1', 'Salmon')], error: null });
+    await Promise.all([first, second]);
+    expect(useInventoryStore.getState().items.map((item) => item.id)).toEqual(['item-1']);
+  });
+
+  test('runs one follow-up refresh when force arrives during a request', async () => {
+    const firstRequest = deferred<{ data: ReturnType<typeof inventoryItem>[]; error: null }>();
+    listInventoryMock
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockResolvedValueOnce({ data: [inventoryItem('item-2', 'Tuna')], error: null });
+
+    const initial = useInventoryStore.getState().fetchItems();
+    await Promise.resolve();
+    expect(listInventoryMock).toHaveBeenCalledTimes(1);
+    const forced = useInventoryStore.getState().fetchItems({ force: true });
+
+    firstRequest.resolve({ data: [inventoryItem('item-1', 'Salmon')], error: null });
+    await Promise.all([initial, forced]);
+
+    expect(listInventoryMock).toHaveBeenCalledTimes(2);
+    expect(useInventoryStore.getState().items.map((item) => item.id)).toEqual(['item-2']);
+  });
+
+  test('does not join or publish an inventory request from a cleared session', async () => {
+    const oldRequest = deferred<{ data: ReturnType<typeof inventoryItem>[]; error: null }>();
+    const newRequest = deferred<{ data: ReturnType<typeof inventoryItem>[]; error: null }>();
+    listInventoryMock
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockReturnValueOnce(newRequest.promise);
+
+    const oldLoad = useInventoryStore.getState().fetchItems();
+    invalidatePendingInventoryRequests();
+    const newLoad = useInventoryStore.getState().fetchItems();
+
+    await Promise.resolve();
+    expect(listInventoryMock).toHaveBeenCalledTimes(2);
+    newRequest.resolve({ data: [inventoryItem('new-item', 'Tuna')], error: null });
+    await newLoad;
+    oldRequest.resolve({ data: [inventoryItem('old-item', 'Salmon')], error: null });
+    await oldLoad;
+
+    expect(useInventoryStore.getState().items.map((item) => item.id)).toEqual(['new-item']);
+  });
+
+  test('does not persist loading or error updates when cached items are unchanged', async () => {
+    const items = Array.from({ length: 2_001 }, (_, index) =>
+      inventoryItem(`item-${index}`, `Item ${index}`),
+    );
+    useInventoryStore.setState({ items });
+    await Promise.resolve();
+    mockAsyncStorage.setItem.mockClear();
+
+    useInventoryStore.setState({ isLoading: true });
+    useInventoryStore.setState({ error: 'network down' });
+    await Promise.resolve();
+
+    expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+
+    useInventoryStore.setState({
+      items: [...items, inventoryItem('item-new', 'New item')],
+    });
+    await Promise.resolve();
+
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/managerInventoryRowPerformance.test.ts
+++ b/src/__tests__/managerInventoryRowPerformance.test.ts
@@ -1,0 +1,134 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {
+  ManagerInventoryRow,
+  type ManagerInventoryStockItem,
+} from '@/features/inventory/ManagerInventoryRow';
+import type { InventoryItem } from '@/types';
+
+jest.mock('react-native', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react');
+  const createComponent = (name: string) => {
+    const Component = ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement(name, props, children);
+    Component.displayName = name;
+    return Component;
+  };
+  return {
+    View: createComponent('View'),
+    Text: createComponent('Text'),
+    TouchableOpacity: createComponent('TouchableOpacity'),
+    Platform: {
+      OS: 'ios',
+      select: (values: Record<string, unknown>) => values.ios ?? values.default,
+    },
+    StyleSheet: { hairlineWidth: 1 },
+  };
+});
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: Record<string, unknown>) => React.createElement('Ionicons', props),
+}));
+
+jest.mock('@/hooks/useScaledStyles', () => ({
+  useScaledStyles: () => ({
+    spacing: (value: number) => value,
+    fontSize: (value: number) => value,
+    icon: (value: number) => value,
+  }),
+}));
+
+function makeItem(id: string, onNameRead: () => void): ManagerInventoryStockItem {
+  const inventoryItem: InventoryItem = {
+    id: `inventory-${id}`,
+    name: `Item ${id}`,
+    category: 'produce',
+    supplier_category: 'main_distributor',
+    base_unit: 'each',
+    pack_unit: 'case',
+    pack_size: 1,
+    active: true,
+    created_at: '2026-09-01T00:00:00Z',
+  };
+  Object.defineProperty(inventoryItem, 'name', {
+    enumerable: true,
+    get: () => {
+      onNameRead();
+      return `Item ${id}`;
+    },
+  });
+
+  return {
+    id,
+    inventory_item: inventoryItem,
+    location: {
+      id: 'location-1',
+      name: 'Sushi',
+      short_code: 'SU',
+      active: true,
+      created_at: '2026-09-01T00:00:00Z',
+    },
+    area_ids: ['area-1'],
+    areas: [],
+    area_names: ['Walk-in'],
+    current_quantity: 2,
+    min_quantity: 4,
+    max_quantity: 10,
+    unit_type: 'case',
+    last_updated_at: '2026-09-01T00:00:00Z',
+    status: 'critical',
+    overdue: false,
+    fillPercent: 20,
+    areaLabel: 'Walk-in',
+  };
+}
+
+describe('ManagerInventoryRow render behavior', () => {
+  test('rerenders only the row whose selection state changed', () => {
+    let firstNameReads = 0;
+    let secondNameReads = 0;
+    const first = makeItem('first', () => { firstNameReads += 1; });
+    const second = makeItem('second', () => { secondNameReads += 1; });
+    const onOpen = jest.fn();
+    const onEnterBulk = jest.fn();
+    const onToggleBulk = jest.fn();
+    const onAddToReorder = jest.fn();
+
+    function Rows({ firstSelected }: { firstSelected: boolean }) {
+      return React.createElement(
+        React.Fragment,
+        null,
+        ...[first, second].map((item, index) =>
+          React.createElement(ManagerInventoryRow, {
+            key: item.id,
+            item,
+            variant: 'list',
+            added: false,
+            isBulkMode: true,
+            isSelected: index === 0 && firstSelected,
+            onOpen,
+            onEnterBulk,
+            onToggleBulk,
+            onAddToReorder,
+          }),
+        ),
+      );
+    }
+
+    let component!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      component = renderer.create(React.createElement(Rows, { firstSelected: false }));
+    });
+    const firstReadsAfterMount = firstNameReads;
+    const secondReadsAfterMount = secondNameReads;
+
+    renderer.act(() => {
+      component.update(React.createElement(Rows, { firstSelected: true }));
+    });
+
+    expect(firstNameReads).toBeGreaterThan(firstReadsAfterMount);
+    expect(secondNameReads).toBe(secondReadsAfterMount);
+    renderer.act(() => component.unmount());
+  });
+});

--- a/src/__tests__/managerInventorySelectorsPerformance.test.ts
+++ b/src/__tests__/managerInventorySelectorsPerformance.test.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+import { selectManagerInventoryOrderState } from '@/features/inventory/managerInventorySelectors';
+import type { OrderState } from '@/store/orderStore.types';
+
+type TestOrderState = Pick<OrderState, 'addToCart' | 'getTotalCartCount'> & {
+  managerCount: number;
+  unrelatedRevision: number;
+};
+
+describe('manager inventory order selector', () => {
+  test('ignores unrelated updates and keeps the derived manager cart count live', () => {
+    const initialAddToCart: OrderState['addToCart'] = () => undefined;
+    const replacementAddToCart: OrderState['addToCart'] = () => undefined;
+    const useTestOrderStore = create<TestOrderState>((_set, get) => ({
+      addToCart: initialAddToCart,
+      getTotalCartCount: (context) => (context === 'manager' ? get().managerCount : 0),
+      managerCount: 0,
+      unrelatedRevision: 0,
+    }));
+    const snapshots: ReturnType<typeof selectManagerInventoryOrderState>[] = [];
+
+    function Probe() {
+      snapshots.push(useTestOrderStore(useShallow(selectManagerInventoryOrderState)));
+      return React.createElement('Probe');
+    }
+
+    let component!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      component = renderer.create(React.createElement(Probe));
+    });
+    renderer.act(() => {
+      useTestOrderStore.setState({ unrelatedRevision: 1 });
+    });
+    expect(snapshots).toHaveLength(1);
+
+    renderer.act(() => {
+      useTestOrderStore.setState({ managerCount: 3 });
+    });
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[1].cartCount).toBe(3);
+
+    renderer.act(() => {
+      useTestOrderStore.setState({ addToCart: replacementAddToCart });
+    });
+    expect(snapshots).toHaveLength(3);
+    expect(snapshots[2].addToCart).toBe(replacementAddToCart);
+
+    renderer.act(() => component.unmount());
+  });
+});

--- a/src/__tests__/moduleAccess.test.ts
+++ b/src/__tests__/moduleAccess.test.ts
@@ -4,11 +4,11 @@
  * tab sets live when a manager flips a toggle.
  */
 
-const mockGetMyModules = jest.fn();
+const mockGetModulesForUser = jest.fn();
 const mockSubscribeToMyModules = jest.fn();
 
 jest.mock('@/services/userModules', () => ({
-  getMyModules: (...args: unknown[]) => mockGetMyModules(...args),
+  getModulesForUser: (...args: unknown[]) => mockGetModulesForUser(...args),
   subscribeToMyModules: (...args: unknown[]) => mockSubscribeToMyModules(...args),
 }));
 
@@ -195,7 +195,7 @@ describe('module store', () => {
   });
 
   it('loads the effective module set and marks the store ready', async () => {
-    mockGetMyModules.mockResolvedValue([{ key: 'stock_check', enabled: true }]);
+    mockGetModulesForUser.mockResolvedValue([{ key: 'stock_check', enabled: true }]);
 
     await useModuleStore.getState().load('user-1');
 
@@ -204,10 +204,11 @@ describe('module store', () => {
       fetched: [{ key: 'stock_check', enabled: true }],
       status: 'ready',
     });
+    expect(mockGetModulesForUser).toHaveBeenCalledWith('user-1');
   });
 
   it('falls back to no data (role defaults downstream) when the fetch fails', async () => {
-    mockGetMyModules.mockRejectedValue(new Error('network down'));
+    mockGetModulesForUser.mockRejectedValue(new Error('network down'));
 
     await useModuleStore.getState().load('user-1');
 
@@ -221,10 +222,10 @@ describe('module store', () => {
   });
 
   it('keeps last-known data when a refresh for the same user fails', async () => {
-    mockGetMyModules.mockResolvedValueOnce([{ key: 'tips', enabled: true }]);
+    mockGetModulesForUser.mockResolvedValueOnce([{ key: 'tips', enabled: true }]);
     await useModuleStore.getState().load('user-1');
 
-    mockGetMyModules.mockRejectedValueOnce(new Error('flaky'));
+    mockGetModulesForUser.mockRejectedValueOnce(new Error('flaky'));
     await useModuleStore.getState().load('user-1');
 
     expect(useModuleStore.getState()).toMatchObject({
@@ -234,11 +235,11 @@ describe('module store', () => {
   });
 
   it('drops stale data when a different user loads', async () => {
-    mockGetMyModules.mockResolvedValueOnce([{ key: 'tips', enabled: true }]);
+    mockGetModulesForUser.mockResolvedValueOnce([{ key: 'tips', enabled: true }]);
     await useModuleStore.getState().load('user-1');
 
     let resolveSecond: (value: unknown) => void = () => {};
-    mockGetMyModules.mockReturnValueOnce(
+    mockGetModulesForUser.mockReturnValueOnce(
       new Promise((resolve) => {
         resolveSecond = resolve;
       }),
@@ -263,9 +264,9 @@ describe('module store', () => {
 
   it('does not restore revoked modules when an older request finishes last', async () => {
     let resolveOlder: (value: unknown) => void = () => {};
-    mockGetMyModules.mockReturnValueOnce(new Promise((resolve) => { resolveOlder = resolve; }));
+    mockGetModulesForUser.mockReturnValueOnce(new Promise((resolve) => { resolveOlder = resolve; }));
     const older = useModuleStore.getState().load('user-1');
-    mockGetMyModules.mockResolvedValueOnce([{ key: 'fulfillment', enabled: false }]);
+    mockGetModulesForUser.mockResolvedValueOnce([{ key: 'fulfillment', enabled: false }]);
     await useModuleStore.getState().load('user-1');
     resolveOlder([{ key: 'fulfillment', enabled: true }]);
     await older;
@@ -275,10 +276,10 @@ describe('module store', () => {
 
   it('ignores an old request after reset and sign-in by the same user', async () => {
     let resolveOlder: (value: unknown) => void = () => {};
-    mockGetMyModules.mockReturnValueOnce(new Promise((resolve) => { resolveOlder = resolve; }));
+    mockGetModulesForUser.mockReturnValueOnce(new Promise((resolve) => { resolveOlder = resolve; }));
     const older = useModuleStore.getState().load('user-1');
     useModuleStore.getState().reset();
-    mockGetMyModules.mockResolvedValueOnce([{ key: 'fulfillment', enabled: false }]);
+    mockGetModulesForUser.mockResolvedValueOnce([{ key: 'fulfillment', enabled: false }]);
     await useModuleStore.getState().load('user-1');
     resolveOlder([{ key: 'fulfillment', enabled: true }]);
     await older;
@@ -293,21 +294,22 @@ describe('module store', () => {
       realtimeCallback = onChange;
       return unsubscribe;
     });
-    mockGetMyModules.mockResolvedValue([{ key: 'ordering_simple', enabled: true }]);
+    mockGetModulesForUser.mockResolvedValue([{ key: 'ordering_simple', enabled: true }]);
 
     const releaseA = acquireModuleAccess('user-1');
     const releaseB = acquireModuleAccess('user-1');
     await flushPromises();
 
     expect(mockSubscribeToMyModules).toHaveBeenCalledTimes(1);
-    expect(mockGetMyModules).toHaveBeenCalledTimes(1);
+    expect(mockSubscribeToMyModules).toHaveBeenCalledWith(expect.any(Function), 'user-1');
+    expect(mockGetModulesForUser).toHaveBeenCalledTimes(1);
 
     // A manager flips a toggle → realtime callback → reload (live tab flip).
-    mockGetMyModules.mockResolvedValue([{ key: 'ordering_simple', enabled: false }]);
+    mockGetModulesForUser.mockResolvedValue([{ key: 'ordering_simple', enabled: false }]);
     realtimeCallback();
     await flushPromises();
 
-    expect(mockGetMyModules).toHaveBeenCalledTimes(2);
+    expect(mockGetModulesForUser).toHaveBeenCalledTimes(2);
     expect(useModuleStore.getState().fetched).toEqual([
       { key: 'ordering_simple', enabled: false },
     ]);

--- a/src/__tests__/quickOrderListCard.test.ts
+++ b/src/__tests__/quickOrderListCard.test.ts
@@ -1,6 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { QuickOrderListCard } from '../features/ordering/QuickOrderListCard';
+import {
+  getScrollbarThumbGeometry,
+  QuickOrderListCard,
+} from '../features/ordering/QuickOrderListCard';
+import { useScaledStyles } from '@/hooks/useScaledStyles';
+import type { ParsedQuickOrderItem } from '@/features/ordering/quickOrderItems';
 
 jest.mock('react-native', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories cannot reference the top-level React import (babel-plugin-jest-hoist restriction)
@@ -46,24 +51,38 @@ jest.mock('react-native-reanimated', () => {
   };
 
   const View = createComponent('Animated.View');
+  const ScrollView = createComponent('ScrollView');
+  type MockScrollEvent = {
+    contentOffset: { y: number };
+    contentSize: { height: number };
+    layoutMeasurement: { height: number };
+  };
   return {
     __esModule: true,
-    default: { View, createAnimatedComponent: (Component: React.ComponentType) => Component },
+    default: {
+      View,
+      ScrollView,
+      createAnimatedComponent: (Component: React.ComponentType) => Component,
+    },
     View,
     Easing: { bezier: jest.fn(() => jest.fn()) },
-    useAnimatedStyle: jest.fn((factory) => factory()),
-    useSharedValue: jest.fn((value) => ({ value })),
-    withTiming: jest.fn((value) => value),
+    useAnimatedScrollHandler: jest.fn(
+      (handler: (event: MockScrollEvent) => void) =>
+        (event: { nativeEvent: MockScrollEvent }) => handler(event.nativeEvent),
+    ),
+    useAnimatedStyle: jest.fn((factory: () => unknown) => factory()),
+    useSharedValue: jest.fn((value: unknown) => ({ value })),
+    withTiming: jest.fn((value: unknown) => value),
   };
 });
 
 jest.mock('@/hooks/useScaledStyles', () => ({
-  useScaledStyles: () => ({
+  useScaledStyles: jest.fn(() => ({
     spacing: (value: number) => value,
     radius: (value: number) => value,
     fontSize: (value: number) => value,
     icon: (value: number) => value,
-  }),
+  })),
 }));
 
 jest.mock('@/lib/haptics', () => ({
@@ -124,6 +143,33 @@ describe('QuickOrderListCard', () => {
     expect(rendered).toContain('2 cases');
     expect(rendered).toContain('Masago');
     expect(rendered).toContain('1 case');
+  });
+
+  test('fills the scrollbar track when content does not overflow', () => {
+    expect(getScrollbarThumbGeometry({
+      viewportHeight: 160,
+      contentHeight: 120,
+      offsetY: 40,
+      minThumbHeight: 28,
+    })).toEqual({ height: 160, top: 0 });
+  });
+
+  test('keeps the scrollbar thumb inside the track at both scroll limits', () => {
+    const start = getScrollbarThumbGeometry({
+      viewportHeight: 160,
+      contentHeight: 640,
+      offsetY: -20,
+      minThumbHeight: 28,
+    });
+    const end = getScrollbarThumbGeometry({
+      viewportHeight: 160,
+      contentHeight: 640,
+      offsetY: 600,
+      minThumbHeight: 28,
+    });
+
+    expect(start).toEqual({ height: 40, top: 0 });
+    expect(end).toEqual({ height: 40, top: 120 });
   });
 
   test('groups multiple units for the same item under one row with full unit words', () => {
@@ -273,5 +319,50 @@ describe('QuickOrderListCard', () => {
     expect(rendered.indexOf('Ground Garlic')).toBeLessThan(rendered.indexOf('Edamame'));
     expect(rendered.indexOf('Edamame')).toBeLessThan(rendered.indexOf('Shrimp (Frozen)'));
     expect(rendered.indexOf('Shrimp (Frozen)')).toBeLessThan(rendered.indexOf('Albacore'));
+  });
+
+  test('updates the custom scrollbar without a React render on each scroll event', () => {
+    const mockedUseScaledStyles = jest.mocked(useScaledStyles);
+    const items: ParsedQuickOrderItem[] = Array.from({ length: 6 }, (_, index) => ({
+      item_id: `item-${index}`,
+      item_name: `Item ${index}`,
+      quantity: index + 1,
+      unit: 'case',
+      status: 'valid',
+      needs_clarification: false,
+      unresolved: false,
+    }));
+    let component!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      component = renderer.create(
+        React.createElement(QuickOrderListCard, {
+          items,
+          issueCount: 0,
+          isSubmitting: false,
+          onEditItem: jest.fn(),
+          onResolveQuantity: jest.fn(),
+          onRemoveItems: jest.fn(),
+          onConfirm: jest.fn(),
+          onHeightChange: jest.fn(),
+        }),
+      );
+    });
+
+    const scrollView = component.root.find((node) => String(node.type) === 'ScrollView');
+    const renderCountBeforeScroll = mockedUseScaledStyles.mock.calls.length;
+
+    renderer.act(() => {
+      scrollView.props.onScroll({
+        nativeEvent: {
+          contentOffset: { x: 0, y: 40 },
+          contentSize: { width: 320, height: 360 },
+          layoutMeasurement: { width: 320, height: 156 },
+        },
+      });
+    });
+
+    expect(mockedUseScaledStyles).toHaveBeenCalledTimes(renderCountBeforeScroll);
+
+    renderer.act(() => component.unmount());
   });
 });

--- a/src/__tests__/quickOrderRehydratedCartRender.test.ts
+++ b/src/__tests__/quickOrderRehydratedCartRender.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Issue #70 regression guard (render side).
+ *
+ * The screen is wrapped in an ErrorBoundary, which only catches render and
+ * commit-phase errors. This suite renders the Order list card with a cart
+ * rehydrated straight out of `quick_order_sessions.parsed_items` whose row has
+ * no resolved unit, then re-renders it with the item the send path would have
+ * merged in, so a row in that state can never take the screen down.
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { QuickOrderListCard } from '../features/ordering/QuickOrderListCard';
+import { QuickOrderItemRow } from '../features/ordering/QuickOrderItemRow';
+import {
+  mergeQuickOrderParsedItemsDetailed,
+  countUnresolvedItems,
+  type ParsedQuickOrderItem,
+} from '../features/ordering/quickOrderItems';
+
+jest.mock('react-native', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories cannot reference the top-level React import (babel-plugin-jest-hoist restriction)
+  const React = require('react');
+  const createComponent = (name: string) => {
+    const Component = React.forwardRef(
+      ({ children, ...props }: { children?: React.ReactNode }, ref: React.Ref<unknown>) =>
+        React.createElement(name, { ...props, ref }, children),
+    );
+    Component.displayName = name;
+    return Component;
+  };
+
+  return {
+    View: createComponent('View'),
+    Text: createComponent('Text'),
+    ScrollView: createComponent('ScrollView'),
+    Pressable: createComponent('Pressable'),
+    TouchableOpacity: createComponent('TouchableOpacity'),
+    ActivityIndicator: createComponent('ActivityIndicator'),
+    StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+    Platform: { OS: 'ios', select: (values: Record<string, unknown>) => values.ios ?? values.default },
+  };
+});
+
+jest.mock('react-native-reanimated', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories cannot reference the top-level React import (babel-plugin-jest-hoist restriction)
+  const React = require('react');
+  const createComponent = (name: string) => {
+    const Component = React.forwardRef(
+      ({ children, ...props }: { children?: React.ReactNode }, ref: React.Ref<unknown>) =>
+        React.createElement(name, { ...props, ref }, children),
+    );
+    Component.displayName = name;
+    return Component;
+  };
+
+  const View = createComponent('Animated.View');
+  const ScrollView = createComponent('ScrollView');
+  type MockScrollEvent = {
+    contentOffset: { y: number };
+    contentSize: { height: number };
+    layoutMeasurement: { height: number };
+  };
+  return {
+    __esModule: true,
+    default: {
+      View,
+      ScrollView,
+      createAnimatedComponent: (Component: React.ComponentType) => Component,
+    },
+    View,
+    Easing: { bezier: jest.fn(() => jest.fn()) },
+    useAnimatedScrollHandler: jest.fn(
+      (handler: (event: MockScrollEvent) => void) =>
+        (event: { nativeEvent: MockScrollEvent }) => handler(event.nativeEvent),
+    ),
+    useAnimatedStyle: jest.fn((factory: () => unknown) => factory()),
+    useSharedValue: jest.fn((value: unknown) => ({ value })),
+    withTiming: jest.fn((value: unknown) => value),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories cannot reference the top-level React import (babel-plugin-jest-hoist restriction)
+  const React = require('react');
+  return {
+    Ionicons: (props: Record<string, unknown>) => React.createElement('Ionicons', props),
+  };
+});
+
+jest.mock('@/hooks/useScaledStyles', () => ({
+  useScaledStyles: jest.fn(() => ({
+    spacing: (value: number) => value,
+    radius: (value: number) => value,
+    fontSize: (value: number) => value,
+    icon: (value: number) => value,
+  })),
+}));
+
+jest.mock('@/lib/haptics', () => ({
+  triggerConfirmationHaptic: jest.fn(),
+  triggerSelectionHaptic: jest.fn(),
+}));
+
+/** Cart as it comes back off the persisted session row. */
+function rehydratedCart(unit: unknown): ParsedQuickOrderItem[] {
+  return JSON.parse(
+    JSON.stringify([
+      {
+        item_id: 'rice-id',
+        item_name: 'Fixture Rice',
+        raw_token: '2 bags of fixture rice',
+        quantity: 2,
+        unit: 'bag',
+        status: 'valid',
+        needs_clarification: false,
+        unresolved: false,
+      },
+      {
+        item_id: 'salmon-id',
+        item_name: 'Fixture Salmon',
+        raw_token: '3 fixture salmon',
+        quantity: 3,
+        unit,
+        valid_units: ['lb', 'cs'],
+        status: 'missing_unit',
+        action: 'Choose unit',
+        needs_clarification: true,
+        unresolved: false,
+      },
+    ]),
+  ) as ParsedQuickOrderItem[];
+}
+
+const NORI: ParsedQuickOrderItem = {
+  item_id: 'nori-id',
+  item_name: 'Fixture Nori',
+  raw_token: '4 packs of fixture nori',
+  quantity: 4,
+  unit: 'pack',
+  status: 'valid',
+  needs_clarification: false,
+  unresolved: false,
+};
+
+function renderCard(items: ParsedQuickOrderItem[]) {
+  let component!: renderer.ReactTestRenderer;
+  renderer.act(() => {
+    component = renderer.create(
+      React.createElement(QuickOrderListCard, {
+        items,
+        issueCount: countUnresolvedItems(items),
+        isSubmitting: false,
+        onEditItem: jest.fn(),
+        onResolveQuantity: jest.fn(),
+        onRemoveItems: jest.fn(),
+        onConfirm: jest.fn(),
+        onHeightChange: jest.fn(),
+      }),
+    );
+  });
+  return component;
+}
+
+describe('issue #70: Order list card renders a rehydrated cart with an unresolved unit', () => {
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      IS_REACT_ACT_ENVIRONMENT: true,
+      requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(callback, 0),
+      cancelAnimationFrame: (id: ReturnType<typeof setTimeout>) => clearTimeout(id),
+    });
+  });
+
+  test.each([
+    ['a null unit', null],
+    ['an undefined unit', undefined],
+    ['an empty unit', ''],
+    ['a unit id no longer in the catalog', 'legacy-unit-id-4471'],
+  ])('renders the rehydrated cart with %s', (_label, unit) => {
+    const items = rehydratedCart(unit);
+    let component!: renderer.ReactTestRenderer;
+    expect(() => {
+      component = renderCard(items);
+    }).not.toThrow();
+    const rendered = JSON.stringify(component.toJSON());
+    expect(rendered).toContain('Fixture Salmon');
+    renderer.act(() => component.unmount());
+  });
+
+  test('re-renders after the send path merges a new item into the rehydrated cart', () => {
+    const items = rehydratedCart(null);
+    const component = renderCard(items);
+    const merged = mergeQuickOrderParsedItemsDetailed(items, [NORI]).items;
+
+    expect(() => {
+      renderer.act(() => {
+        component.update(
+          React.createElement(QuickOrderListCard, {
+            items: merged,
+            issueCount: countUnresolvedItems(merged),
+            isSubmitting: false,
+            onEditItem: jest.fn(),
+            onResolveQuantity: jest.fn(),
+            onRemoveItems: jest.fn(),
+            onConfirm: jest.fn(),
+            onHeightChange: jest.fn(),
+          }),
+        );
+      });
+    }).not.toThrow();
+
+    const rendered = JSON.stringify(component.toJSON());
+    expect(rendered).toContain('Fixture Nori');
+    expect(rendered).toContain('1 to fix');
+    renderer.act(() => component.unmount());
+  });
+
+  test('renders an item row for an unresolved unit with no quantity lines', () => {
+    const [, salmon] = rehydratedCart(null);
+    let component!: renderer.ReactTestRenderer;
+    expect(() => {
+      renderer.act(() => {
+        component = renderer.create(
+          React.createElement(QuickOrderItemRow, {
+            item: salmon,
+            quantityLines: [],
+            showDivider: false,
+            onEdit: jest.fn(),
+            onResolveQuantity: jest.fn(),
+          }),
+        );
+      });
+    }).not.toThrow();
+    expect(JSON.stringify(component.toJSON())).toContain('Choose unit');
+    renderer.act(() => component.unmount());
+  });
+});

--- a/src/__tests__/quickOrderRehydratedSend.test.ts
+++ b/src/__tests__/quickOrderRehydratedSend.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Issue #70.
+ *
+ * Advanced ordering hit its error boundary once when the user sent a new
+ * message while the cart had been rehydrated from
+ * `quick_order_sessions.parsed_items` and still held an item with no resolved
+ * unit. The original failure did not reproduce here, so the first block drives
+ * the pure pipeline the composer send path runs over `parsedItems` as a
+ * regression guard, and the last two cover the guards added for that state:
+ * rehydrated rows are normalized on load so an unresolved unit always shows a
+ * resolve prompt, and the render-phase cart update can no longer throw into the
+ * error boundary.
+ */
+import {
+  applyQuickOrderOperations,
+  countUnresolvedItems,
+  getParsedItemIssue,
+  getParsedItemKey,
+  isParsedItemReady,
+  mergeQuickOrderParsedItemsDetailed,
+  normalizeQuickOrderItemForDisplay,
+  detectRepeatedOrderList,
+  formatParsedItemQuantity,
+  getParsedItemDisplayName,
+  updateParsedItem,
+  removeParsedItem,
+  type ParsedQuickOrderItem,
+} from '../features/ordering/quickOrderItems';
+import {
+  buildQuickOrderAssistantMessage,
+  hasQuickOrderStateChange,
+  normalizeQuickOrderParseResponse,
+} from '../features/ordering/quickOrderResponse';
+import {
+  getQuantityFixQueue,
+  resolveQuantityUnitOptions,
+  getQuantitySheetInitialState,
+} from '../features/ordering/quickOrderQuantityFlow';
+import {
+  areQuickOrderItemsCartReady,
+  quickOrderItemsToCartAdds,
+} from '../store/helpers/quickOrderCart';
+import {
+  applyQuickOrderCartUpdate,
+  normalizePersistedQuickOrderItems,
+  QUICK_ORDER_CART_APPLY_ERROR_CODE,
+} from '../features/ordering/quickOrderSendGuards';
+import { toFriendlyQuickOrderError } from '../features/ordering/quickOrderErrors';
+
+/**
+ * A cart as it comes back off `quick_order_sessions.parsed_items`: raw JSON,
+ * no display normalization. Salmon is the "1 to fix" row from the report —
+ * matched to an inventory id but with no unit.
+ */
+function rehydratedCartWithMissingUnit(): ParsedQuickOrderItem[] {
+  return JSON.parse(
+    JSON.stringify([
+      {
+        item_id: 'rice-id',
+        item_name: 'Fixture Rice',
+        raw_token: '2 bags of fixture rice',
+        quantity: 2,
+        unit: 'bag',
+        status: 'valid',
+        needs_clarification: false,
+        unresolved: false,
+      },
+      {
+        item_id: 'salmon-id',
+        item_name: 'Fixture Salmon',
+        raw_token: '3 fixture salmon',
+        quantity: 3,
+        unit: null,
+        valid_units: ['lb', 'cs'],
+        status: 'missing_unit',
+        action: 'Choose unit',
+        needs_clarification: true,
+        unresolved: false,
+      },
+    ]),
+  ) as ParsedQuickOrderItem[];
+}
+
+/** Same cart, but the unit is an id the catalog no longer knows about. */
+function rehydratedCartWithStaleUnit(): ParsedQuickOrderItem[] {
+  const items = rehydratedCartWithMissingUnit();
+  items[1] = {
+    ...items[1],
+    unit: 'legacy-unit-id-4471',
+    valid_units: ['lb', 'cs'],
+    status: 'invalid_unit',
+    action: 'Fix unit',
+  };
+  return items;
+}
+
+/** Cart where the unit key is missing from the JSON entirely (undefined). */
+function rehydratedCartWithAbsentUnit(): ParsedQuickOrderItem[] {
+  const items = rehydratedCartWithMissingUnit();
+  const salmon = { ...items[1] } as Record<string, unknown>;
+  delete salmon.unit;
+  delete salmon.valid_units;
+  delete salmon.status;
+  items[1] = salmon as ParsedQuickOrderItem;
+  return items;
+}
+
+/** The parse-order payload for "4 packs of fixture nori". */
+const NORI_PARSE_RESPONSE = {
+  status: 'ok',
+  assistant_message: 'Got it.',
+  parsed_items: [
+    {
+      item_id: 'nori-id',
+      item_name: 'Fixture Nori',
+      raw_text: '4 packs of fixture nori',
+      quantity: 4,
+      unit: 'pack',
+      status: 'valid',
+    },
+  ],
+};
+
+/** Mirrors QuickOrderScreen.buildQuickOrderCartHash. */
+function buildQuickOrderCartHash(items: ParsedQuickOrderItem[]): string {
+  return items
+    .filter((item) => item.item_id && item.quantity != null)
+    .map(
+      (item) =>
+        `${item.item_id}:${Number(item.quantity ?? 0).toFixed(4)}:${String(item.unit ?? '')
+          .trim()
+          .toLowerCase()}`,
+    )
+    .sort()
+    .join('|');
+}
+
+/**
+ * Everything the composer send path runs over `parsedItems`, in the order the
+ * screen runs it: the pre-send helpers, the parse response normalization, the
+ * `setParsedItems` render-phase updater (operations -> merge -> assistant
+ * message), and the post-send reads.
+ */
+function runSendPipeline(rehydrated: ParsedQuickOrderItem[]) {
+  // Pre-send reads.
+  buildQuickOrderCartHash(rehydrated);
+  countUnresolvedItems(rehydrated);
+  rehydrated.forEach((item) => {
+    getParsedItemIssue(item);
+    getParsedItemKey(item);
+    getParsedItemDisplayName(item);
+    formatParsedItemQuantity(item);
+    isParsedItemReady(item);
+  });
+  getQuantityFixQueue(rehydrated);
+
+  const response = normalizeQuickOrderParseResponse(NORI_PARSE_RESPONSE);
+
+  // The render-phase state updater.
+  const operationResult =
+    response.operations.length > 0
+      ? applyQuickOrderOperations(rehydrated, response.operations)
+      : null;
+  const operationBase = operationResult ? operationResult.items : rehydrated;
+  const mergeResult = mergeQuickOrderParsedItemsDetailed(
+    operationBase,
+    response.parsedItems,
+  );
+  hasQuickOrderStateChange(mergeResult, response.pendingActions.length, operationResult);
+  const assistantMessage = buildQuickOrderAssistantMessage({
+    normalized: response,
+    mergeResult,
+    pendingCount: response.pendingActions.length,
+    operationResult,
+  });
+
+  // Post-send reads.
+  const next = mergeResult.items;
+  countUnresolvedItems(next);
+  buildQuickOrderCartHash(next);
+  detectRepeatedOrderList(next, response.parsedItems);
+  next.map((item) => item.item_id);
+  areQuickOrderItemsCartReady(next);
+  getQuantityFixQueue(next);
+
+  return { assistantMessage, items: next, mergeResult };
+}
+
+describe('issue #70: sending after a rehydrated cart with an unresolved unit', () => {
+  test.each([
+    ['unit null', rehydratedCartWithMissingUnit],
+    ['unit absent from the persisted JSON', rehydratedCartWithAbsentUnit],
+    ['unit id no longer in the catalog', rehydratedCartWithStaleUnit],
+  ])('send pipeline does not throw when the rehydrated cart has %s', (_label, build) => {
+    expect(() => runSendPipeline(build())).not.toThrow();
+  });
+
+  test('the unresolved row survives the send and still reports an issue', () => {
+    const { items } = runSendPipeline(rehydratedCartWithMissingUnit());
+    const salmon = items.find((item) => item.item_id === 'salmon-id');
+    expect(salmon).toBeDefined();
+    expect(getParsedItemIssue(salmon as ParsedQuickOrderItem)).not.toBeNull();
+    expect(items.some((item) => item.item_id === 'nori-id')).toBe(true);
+  });
+
+  test('the cart is never reported ready while a unit is unresolved', () => {
+    const { items } = runSendPipeline(rehydratedCartWithMissingUnit());
+    expect(areQuickOrderItemsCartReady(items)).toBe(false);
+  });
+
+  test('the quantity sheet can still be built for a rehydrated unresolved row', () => {
+    const items = rehydratedCartWithMissingUnit();
+    const salmon = items[1];
+    expect(() => {
+      const resolution = resolveQuantityUnitOptions({
+        item: salmon,
+        inventoryItem: null,
+        suggestion: null,
+      });
+      getQuantitySheetInitialState({
+        item: salmon,
+        options: resolution.options,
+        defaultValue: resolution.defaultValue,
+        suggestion: null,
+      });
+    }).not.toThrow();
+  });
+
+  test('editing and removing a rehydrated unresolved row does not throw', () => {
+    const items = rehydratedCartWithMissingUnit();
+    const key = getParsedItemKey(items[1]);
+    expect(() => {
+      updateParsedItem(items, key, { unit: 'lb' });
+      removeParsedItem(items, key);
+      normalizeQuickOrderItemForDisplay(items[1]);
+    }).not.toThrow();
+  });
+
+  test('confirm conversion refuses a cart with an unresolved unit instead of half-submitting', () => {
+    const { items } = runSendPipeline(rehydratedCartWithMissingUnit());
+    expect(() => quickOrderItemsToCartAdds(items, new Map())).toThrow();
+  });
+});
+
+describe('normalizePersistedQuickOrderItems', () => {
+  test('turns a persisted row with no unit into a visible "Choose unit" prompt', () => {
+    // Persisted while the row was still being fixed: the stored status says
+    // "valid" but there is no unit on the row.
+    const [item] = normalizePersistedQuickOrderItems([
+      {
+        item_id: 'salmon-id',
+        item_name: 'Fixture Salmon',
+        quantity: 3,
+        unit: null,
+        valid_units: ['lb', 'cs'],
+        status: 'valid',
+        needs_clarification: false,
+      },
+    ]);
+
+    expect(item.status).toBe('missing_unit');
+    expect(item.action).toBe('Choose unit');
+    expect(getParsedItemIssue(item)).toEqual({ kind: 'pick-unit', label: 'Choose unit' });
+    expect(isParsedItemReady(item)).toBe(false);
+  });
+
+  test('keeps a "Fix unit" prompt for a unit id that is no longer in the catalog', () => {
+    const [item] = normalizePersistedQuickOrderItems([
+      {
+        item_id: 'salmon-id',
+        item_name: 'Fixture Salmon',
+        quantity: 3,
+        unit: 'legacy-unit-id-4471',
+        valid_units: ['lb', 'cs'],
+        status: 'invalid_unit',
+      },
+    ]);
+
+    expect(item.action).toBe('Fix unit');
+    expect(getParsedItemIssue(item)?.kind).toBe('fix-unit');
+  });
+
+  test('fills the only orderable unit instead of prompting for it', () => {
+    const [item] = normalizePersistedQuickOrderItems([
+      {
+        item_id: 'nori-id',
+        item_name: 'Fixture Nori',
+        quantity: 4,
+        unit: null,
+        valid_units: ['pack'],
+        status: 'missing_unit',
+      },
+    ]);
+
+    expect(item.unit).toBe('pack');
+    expect(getParsedItemIssue(item)).toBeNull();
+  });
+
+  test('drops entries there is nothing to render and tolerates a non-array payload', () => {
+    expect(normalizePersistedQuickOrderItems(null)).toEqual([]);
+    expect(normalizePersistedQuickOrderItems('not-an-array')).toEqual([]);
+    expect(
+      normalizePersistedQuickOrderItems([null, 'nope', [], {}, { quantity: 2, unit: 'cs' }]),
+    ).toEqual([]);
+  });
+
+  test('keeps a nameless row so it still shows an "Unknown item" prompt', () => {
+    const items = normalizePersistedQuickOrderItems([
+      { raw_token: '3 fillets fixture salmon', quantity: 3, unit: null },
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(getParsedItemDisplayName(items[0])).toBe('3 fillets fixture salmon');
+    expect(getParsedItemIssue(items[0])?.kind).toBe('choose-item');
+  });
+});
+
+describe('applyQuickOrderCartUpdate', () => {
+  test('commits the computed cart when the update succeeds', () => {
+    const current = rehydratedCartWithMissingUnit();
+    const next = [...current, { ...current[0], item_id: 'nori-id' }];
+
+    const result = applyQuickOrderCartUpdate(current, () => ({
+      items: next,
+      snapshot: 'applied',
+    }));
+
+    expect(result.error).toBeNull();
+    expect(result.snapshot).toBe('applied');
+    expect(result.items).toBe(next);
+  });
+
+  test('leaves the cart untouched and reports the failure instead of throwing', () => {
+    const current = rehydratedCartWithMissingUnit();
+    const boom = new TypeError("Cannot read properties of null (reading 'trim')");
+
+    let result!: ReturnType<typeof applyQuickOrderCartUpdate<string>>;
+    expect(() => {
+      result = applyQuickOrderCartUpdate<string>(current, () => {
+        throw boom;
+      });
+    }).not.toThrow();
+
+    expect(result.items).toBe(current);
+    expect(result.snapshot).toBeNull();
+    expect(result.error).toBe(boom);
+  });
+
+  test('treats a malformed cart result as a failure rather than committing it', () => {
+    const current = rehydratedCartWithMissingUnit();
+    const result = applyQuickOrderCartUpdate(current, () =>
+      ({ items: undefined, snapshot: 'bad' } as unknown as {
+        items: ParsedQuickOrderItem[];
+        snapshot: string;
+      }),
+    );
+
+    expect(result.items).toBe(current);
+    expect(result.snapshot).toBeNull();
+    expect(result.error).toBeInstanceOf(Error);
+  });
+
+  test('the failure code maps to user-facing copy, not a stack trace', () => {
+    const message = toFriendlyQuickOrderError(
+      undefined,
+      QUICK_ORDER_CART_APPLY_ERROR_CODE,
+    );
+    expect(message).toContain('order list');
+    expect(message).not.toMatch(/TypeError|undefined|null/);
+  });
+});

--- a/src/__tests__/rootLayoutPerformance.test.ts
+++ b/src/__tests__/rootLayoutPerformance.test.ts
@@ -1,0 +1,119 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { create } from 'zustand';
+
+interface AuthSnapshot {
+  initialize: () => Promise<void>;
+  isInitialized: boolean;
+  isLoading: boolean;
+  session: { user: { id: string } } | null;
+  locations: string[];
+}
+
+const mockUseAuthStore = create<AuthSnapshot>(() => ({
+  initialize: jest.fn(async () => undefined),
+  isInitialized: true,
+  isLoading: false,
+  session: null,
+  locations: [],
+}));
+const mockUseDisplayStore = create(() => ({ theme: 'system', reduceMotion: false }));
+const mockStackRender = jest.fn();
+const mockInventorySubscription = jest.fn();
+const mockOrderSubscription = jest.fn();
+const mockInventoryCleanup = jest.fn();
+const mockOrderCleanup = jest.fn();
+
+jest.mock('@/store', () => ({
+  useAuthStore: mockUseAuthStore,
+  useDisplayStore: mockUseDisplayStore,
+}));
+jest.mock('@/hooks', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    useInventorySubscription: () => {
+      mockInventorySubscription();
+      React.useEffect(() => mockInventoryCleanup, []);
+    },
+    useOrderSubscription: () => {
+      mockOrderSubscription();
+      React.useEffect(() => mockOrderCleanup, []);
+    },
+  };
+});
+jest.mock('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  Platform: { OS: 'ios', select: (options: { default: string }) => options.default },
+  LogBox: { ignoreLogs: jest.fn() },
+  Appearance: { setColorScheme: jest.fn() },
+  AppState: {
+    currentState: 'background',
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+}));
+jest.mock('react-native-gesture-handler', () => ({
+  GestureHandlerRootView: 'GestureHandlerRootView',
+}));
+jest.mock('expo-status-bar', () => ({ StatusBar: 'StatusBar' }));
+jest.mock('expo-router', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const Stack = Object.assign(
+    ({ children }: { children?: React.ReactNode }) => {
+      mockStackRender();
+      return React.createElement('Stack', null, children);
+    },
+    { Screen: () => null },
+  );
+  return { Stack };
+});
+jest.mock('@/lib/supabase', () => ({
+  supabaseConfigError: null,
+  supabase: { auth: { startAutoRefresh: jest.fn(), stopAutoRefresh: jest.fn() } },
+}));
+jest.mock('@/services/notificationService', () => ({
+  refreshCurrentDevicePushTokenIfStale: jest.fn(async () => undefined),
+}));
+jest.mock('@/theme/design', () => ({
+  colors: { background: '#fff', textPrimary: '#111', textMuted: '#666' },
+}));
+jest.mock('../../global.css', () => ({}));
+
+// eslint-disable-next-line import/first -- initialize mocked stores before importing the real layout
+import RootLayout from '../../app/_layout';
+
+describe('root layout store subscriptions', () => {
+  let component: renderer.ReactTestRenderer;
+
+  beforeEach(() => {
+    mockUseAuthStore.setState({ session: null, locations: [], isInitialized: true });
+    jest.clearAllMocks();
+    renderer.act(() => { component = renderer.create(React.createElement(RootLayout)); });
+  });
+
+  afterEach(() => {
+    renderer.act(() => component.unmount());
+  });
+
+  test('does not rerender navigation when only the location catalog changes', () => {
+    expect(mockStackRender).toHaveBeenCalledTimes(1);
+    renderer.act(() => { mockUseAuthStore.setState({ locations: ['location-1'] }); });
+    expect(mockStackRender).toHaveBeenCalledTimes(1);
+  });
+
+  test('still mounts subscriptions on sign-in and removes them on sign-out', () => {
+    expect(mockInventorySubscription).not.toHaveBeenCalled();
+    renderer.act(() => {
+      mockUseAuthStore.setState({ session: { user: { id: 'test-user' } } });
+    });
+    expect(mockInventorySubscription).toHaveBeenCalledTimes(1);
+    expect(mockOrderSubscription).toHaveBeenCalledTimes(1);
+    expect(mockStackRender).toHaveBeenCalledTimes(2);
+
+    renderer.act(() => { mockUseAuthStore.setState({ session: null }); });
+    expect(mockInventorySubscription).toHaveBeenCalledTimes(1);
+    expect(mockStackRender).toHaveBeenCalledTimes(3);
+    expect(mockInventoryCleanup).toHaveBeenCalledTimes(1);
+    expect(mockOrderCleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/simpleOrderCatalogSearch.test.ts
+++ b/src/__tests__/simpleOrderCatalogSearch.test.ts
@@ -1,4 +1,6 @@
 import {
+  buildCatalogSearchIndex,
+  filterCatalogSearchIndex,
   filterCatalogItems,
   mapVoiceActionsToAdditions,
 } from '@/features/simpleOrder/catalogSearch';
@@ -70,6 +72,41 @@ describe('filterCatalogItems', () => {
   it('respects the result limit', () => {
     const results = filterCatalogItems(catalog, 'salmon', 2);
     expect(results).toHaveLength(2);
+  });
+
+  it('indexes item text once across repeated queries', () => {
+    let nameReads = 0;
+    let aliasReads = 0;
+    const indexedCatalog = Array.from({ length: 40 }, (_, index) => {
+      const item = makeInventoryItem({ id: `indexed-${index}` });
+      Object.defineProperties(item, {
+        name: {
+          configurable: true,
+          enumerable: true,
+          get: () => {
+            nameReads += 1;
+            return `Ingredient ${index}`;
+          },
+        },
+        aliases: {
+          configurable: true,
+          enumerable: true,
+          get: () => {
+            aliasReads += 1;
+            return [`alias ${index}`];
+          },
+        },
+      });
+      return item;
+    });
+
+    const index = buildCatalogSearchIndex(indexedCatalog);
+    for (const query of ['ingredient', 'alias', 'ingredient 3', 'missing']) {
+      filterCatalogSearchIndex(index, query);
+    }
+
+    expect(nameReads).toBe(indexedCatalog.length);
+    expect(aliasReads).toBe(indexedCatalog.length);
   });
 });
 

--- a/src/__tests__/useScaledStylesPerformance.test.ts
+++ b/src/__tests__/useScaledStylesPerformance.test.ts
@@ -1,0 +1,125 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { PixelRatio } from 'react-native';
+import { useScaledStyles } from '@/hooks/useScaledStyles';
+import { useDisplayStore } from '@/store/displayStore';
+
+jest.mock('react-native', () => ({
+  PixelRatio: { getFontScale: jest.fn(() => 1) },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => undefined),
+    removeItem: jest.fn(async () => undefined),
+  },
+}));
+
+describe('useScaledStyles render behavior', () => {
+  beforeEach(() => {
+    jest.mocked(PixelRatio.getFontScale).mockReturnValue(1);
+    useDisplayStore.setState({
+      textScale: 1,
+      uiScale: 'default',
+      buttonSize: 'medium',
+      theme: 'system',
+      hapticFeedback: true,
+      reduceMotion: false,
+    });
+  });
+
+  test('keeps its return object stable across an unrelated parent render', () => {
+    const values: ReturnType<typeof useScaledStyles>[] = [];
+
+    function Probe({ tick }: { tick: number }) {
+      const value = useScaledStyles();
+      values.push(value);
+      return React.createElement('Probe', { tick });
+    }
+
+    let component!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      component = renderer.create(React.createElement(Probe, { tick: 0 }));
+    });
+    renderer.act(() => {
+      component.update(React.createElement(Probe, { tick: 1 }));
+    });
+
+    expect(values).toHaveLength(2);
+    expect(values[1]).toBe(values[0]);
+    renderer.act(() => component.unmount());
+  });
+
+  test('does not rerender when a display setting outside its return contract changes', () => {
+    let renderCount = 0;
+
+    function Probe() {
+      useScaledStyles();
+      renderCount += 1;
+      return React.createElement('Probe');
+    }
+
+    let component!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      component = renderer.create(React.createElement(Probe));
+    });
+    expect(renderCount).toBe(1);
+
+    renderer.act(() => {
+      useDisplayStore.getState().setHapticFeedback(false);
+    });
+
+    expect(renderCount).toBe(1);
+    renderer.act(() => component.unmount());
+  });
+
+  test('updates its identity and values for relevant display settings', () => {
+    const values: ReturnType<typeof useScaledStyles>[] = [];
+
+    function Probe() {
+      values.push(useScaledStyles());
+      return React.createElement('Probe');
+    }
+
+    let component!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      component = renderer.create(React.createElement(Probe));
+    });
+    renderer.act(() => {
+      useDisplayStore.getState().setButtonSize('small');
+    });
+
+    expect(values).toHaveLength(2);
+    expect(values[1]).not.toBe(values[0]);
+    expect(values[1].buttonH).toBe(40);
+    expect(values[1].buttonFont).toBe(13);
+    expect(values[1].buttonPadH).toBe(12);
+    renderer.act(() => component.unmount());
+  });
+
+  test('publishes a new identity after a runtime Dynamic Type change', () => {
+    const values: ReturnType<typeof useScaledStyles>[] = [];
+
+    function Probe({ tick }: { tick: number }) {
+      values.push(useScaledStyles());
+      return React.createElement('Probe', { tick });
+    }
+
+    let component!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      component = renderer.create(React.createElement(Probe, { tick: 0 }));
+    });
+    jest.mocked(PixelRatio.getFontScale).mockReturnValue(1.25);
+    expect(values[0].fontSize(16)).toBe(20);
+    renderer.act(() => {
+      component.update(React.createElement(Probe, { tick: 1 }));
+    });
+
+    expect(values).toHaveLength(2);
+    expect(values[1]).not.toBe(values[0]);
+    expect(values[1].fontSize(16)).toBe(20);
+    renderer.act(() => component.unmount());
+  });
+});

--- a/src/__tests__/userModules.test.ts
+++ b/src/__tests__/userModules.test.ts
@@ -136,4 +136,36 @@ describe('user modules service', () => {
     unsubscribe();
     expect(mockSupabase.removeChannel).toHaveBeenCalledWith(channel);
   });
+
+  it('subscribes with a known user id without another auth request', async () => {
+    const channel = {
+      on: jest.fn(),
+      subscribe: jest.fn(),
+    };
+    channel.on.mockReturnValue(channel);
+    channel.subscribe.mockReturnValue(channel);
+    mockSupabase.channel.mockReturnValue(channel);
+
+    subscribeToMyModules(jest.fn(), 'known-user-id');
+    await flushPromises();
+
+    expect(mockSupabase.auth.getUser).not.toHaveBeenCalled();
+    expect(mockSupabase.channel).toHaveBeenCalledWith(
+      'user-module-updates-known-user-id',
+    );
+  });
+
+  it('keeps known-user subscription setup best effort', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockSupabase.channel.mockImplementationOnce(() => {
+      throw new Error('realtime unavailable');
+    });
+
+    expect(() => subscribeToMyModules(jest.fn(), 'known-user-id')).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to subscribe to module updates',
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
 });

--- a/src/features/browse/BrowseInventoryScreenView.tsx
+++ b/src/features/browse/BrowseInventoryScreenView.tsx
@@ -177,6 +177,14 @@ export function BrowseInventoryScreenView({
         .sort((left, right) => left.name.localeCompare(right.name)),
     [activeLocationId, items],
   );
+  const browseSearchIndex = useMemo(
+    () =>
+      allItemsSorted.map((item) => ({
+        item,
+        normalizedName: item.name.toLowerCase(),
+      })),
+    [allItemsSorted],
+  );
   const dynamicCategories = useMemo(() => buildCategoryList(items), [items]);
   const sortedLocations = useMemo(
     () => [...locations].sort((a, b) => a.name.localeCompare(b.name)),
@@ -205,18 +213,18 @@ export function BrowseInventoryScreenView({
     [allItemsSorted, initialFocusItemId],
   );
 
-  const filteredBrowseItems = useMemo(
-    () =>
-      allItemsSorted.filter((item) => {
+  const filteredBrowseItems = useMemo(() => {
+    const normalizedSearch = browseSearchQuery.trim().toLowerCase();
+    return browseSearchIndex
+      .filter(({ item, normalizedName }) => {
         const matchesCategory =
           !browseCategory || item.category === browseCategory;
         const matchesSearch =
-          browseSearchQuery.trim().length === 0 ||
-          item.name.toLowerCase().includes(browseSearchQuery.trim().toLowerCase());
+          normalizedSearch.length === 0 || normalizedName.includes(normalizedSearch);
         return matchesCategory && matchesSearch;
-      }),
-    [allItemsSorted, browseCategory, browseSearchQuery],
-  );
+      })
+      .map(({ item }) => item);
+  }, [browseCategory, browseSearchIndex, browseSearchQuery]);
   const focusedBrowseItemIndex = useMemo(
     () =>
       initialFocusItemId

--- a/src/features/inventory/ManagerInventoryRow.tsx
+++ b/src/features/inventory/ManagerInventoryRow.tsx
@@ -1,0 +1,280 @@
+import React, { memo, useCallback } from 'react';
+import {
+  type GestureResponderEvent,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from '@/constants';
+import { useScaledStyles } from '@/hooks/useScaledStyles';
+import type { InventoryWithStock } from '@/lib/api/stock';
+
+export type ManagerInventoryStatus = 'critical' | 'low' | 'good';
+
+export type ManagerInventoryStockItem = InventoryWithStock & {
+  status: ManagerInventoryStatus;
+  overdue: boolean;
+  fillPercent: number;
+  areaLabel: string;
+};
+
+type ManagerInventoryRowProps = {
+  item: ManagerInventoryStockItem;
+  variant: 'list' | 'compact';
+  added: boolean;
+  isBulkMode: boolean;
+  isSelected: boolean;
+  onOpen: (item: ManagerInventoryStockItem) => void;
+  onEnterBulk: (item: ManagerInventoryStockItem) => void;
+  onToggleBulk: (itemId: string) => void;
+  onAddToReorder: (item: ManagerInventoryStockItem) => void;
+};
+
+const CATEGORY_EMOJI: Record<string, string> = {
+  fish: '🐟',
+  protein: '🥩',
+  produce: '🥬',
+  dry: '🍚',
+  dairy_cold: '🧊',
+  frozen: '❄️',
+  sauces: '🍶',
+  alcohol: '🍺',
+  packaging: '📦',
+};
+
+const STATUS_COLORS: Record<ManagerInventoryStatus, string> = {
+  critical: colors.error,
+  low: colors.warning,
+  good: colors.success,
+};
+
+function getRelativeTime(timestamp: string | null): string {
+  if (!timestamp) return 'Never updated';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return 'Never updated';
+  const diffMs = Date.now() - date.getTime();
+  const hours = Math.round(diffMs / (1000 * 60 * 60));
+  const days = Math.round(diffMs / (1000 * 60 * 60 * 24));
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+function ManagerInventoryRowInner({
+  item,
+  variant,
+  added,
+  isBulkMode,
+  isSelected,
+  onOpen,
+  onEnterBulk,
+  onToggleBulk,
+  onAddToReorder,
+}: ManagerInventoryRowProps) {
+  const ds = useScaledStyles();
+  const statusColor = STATUS_COLORS[item.status];
+  const reorderQty = Math.max(item.max_quantity - item.current_quantity, 0);
+
+  const handlePress = useCallback(() => {
+    if (isBulkMode) {
+      onToggleBulk(item.id);
+      return;
+    }
+    onOpen(item);
+  }, [isBulkMode, item, onOpen, onToggleBulk]);
+
+  const handleLongPress = useCallback(() => {
+    if (!isBulkMode) onEnterBulk(item);
+  }, [isBulkMode, item, onEnterBulk]);
+
+  const handleAddToReorder = useCallback(
+    (event: GestureResponderEvent) => {
+      event.stopPropagation();
+      onAddToReorder(item);
+    },
+    [item, onAddToReorder],
+  );
+
+  if (variant === 'compact') {
+    return (
+      <TouchableOpacity
+        activeOpacity={0.9}
+        className="bg-white border border-gray-100 rounded-2xl overflow-hidden"
+        style={{ marginBottom: ds.spacing(8) }}
+        onPress={handlePress}
+        onLongPress={handleLongPress}
+      >
+        <View
+          className="flex-row items-center"
+          style={{
+            paddingHorizontal: ds.spacing(16),
+            paddingVertical: ds.spacing(12),
+          }}
+        >
+          {isBulkMode ? (
+            <Ionicons
+              name={isSelected ? 'checkbox' : 'square-outline'}
+              size={ds.icon(18)}
+              color={isSelected ? colors.primary[500] : colors.gray[400]}
+              style={{ marginRight: ds.spacing(8) }}
+            />
+          ) : null}
+          <Text style={{ fontSize: ds.fontSize(18), marginRight: ds.spacing(8) }}>
+            {CATEGORY_EMOJI[item.inventory_item.category] ?? '📦'}
+          </Text>
+          <View className="flex-1">
+            <Text
+              className="font-semibold text-gray-900"
+              style={{ fontSize: ds.fontSize(14) }}
+              numberOfLines={1}
+            >
+              {item.inventory_item.name}
+            </Text>
+            <Text className="text-gray-500" style={{ fontSize: ds.fontSize(12) }}>
+              {item.current_quantity} / {item.max_quantity} {item.unit_type}
+            </Text>
+          </View>
+          <View className="flex-row items-center">
+            <View
+              className="rounded-full"
+              style={{
+                width: ds.spacing(10),
+                height: ds.spacing(10),
+                backgroundColor: statusColor,
+                marginRight: ds.spacing(8),
+              }}
+            />
+            {item.status === 'critical' && reorderQty > 0 && !isBulkMode ? (
+              <TouchableOpacity
+                className={`rounded-full items-center justify-center border ${added ? 'border-green-500' : 'border-orange-500'}`}
+                style={{
+                  width: Math.max(36, ds.icon(32)),
+                  height: Math.max(36, ds.icon(32)),
+                }}
+                onPress={handleAddToReorder}
+              >
+                <Ionicons
+                  name={added ? 'checkmark' : 'add'}
+                  size={ds.icon(16)}
+                  color={added ? colors.success : colors.primary[500]}
+                />
+              </TouchableOpacity>
+            ) : null}
+          </View>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+
+  const relativeTime = getRelativeTime(item.last_updated_at);
+  return (
+    <TouchableOpacity
+      activeOpacity={0.9}
+      style={{ marginBottom: ds.spacing(12) }}
+      onPress={handlePress}
+      onLongPress={handleLongPress}
+    >
+      <View
+        className="bg-white rounded-2xl border border-gray-100"
+        style={{
+          paddingHorizontal: ds.spacing(16),
+          paddingVertical: ds.spacing(14),
+          shadowColor: colors.background,
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.05,
+          shadowRadius: 2,
+          elevation: 1,
+        }}
+      >
+        <View className="flex-row items-start justify-between">
+          <View className="flex-row items-center flex-1" style={{ paddingRight: ds.spacing(8) }}>
+            {isBulkMode ? (
+              <Ionicons
+                name={isSelected ? 'checkbox' : 'square-outline'}
+                size={ds.icon(20)}
+                color={isSelected ? colors.primary[500] : colors.gray[400]}
+                style={{ marginRight: ds.spacing(8) }}
+              />
+            ) : null}
+            <Text style={{ fontSize: ds.fontSize(18), marginRight: ds.spacing(8) }}>
+              {CATEGORY_EMOJI[item.inventory_item.category] ?? '📦'}
+            </Text>
+            <Text
+              className="font-semibold text-gray-900"
+              style={{ fontSize: ds.fontSize(15) }}
+              numberOfLines={1}
+            >
+              {item.inventory_item.name}
+            </Text>
+          </View>
+          <View
+            className="rounded-full"
+            style={{
+              width: ds.spacing(10),
+              height: ds.spacing(10),
+              backgroundColor: statusColor,
+              marginTop: ds.spacing(4),
+            }}
+          />
+        </View>
+
+        <Text
+          className="text-gray-500"
+          style={{ fontSize: ds.fontSize(12), marginTop: ds.spacing(4) }}
+        >
+          {item.areaLabel} • {item.location.name}
+        </Text>
+
+        <View style={{ marginTop: ds.spacing(12) }}>
+          <View
+            className="rounded-full bg-gray-200 overflow-hidden"
+            style={{ height: ds.spacing(6) }}
+          >
+            <View
+              className="h-full rounded-full"
+              style={{ width: `${Math.round(item.fillPercent)}%`, backgroundColor: statusColor }}
+            />
+          </View>
+          <View className="flex-row justify-between" style={{ marginTop: ds.spacing(6) }}>
+            <Text className="text-gray-600" style={{ fontSize: ds.fontSize(12) }}>
+              {item.current_quantity} {item.unit_type}
+            </Text>
+            <Text className="text-gray-500" style={{ fontSize: ds.fontSize(12) }}>
+              Min {item.min_quantity} • Max {item.max_quantity}
+            </Text>
+          </View>
+        </View>
+
+        <View
+          className="flex-row items-center justify-between"
+          style={{ marginTop: ds.spacing(10) }}
+        >
+          <Text className="text-gray-400" style={{ fontSize: ds.fontSize(11) }}>
+            {relativeTime === 'Never updated' ? relativeTime : `Updated ${relativeTime}`}
+          </Text>
+          {item.status === 'critical' && reorderQty > 0 && !isBulkMode ? (
+            <TouchableOpacity
+              className={`rounded-full border ${added ? 'border-green-500' : 'border-orange-500'}`}
+              style={{
+                paddingHorizontal: ds.spacing(12),
+                paddingVertical: ds.spacing(6),
+                minHeight: Math.max(32, ds.icon(28)),
+                justifyContent: 'center',
+              }}
+              onPress={handleAddToReorder}
+            >
+              <Text
+                className={`font-semibold ${added ? 'text-green-600' : 'text-orange-600'}`}
+                style={{ fontSize: ds.fontSize(12) }}
+              >
+                {added ? '✓ Added' : `Reorder ${reorderQty}`}
+              </Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+export const ManagerInventoryRow = memo(ManagerInventoryRowInner);

--- a/src/features/inventory/managerInventorySelectors.ts
+++ b/src/features/inventory/managerInventorySelectors.ts
@@ -1,0 +1,13 @@
+import type { OrderState } from '@/store/orderStore.types';
+
+type ManagerInventoryOrderSource = Pick<
+  OrderState,
+  'addToCart' | 'getTotalCartCount'
+>;
+
+export function selectManagerInventoryOrderState(state: ManagerInventoryOrderSource) {
+  return {
+    addToCart: state.addToCart,
+    cartCount: state.getTotalCartCount('manager'),
+  };
+}

--- a/src/features/ordering/QuickOrderListCard.tsx
+++ b/src/features/ordering/QuickOrderListCard.tsx
@@ -1,10 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   ActivityIndicator,
   LayoutChangeEvent,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -13,6 +10,7 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import Animated, {
   Easing,
+  useAnimatedScrollHandler,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -127,7 +125,7 @@ export function QuickOrderListCard({
   onClear,
 }: QuickOrderListCardProps) {
   const ds = useScaledStyles();
-  const scrollRef = useRef<ScrollView | null>(null);
+  const scrollRef = useRef<React.ComponentRef<typeof Animated.ScrollView> | null>(null);
 
   const showLocationPill = Boolean(onToggleLocationDropdown && locationShortLabel);
   const sortedLocations = useMemo(
@@ -176,62 +174,51 @@ export function QuickOrderListCard({
   // native indicator fades out after scrolling stops, so we draw our own thumb
   // and keep it pinned. Seeded from onLayout / onContentSizeChange so the bar
   // is correct before the first scroll event.
-  const [scrollGeometry, setScrollGeometry] = useState({
-    offsetY: 0,
-    contentHeight: 0,
-    viewportHeight: 0,
+  const offsetY = useSharedValue(0);
+  const contentHeight = useSharedValue(0);
+  const viewportHeight = useSharedValue(0);
+
+  const handleScroll = useAnimatedScrollHandler((event) => {
+    offsetY.value = event.contentOffset.y;
+    contentHeight.value = event.contentSize.height;
+    viewportHeight.value = event.layoutMeasurement.height;
   });
 
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } =
-        event.nativeEvent;
-      setScrollGeometry({
-        offsetY: contentOffset.y,
-        contentHeight: contentSize.height,
-        viewportHeight: layoutMeasurement.height,
-      });
-    },
-    [],
-  );
-
   const handleScrollContentSizeChange = useCallback(
-    (_width: number, height: number) =>
-      setScrollGeometry((prev) => ({ ...prev, contentHeight: height })),
-    [],
+    (_width: number, height: number) => {
+      contentHeight.value = height;
+    },
+    [contentHeight],
   );
 
   const handleScrollViewLayout = useCallback(
-    (event: LayoutChangeEvent) =>
-      setScrollGeometry((prev) => ({
-        ...prev,
-        viewportHeight: event.nativeEvent.layout.height,
-      })),
-    [],
+    (event: LayoutChangeEvent) => {
+      viewportHeight.value = event.nativeEvent.layout.height;
+    },
+    [viewportHeight],
   );
 
   // Derive the custom scrollbar thumb geometry. We seed it from the known row
   // count (available on first render) and refine with measured values once the
   // ScrollView reports them, so the bar is visible immediately and stays
   // accurate as rows resize.
-  const viewportHeight =
-    scrollGeometry.viewportHeight > 0 ? scrollGeometry.viewportHeight : listMaxHeight;
-  const contentHeight = Math.max(
-    scrollGeometry.contentHeight,
-    count * rowSlot,
-  );
-  const offsetY = scrollGeometry.offsetY;
   const showScrollbar = scrollable;
-  const thumbHeight = Math.min(
-    viewportHeight,
-    Math.max(SCROLLBAR_MIN_THUMB, (viewportHeight * viewportHeight) / contentHeight),
-  );
-  const maxOffset = Math.max(0, contentHeight - viewportHeight);
-  const maxThumbTravel = Math.max(0, viewportHeight - thumbHeight);
-  const thumbTop =
-    maxOffset > 0
-      ? Math.min(maxThumbTravel, (offsetY / maxOffset) * maxThumbTravel)
-      : 0;
+  const scrollbarThumbStyle = useAnimatedStyle(() => {
+    const measuredViewportHeight =
+      viewportHeight.value > 0 ? viewportHeight.value : listMaxHeight;
+    const measuredContentHeight = Math.max(contentHeight.value, count * rowSlot);
+    const geometry = getScrollbarThumbGeometry({
+      viewportHeight: measuredViewportHeight,
+      contentHeight: measuredContentHeight,
+      offsetY: offsetY.value,
+      minThumbHeight: SCROLLBAR_MIN_THUMB,
+    });
+
+    return {
+      height: geometry.height,
+      transform: [{ translateY: geometry.top }],
+    };
+  }, [count, listMaxHeight, rowSlot]);
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) =>
@@ -405,7 +392,7 @@ export function QuickOrderListCard({
             </View>
           ) : (
             <View style={{ position: "relative" }}>
-              <ScrollView
+              <Animated.ScrollView
                 ref={scrollRef}
                 style={{ maxHeight: listMaxHeight }}
                 contentContainerStyle={{ paddingRight: ds.spacing(14) }}
@@ -430,7 +417,7 @@ export function QuickOrderListCard({
                     onRemove={() => onRemoveItems(group.items)}
                   />
                 ))}
-              </ScrollView>
+              </Animated.ScrollView>
               {showScrollbar ? (
                 <View
                   pointerEvents="none"
@@ -442,12 +429,11 @@ export function QuickOrderListCard({
                     },
                   ]}
                 >
-                  <View
+                  <Animated.View
                     style={[
                       styles.scrollbarThumb,
+                      scrollbarThumbStyle,
                       {
-                        height: thumbHeight,
-                        top: thumbTop,
                         borderRadius: ds.radius(SCROLLBAR_WIDTH),
                       },
                     ]}
@@ -536,6 +522,32 @@ export function QuickOrderListCard({
       </View>
     </View>
   );
+}
+
+export function getScrollbarThumbGeometry({
+  viewportHeight,
+  contentHeight,
+  offsetY,
+  minThumbHeight,
+}: {
+  viewportHeight: number;
+  contentHeight: number;
+  offsetY: number;
+  minThumbHeight: number;
+}): { height: number; top: number } {
+  'worklet';
+  if (viewportHeight <= 0 || contentHeight <= viewportHeight) {
+    return { height: Math.max(0, viewportHeight), top: 0 };
+  }
+
+  const height = Math.min(
+    viewportHeight,
+    Math.max(minThumbHeight, (viewportHeight * viewportHeight) / contentHeight),
+  );
+  const maxOffset = contentHeight - viewportHeight;
+  const maxTop = viewportHeight - height;
+  const top = Math.max(0, Math.min(maxTop, (offsetY / maxOffset) * maxTop));
+  return { height, top };
 }
 
 function groupOrderListItems(items: ParsedQuickOrderItem[]): OrderListGroup[] {

--- a/src/features/ordering/QuickOrderScreen.tsx
+++ b/src/features/ordering/QuickOrderScreen.tsx
@@ -117,6 +117,11 @@ import {
   toFriendlyQuickOrderError,
 } from "./quickOrderErrors";
 import {
+  applyQuickOrderCartUpdate,
+  normalizePersistedQuickOrderItems,
+  QUICK_ORDER_CART_APPLY_ERROR_CODE,
+} from "./quickOrderSendGuards";
+import {
   buildSendSnapDelays,
   calculateQuickOrderBottomScrollOffset,
   calculateQuickOrderBottomPadding,
@@ -162,7 +167,6 @@ import {
   getParsedItemDisplayName,
   getParsedItemIssue,
   getParsedItemKey,
-  hasParsedItemName,
   isUuid,
   mergeQuickOrderParsedItemsDetailed,
   removeParsedItem,
@@ -604,30 +608,12 @@ function devIdFingerprint(id: string | null | undefined): string | null {
   return devTextFingerprint(id);
 }
 
-function normalizeParsedItems(value: unknown): ParsedQuickOrderItem[] {
-  if (!Array.isArray(value)) return [];
-
-  return (
-    value
-      .map((entry) =>
-        entry && typeof entry === "object"
-          ? (entry as ParsedQuickOrderItem)
-          : null,
-      )
-      // Keep anything we can render a row for: a name, a raw token, or an id. A
-      // nameless item still gets a visible "Unknown item" row + issue indicator
-      // rather than being silently dropped.
-      .filter((entry): entry is ParsedQuickOrderItem =>
-        Boolean(
-          entry &&
-          (hasParsedItemName(entry) ||
-            entry.raw_token?.trim() ||
-            entry.raw_text?.trim() ||
-            entry.item_id),
-        ),
-      )
-  );
-}
+/**
+ * Rebuilds the parsed-item cart from persisted / message-embedded JSON. Lives
+ * in `quickOrderSendGuards` so a rehydrated row is normalized exactly like a
+ * freshly parsed one. See the note there about unresolved units.
+ */
+const normalizeParsedItems = normalizePersistedQuickOrderItems;
 
 function normalizeSuggestions(value: unknown): QuickOrderSuggestion[] {
   if (!Array.isArray(value)) return [];
@@ -3965,10 +3951,18 @@ export function QuickOrderScreen({ mode }: QuickOrderScreenProps) {
       // If the user typed a bare quantity ("1pk", "2 cases") and the most
       // recent item in the order is still missing a quantity, prepend that
       // item's name so the parser applies the quantity to the right line.
-      const rawText = rewriteBareQuantityWithContext(
-        rawTextInput,
-        parsedItems,
-      );
+      // A rehydrated cart can hold rows in states this rewrite has never seen,
+      // so a failure here falls back to the text the user typed rather than
+      // taking the whole screen down.
+      let rawText = rawTextInput;
+      try {
+        rawText = rewriteBareQuantityWithContext(rawTextInput, parsedItems);
+      } catch (rewriteError) {
+        console.warn(
+          "[QuickOrder] bare-quantity rewrite failed, sending the raw text:",
+          rewriteError,
+        );
+      }
       const trimmed = rawText.trim();
       if (!trimmed || isSendingRef.current || isSending) {
         return;
@@ -4307,13 +4301,14 @@ export function QuickOrderScreen({ mode }: QuickOrderScreenProps) {
           operationResult: QuickOrderOperationResult | null;
         };
 
-        let applySnapshot: ParseApplySnapshot | undefined;
-
-        setParsedItems((currentParsed) => {
-          if (requestGeneration !== requestGenerationRef.current) {
-            return currentParsed;
-          }
-
+        // React runs a state updater during the render phase, so anything this
+        // body throws reaches the screen's error boundary and replaces the whole
+        // surface (issue #70). It is computed here and committed through
+        // `applyQuickOrderCartUpdate`, which leaves the cart untouched and
+        // reports the failure as an inline error pill instead.
+        const computeParseApply = (
+          currentParsed: ParsedQuickOrderItem[],
+        ): { items: ParsedQuickOrderItem[]; snapshot: ParseApplySnapshot } => {
           let operationResult: QuickOrderOperationResult | null = null;
           let operationBase = currentParsed;
           if (operations.length > 0) {
@@ -4402,7 +4397,7 @@ export function QuickOrderScreen({ mode }: QuickOrderScreenProps) {
             }
           }
 
-          applySnapshot = {
+          const nextSnapshot: ParseApplySnapshot = {
             nextParsedItems: mergeResult.items,
             assistantMessage: {
               id: createMessageId(),
@@ -4433,8 +4428,39 @@ export function QuickOrderScreen({ mode }: QuickOrderScreenProps) {
             operationResult,
           };
 
-          return applySnapshot.nextParsedItems;
+          return { items: nextSnapshot.nextParsedItems, snapshot: nextSnapshot };
+        };
+
+        let applySnapshot: ParseApplySnapshot | undefined;
+        let applyError: unknown = null;
+
+        setParsedItems((currentParsed) => {
+          if (requestGeneration !== requestGenerationRef.current) {
+            return currentParsed;
+          }
+
+          const applied = applyQuickOrderCartUpdate(currentParsed, () =>
+            computeParseApply(currentParsed),
+          );
+          applySnapshot = applied.snapshot ?? undefined;
+          applyError = applied.error;
+          return applied.items;
         });
+
+        if (applyError) {
+          console.warn("[QuickOrder] cart_apply_failed:", applyError);
+          if (
+            activeSessionId &&
+            requestGeneration === requestGenerationRef.current
+          ) {
+            await appendErrorMessage(
+              optimisticMessages,
+              activeSessionId,
+              QUICK_ORDER_CART_APPLY_ERROR_CODE,
+            );
+          }
+          return;
+        }
 
         if (!applySnapshot || requestGeneration !== requestGenerationRef.current) {
           return;

--- a/src/features/ordering/quickOrderErrors.ts
+++ b/src/features/ordering/quickOrderErrors.ts
@@ -22,6 +22,8 @@ export const QUICK_ORDER_ERROR_MESSAGES: Record<string, string> = {
   auth_failed: 'Please sign in again to use Quick Order.',
   network_error: "Couldn't reach the server. Check your connection and try again.",
   schema_validation_failed: 'I had trouble processing the result. Please try again.',
+  cart_apply_failed:
+    "I couldn't add that to your order list. Your items are unchanged. Fix any item marked in amber, then try again.",
 };
 
 /** Generic fallback when nothing more specific is known. */

--- a/src/features/ordering/quickOrderSendGuards.ts
+++ b/src/features/ordering/quickOrderSendGuards.ts
@@ -1,0 +1,95 @@
+/**
+ * Guards for the Advanced ordering composer send path.
+ *
+ * The Advanced ordering screen is wrapped in an `ErrorBoundary`, which catches
+ * errors thrown during render and commit. The composer send path does two
+ * things that run in exactly those phases:
+ *
+ *   1. It seeds `parsedItems` from `quick_order_sessions.parsed_items` after a
+ *      cold launch. Those rows are raw persisted JSON, so unlike freshly parsed
+ *      rows they never went through `normalizeQuickOrderItemForDisplay` and can
+ *      carry a stale `status` / `action` next to an unresolved unit.
+ *   2. It applies the parse result inside a `setParsedItems` updater, which
+ *      React invokes during the render phase.
+ *
+ * Both are handled here so a cart row with no resolved unit can only ever
+ * produce a visible resolve prompt or a visible inline error, never an
+ * unhandled throw that unmounts the screen into the error boundary.
+ */
+
+import {
+  hasParsedItemName,
+  normalizeQuickOrderItemForDisplay,
+  type ParsedQuickOrderItem,
+} from './quickOrderItems';
+
+/** Error code used for the inline pill when the cart update itself fails. */
+export const QUICK_ORDER_CART_APPLY_ERROR_CODE = 'cart_apply_failed';
+
+/**
+ * Rebuilds the parsed-item cart from a persisted `parsed_items` payload.
+ *
+ * Anything we can render a row for is kept: a name, a raw token, or an
+ * inventory id. A nameless row still gets a visible "Unknown item" row plus an
+ * issue indicator rather than being silently dropped.
+ *
+ * Every surviving row is then run through
+ * {@link normalizeQuickOrderItemForDisplay}, the same pass every freshly parsed
+ * row goes through. That is what guarantees a rehydrated row with an unresolved
+ * unit carries `status: 'missing_unit'` and `action: 'Choose unit'` — a visible
+ * resolve prompt — instead of whatever stale shape happened to be persisted.
+ */
+export function normalizePersistedQuickOrderItems(
+  value: unknown,
+): ParsedQuickOrderItem[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((entry) =>
+      entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? (entry as ParsedQuickOrderItem)
+        : null,
+    )
+    .filter((entry): entry is ParsedQuickOrderItem =>
+      Boolean(
+        entry &&
+          (hasParsedItemName(entry) ||
+            entry.raw_token?.trim() ||
+            entry.raw_text?.trim() ||
+            entry.item_id),
+      ),
+    )
+    .map((entry) => normalizeQuickOrderItemForDisplay(entry));
+}
+
+/** Outcome of a guarded cart update. `error` is null on success. */
+export type QuickOrderCartApplyResult<TSnapshot> = {
+  /** The cart to commit: the computed one on success, the current one on failure. */
+  items: ParsedQuickOrderItem[];
+  /** Everything the caller needs after a successful apply, or null on failure. */
+  snapshot: TSnapshot | null;
+  error: unknown;
+};
+
+/**
+ * Runs the body of a `setParsedItems` updater inside a try/catch.
+ *
+ * React calls state updaters during render, so a throw in there reaches the
+ * screen's error boundary and replaces the whole surface. Instead this returns
+ * the cart unchanged and hands the error back to the caller, which surfaces it
+ * as an inline error pill the user can retry from.
+ */
+export function applyQuickOrderCartUpdate<TSnapshot>(
+  current: ParsedQuickOrderItem[],
+  compute: () => { items: ParsedQuickOrderItem[]; snapshot: TSnapshot },
+): QuickOrderCartApplyResult<TSnapshot> {
+  try {
+    const result = compute();
+    if (!Array.isArray(result.items)) {
+      return { items: current, snapshot: null, error: new Error('Cart update produced no items.') };
+    }
+    return { items: result.items, snapshot: result.snapshot, error: null };
+  } catch (error) {
+    return { items: current, snapshot: null, error: error ?? new Error('Cart update failed.') };
+  }
+}

--- a/src/features/simpleOrder/SimpleOrderScreen.tsx
+++ b/src/features/simpleOrder/SimpleOrderScreen.tsx
@@ -60,7 +60,11 @@ import {
 } from './checklistSelection';
 import { buildDirectSendLines } from './directSendFlow';
 import { deriveDisplaySections, type DisplaySection } from './displaySections';
-import { filterCatalogItems, type VoiceAddition } from './catalogSearch';
+import {
+  buildCatalogSearchIndex,
+  filterCatalogSearchIndex,
+  type VoiceAddition,
+} from './catalogSearch';
 import { unitOptionsForLine } from './unitOptions';
 import { ChecklistItemRow } from './components/ChecklistItemRow';
 import { ChecklistSettingsSheet } from './components/ChecklistSettingsSheet';
@@ -278,9 +282,14 @@ export function SimpleOrderScreen() {
     [inventoryItems, location?.id],
   );
 
+  const catalogSearchIndex = useMemo(
+    () => buildCatalogSearchIndex(searchableItems),
+    [searchableItems],
+  );
+
   const searchResults = useMemo(
-    () => filterCatalogItems(searchableItems, searchQuery),
-    [searchQuery, searchableItems],
+    () => filterCatalogSearchIndex(catalogSearchIndex, searchQuery),
+    [catalogSearchIndex, searchQuery],
   );
 
   const handleVoiceApply = useCallback(

--- a/src/features/simpleOrder/catalogSearch.ts
+++ b/src/features/simpleOrder/catalogSearch.ts
@@ -16,13 +16,22 @@ function normalize(value: string): string {
   return value.trim().toLowerCase();
 }
 
-/**
- * Filters the full inventory catalog by name or alias. Name-prefix matches
- * rank ahead of name substring matches, which rank ahead of alias matches,
- * preserving catalog order within each tier.
- */
-export function filterCatalogItems(
-  items: InventoryItem[],
+export interface CatalogSearchEntry {
+  item: InventoryItem;
+  normalizedName: string;
+  normalizedAliases: string[];
+}
+
+export function buildCatalogSearchIndex(items: InventoryItem[]): CatalogSearchEntry[] {
+  return items.map((item) => ({
+    item,
+    normalizedName: normalize(item.name),
+    normalizedAliases: (item.aliases ?? []).map(normalize),
+  }));
+}
+
+export function filterCatalogSearchIndex(
+  index: CatalogSearchEntry[],
   query: string,
   limit: number = MAX_SEARCH_RESULTS,
 ): InventoryItem[] {
@@ -33,21 +42,33 @@ export function filterCatalogItems(
   const substring: InventoryItem[] = [];
   const alias: InventoryItem[] = [];
 
-  for (const item of items) {
-    const name = normalize(item.name);
-    if (name.startsWith(normalized)) {
-      prefix.push(item);
-    } else if (name.includes(normalized)) {
-      substring.push(item);
+  for (const entry of index) {
+    if (entry.normalizedName.startsWith(normalized)) {
+      prefix.push(entry.item);
+    } else if (entry.normalizedName.includes(normalized)) {
+      substring.push(entry.item);
     } else if (
-      (item.aliases ?? []).some((entry) => normalize(entry).includes(normalized))
+      entry.normalizedAliases.some((value) => value.includes(normalized))
     ) {
-      alias.push(item);
+      alias.push(entry.item);
     }
     if (prefix.length >= limit) break;
   }
 
   return [...prefix, ...substring, ...alias].slice(0, limit);
+}
+
+/**
+ * Filters the full inventory catalog by name or alias. Name-prefix matches
+ * rank ahead of name substring matches, which rank ahead of alias matches,
+ * preserving catalog order within each tier.
+ */
+export function filterCatalogItems(
+  items: InventoryItem[],
+  query: string,
+  limit: number = MAX_SEARCH_RESULTS,
+): InventoryItem[] {
+  return filterCatalogSearchIndex(buildCatalogSearchIndex(items), query, limit);
 }
 
 export interface VoiceAddition {

--- a/src/hooks/useScaledStyles.ts
+++ b/src/hooks/useScaledStyles.ts
@@ -1,29 +1,85 @@
-import { useDisplayStore } from '@/store/displayStore';
+import { useCallback, useMemo } from 'react';
+import { PixelRatio } from 'react-native';
+import { useShallow } from 'zustand/react/shallow';
+import { computeScaledFontSize, useDisplayStore } from '@/store/displayStore';
 
 export function useScaledStyles() {
-  const store = useDisplayStore();
+  const {
+    scaledSpacing,
+    scaledRadius,
+    iconSize,
+    buttonH,
+    buttonFont,
+    buttonPadH,
+    cardPad,
+    rowH,
+    textScale,
+    uiScale,
+    reduceMotion,
+    theme,
+  } = useDisplayStore(
+    useShallow((store) => ({
+      scaledSpacing: store.scaledSpacing,
+      scaledRadius: store.scaledRadius,
+      iconSize: store.iconSize,
+      buttonH: store.buttonHeight(),
+      buttonFont: store.buttonFontSize(),
+      buttonPadH: store.buttonPaddingH(),
+      cardPad: store.cardPadding(),
+      rowH: store.itemRowHeight(),
+      textScale: store.textScale,
+      uiScale: store.uiScale,
+      reduceMotion: store.reduceMotion,
+      theme: store.theme,
+    })),
+  );
+  const systemFontScale = PixelRatio.getFontScale();
+  const fontSize = useCallback(
+    (basePx: number) => computeScaledFontSize(basePx, textScale, uiScale),
+    // PixelRatio is not observable. This invalidates memoized styles on the next render,
+    // while computeScaledFontSize still reads the current value at call time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [systemFontScale, textScale, uiScale],
+  );
 
-  return {
-    // Scaling functions
-    fontSize: store.scaledFontSize,
-    spacing: store.scaledSpacing,
-    radius: store.scaledRadius,
-    icon: store.iconSize,
+  return useMemo(
+    () => ({
+      // Scaling functions
+      fontSize,
+      spacing: scaledSpacing,
+      radius: scaledRadius,
+      icon: iconSize,
 
-    // Button values
-    buttonH: store.buttonHeight(),
-    buttonFont: store.buttonFontSize(),
-    buttonPadH: store.buttonPaddingH(),
+      // Button values
+      buttonH,
+      buttonFont,
+      buttonPadH,
 
-    // Layout values
-    cardPad: store.cardPadding(),
-    rowH: store.itemRowHeight(),
+      // Layout values
+      cardPad,
+      rowH,
 
-    // Raw values for direct access
-    textScale: store.textScale,
-    isLarge: store.uiScale === 'large',
-    isCompact: store.uiScale === 'compact',
-    reduceMotion: store.reduceMotion,
-    theme: store.theme,
-  };
+      // Raw values for direct access
+      textScale,
+      isLarge: uiScale === 'large',
+      isCompact: uiScale === 'compact',
+      reduceMotion,
+      theme,
+    }),
+    [
+      buttonFont,
+      buttonH,
+      buttonPadH,
+      cardPad,
+      fontSize,
+      iconSize,
+      reduceMotion,
+      scaledRadius,
+      scaledSpacing,
+      rowH,
+      textScale,
+      theme,
+      uiScale,
+    ],
+  );
 }

--- a/src/lib/equalityGatedJSONStorage.ts
+++ b/src/lib/equalityGatedJSONStorage.ts
@@ -2,13 +2,21 @@ import {
   createJSONStorage,
   type PersistStorage,
   type StateStorage,
+  type StorageValue,
 } from 'zustand/middleware';
 
-interface StoredKey<Key> {
+interface StoredKey<State, Key> {
   revision: number;
   persisted: PersistIdentity<Key> | null;
-  pending: {
+  inFlight: {
     identity: PersistIdentity<Key>;
+    promise: Promise<unknown>;
+  } | null;
+  queued: {
+    identity: PersistIdentity<Key>;
+    value: StorageValue<State>;
+    resolve: (result: unknown) => void;
+    reject: (error: unknown) => void;
     promise: Promise<unknown>;
   } | null;
 }
@@ -20,8 +28,11 @@ interface PersistIdentity<Key> {
 
 /**
  * JSON persistence that avoids serialization and native writes while the
- * selected persisted value is unchanged. Writes still start immediately when
- * that value changes, and failed writes remain eligible for retry.
+ * selected persisted value is unchanged. Writes for one storage name are
+ * serialized: while a native write is in flight, the newest requested value
+ * waits and is written once the in-flight write settles, so the last value
+ * on disk is always the newest one requested. Failed writes remain eligible
+ * for retry.
  */
 export function createEqualityGatedJSONStorage<State, Key>(
   getStorage: () => StateStorage,
@@ -31,21 +42,78 @@ export function createEqualityGatedJSONStorage<State, Key>(
   const jsonStorage = createJSONStorage<State>(getStorage);
   if (!jsonStorage) return undefined;
 
-  const keysByStorageName = new Map<string, StoredKey<Key>>();
+  const keysByStorageName = new Map<string, StoredKey<State, Key>>();
   const identitiesEqual = (
     left: PersistIdentity<Key>,
     right: PersistIdentity<Key>,
   ): boolean => left.version === right.version && equals(left.key, right.key);
-  const getStoredKey = (name: string): StoredKey<Key> => {
+  const getStoredKey = (name: string): StoredKey<State, Key> => {
     const existing = keysByStorageName.get(name);
     if (existing) return existing;
-    const created: StoredKey<Key> = {
+    const created: StoredKey<State, Key> = {
       revision: 0,
       persisted: null,
-      pending: null,
+      inFlight: null,
+      queued: null,
     };
     keysByStorageName.set(name, created);
     return created;
+  };
+
+  const startWrite = (
+    name: string,
+    storedKey: StoredKey<State, Key>,
+    identity: PersistIdentity<Key>,
+    value: StorageValue<State>,
+  ): Promise<unknown> => {
+    const previousRevision = storedKey.revision;
+    storedKey.revision = previousRevision + 1;
+
+    let write: unknown | Promise<unknown>;
+    try {
+      write = jsonStorage.setItem(name, value);
+    } catch (error) {
+      storedKey.revision = previousRevision;
+      throw error;
+    }
+
+    const promise = Promise.resolve(write).then(
+      (result) => {
+        storedKey.persisted = identity;
+        storedKey.inFlight = null;
+        drainQueue(name, storedKey);
+        return result;
+      },
+      (error: unknown) => {
+        storedKey.inFlight = null;
+        drainQueue(name, storedKey);
+        throw error;
+      },
+    );
+
+    storedKey.inFlight = { identity, promise };
+    return promise;
+  };
+
+  const drainQueue = (name: string, storedKey: StoredKey<State, Key>) => {
+    const queued = storedKey.queued;
+    if (!queued) return;
+    storedKey.queued = null;
+    if (
+      storedKey.persisted &&
+      identitiesEqual(storedKey.persisted, queued.identity)
+    ) {
+      queued.resolve(undefined);
+      return;
+    }
+    try {
+      startWrite(name, storedKey, queued.identity, queued.value).then(
+        queued.resolve,
+        queued.reject,
+      );
+    } catch (error) {
+      queued.reject(error);
+    }
   };
 
   return {
@@ -75,48 +143,33 @@ export function createEqualityGatedJSONStorage<State, Key>(
         version: value.version,
       };
 
-      if (
-        storedKey.pending &&
-        identitiesEqual(storedKey.pending.identity, nextIdentity)
-      ) {
-        return storedKey.pending.promise;
-      }
-      if (!storedKey.pending && storedKey.persisted) {
-        if (identitiesEqual(storedKey.persisted, nextIdentity)) return;
+      if (storedKey.queued) {
+        // Only the newest requested value is written after the in-flight
+        // write settles. Earlier queued values are superseded.
+        storedKey.queued.identity = nextIdentity;
+        storedKey.queued.value = value;
+        return storedKey.queued.promise;
       }
 
-      const previousRevision = storedKey.revision;
-      const revision = previousRevision + 1;
-      storedKey.revision = revision;
-
-      let write: unknown | Promise<unknown>;
-      try {
-        write = jsonStorage.setItem(name, value);
-      } catch (error) {
-        storedKey.revision = previousRevision;
-        throw error;
+      if (storedKey.inFlight) {
+        if (identitiesEqual(storedKey.inFlight.identity, nextIdentity)) {
+          return storedKey.inFlight.promise;
+        }
+        let resolve!: (result: unknown) => void;
+        let reject!: (error: unknown) => void;
+        const promise = new Promise<unknown>((done, fail) => {
+          resolve = done;
+          reject = fail;
+        });
+        storedKey.queued = { identity: nextIdentity, value, resolve, reject, promise };
+        return promise;
       }
 
-      const promise = Promise.resolve(write).then(
-        (result) => {
-          // Track the last write that actually completed. If writes finish out
-          // of order, the next state update repairs storage from that result.
-          storedKey.persisted = nextIdentity;
-          if (storedKey.revision === revision) {
-            storedKey.pending = null;
-          }
-          return result;
-        },
-        (error: unknown) => {
-          if (storedKey.revision === revision) {
-            storedKey.pending = null;
-          }
-          throw error;
-        },
-      );
+      if (storedKey.persisted && identitiesEqual(storedKey.persisted, nextIdentity)) {
+        return;
+      }
 
-      storedKey.pending = { identity: nextIdentity, promise };
-      return promise;
+      return startWrite(name, storedKey, nextIdentity, value);
     },
 
     removeItem: (name) => {

--- a/src/lib/equalityGatedJSONStorage.ts
+++ b/src/lib/equalityGatedJSONStorage.ts
@@ -1,0 +1,127 @@
+import {
+  createJSONStorage,
+  type PersistStorage,
+  type StateStorage,
+} from 'zustand/middleware';
+
+interface StoredKey<Key> {
+  revision: number;
+  persisted: PersistIdentity<Key> | null;
+  pending: {
+    identity: PersistIdentity<Key>;
+    promise: Promise<unknown>;
+  } | null;
+}
+
+interface PersistIdentity<Key> {
+  key: Key;
+  version: number | undefined;
+}
+
+/**
+ * JSON persistence that avoids serialization and native writes while the
+ * selected persisted value is unchanged. Writes still start immediately when
+ * that value changes, and failed writes remain eligible for retry.
+ */
+export function createEqualityGatedJSONStorage<State, Key>(
+  getStorage: () => StateStorage,
+  selectKey: (state: State) => Key,
+  equals: (left: Key, right: Key) => boolean = Object.is,
+): PersistStorage<State> | undefined {
+  const jsonStorage = createJSONStorage<State>(getStorage);
+  if (!jsonStorage) return undefined;
+
+  const keysByStorageName = new Map<string, StoredKey<Key>>();
+  const identitiesEqual = (
+    left: PersistIdentity<Key>,
+    right: PersistIdentity<Key>,
+  ): boolean => left.version === right.version && equals(left.key, right.key);
+  const getStoredKey = (name: string): StoredKey<Key> => {
+    const existing = keysByStorageName.get(name);
+    if (existing) return existing;
+    const created: StoredKey<Key> = {
+      revision: 0,
+      persisted: null,
+      pending: null,
+    };
+    keysByStorageName.set(name, created);
+    return created;
+  };
+
+  return {
+    getItem: async (name) => {
+      const storedKey = getStoredKey(name);
+      const revision = storedKey.revision;
+      const value = await jsonStorage.getItem(name);
+
+      if (storedKey.revision === revision) {
+        if (value) {
+          storedKey.persisted = {
+            key: selectKey(value.state),
+            version: value.version,
+          };
+        } else {
+          storedKey.persisted = null;
+        }
+      }
+
+      return value;
+    },
+
+    setItem: (name, value) => {
+      const storedKey = getStoredKey(name);
+      const nextIdentity: PersistIdentity<Key> = {
+        key: selectKey(value.state),
+        version: value.version,
+      };
+
+      if (
+        storedKey.pending &&
+        identitiesEqual(storedKey.pending.identity, nextIdentity)
+      ) {
+        return storedKey.pending.promise;
+      }
+      if (!storedKey.pending && storedKey.persisted) {
+        if (identitiesEqual(storedKey.persisted, nextIdentity)) return;
+      }
+
+      const previousRevision = storedKey.revision;
+      const revision = previousRevision + 1;
+      storedKey.revision = revision;
+
+      let write: unknown | Promise<unknown>;
+      try {
+        write = jsonStorage.setItem(name, value);
+      } catch (error) {
+        storedKey.revision = previousRevision;
+        throw error;
+      }
+
+      const promise = Promise.resolve(write).then(
+        (result) => {
+          // Track the last write that actually completed. If writes finish out
+          // of order, the next state update repairs storage from that result.
+          storedKey.persisted = nextIdentity;
+          if (storedKey.revision === revision) {
+            storedKey.pending = null;
+          }
+          return result;
+        },
+        (error: unknown) => {
+          if (storedKey.revision === revision) {
+            storedKey.pending = null;
+          }
+          throw error;
+        },
+      );
+
+      storedKey.pending = { identity: nextIdentity, promise };
+      return promise;
+    },
+
+    removeItem: (name) => {
+      keysByStorageName.delete(name);
+      return jsonStorage.removeItem(name);
+    },
+  };
+}

--- a/src/services/userModules.ts
+++ b/src/services/userModules.ts
@@ -1,3 +1,4 @@
+import type { RealtimeChannel } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
 
 const MODULE_KEYS = [
@@ -88,15 +89,16 @@ export async function setUserModule(
   }
 }
 
-export function subscribeToMyModules(onChange: () => void): () => void {
+export function subscribeToMyModules(
+  onChange: () => void,
+  knownUserId?: string,
+): () => void {
   let disposed = false;
-  let channel: any = null;
+  let channel: RealtimeChannel | null = null;
 
-  void (async () => {
+  const subscribe = (userId: string) => {
+    if (disposed) return;
     try {
-      const userId = await getCurrentUserId();
-      if (disposed) return;
-
       channel = supabase
         .channel(`user-module-updates-${userId}`)
         .on(
@@ -113,7 +115,20 @@ export function subscribeToMyModules(onChange: () => void): () => void {
     } catch (error) {
       console.error('Failed to subscribe to module updates', error);
     }
-  })();
+  };
+
+  if (knownUserId) {
+    subscribe(knownUserId);
+  } else {
+    void (async () => {
+      try {
+        const userId = await getCurrentUserId();
+        subscribe(userId);
+      } catch (error) {
+        console.error('Failed to subscribe to module updates', error);
+      }
+    })();
+  }
 
   return () => {
     disposed = true;

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -32,6 +32,11 @@ const SUSPENDED_ACCOUNT_MESSAGE = 'Account suspended. Contact a manager.';
 let activeSessionUserId: string | null = null;
 let userScopedResetPromise: Promise<void> | null = null;
 let authStateTransitionId = 0;
+interface LocationRequest {
+  transitionId: number;
+  promise: Promise<Location[]>;
+}
+let activeLocationRequest: LocationRequest | null = null;
 let identityRepairRpcAvailable: boolean | null = null;
 let warnedIdentityRepairRpcUnavailable = false;
 let explicitSignOutInProgress = false;
@@ -531,7 +536,7 @@ async function clearUserScopedClientState() {
       const [
         { useOrderStore, invalidatePendingOrderRequests },
         { useDraftStore },
-        { useInventoryStore },
+        { useInventoryStore, invalidatePendingInventoryRequests },
         { useStockStore, invalidatePendingStockRequests },
         { useFulfillmentStore },
         { useTunaSpecialistStore },
@@ -545,6 +550,7 @@ async function clearUserScopedClientState() {
       ]);
 
       invalidatePendingOrderRequests();
+      invalidatePendingInventoryRequests();
       invalidatePendingStockRequests();
       await Promise.all([
         resetPersistedStore('order-storage', useOrderStore as unknown as PersistedStoreApi),
@@ -1194,15 +1200,36 @@ export const useAuthStore = create<AuthState>()(
       setViewMode: (mode) => set({ viewMode: mode }),
 
       fetchLocations: async () => {
-        const { data } = await supabase
-          .from('locations')
-          .select('*')
-          .eq('active', true)
-          .order('name');
+        const transitionId = authStateTransitionId;
+        if (activeLocationRequest?.transitionId === transitionId) {
+          return activeLocationRequest.promise;
+        }
 
-        const locations = data || [];
-        set({ locations });
-        return locations;
+        const request: LocationRequest = {
+          transitionId,
+          promise: Promise.resolve([]),
+        };
+        activeLocationRequest = request;
+        request.promise = Promise.resolve()
+          .then(async () => {
+            const { data } = await supabase
+              .from('locations')
+              .select('*')
+              .eq('active', true)
+              .order('name');
+
+            if (transitionId !== authStateTransitionId) return [];
+            const locations = data || [];
+            set({ locations });
+            return locations;
+          })
+          .finally(() => {
+            if (activeLocationRequest === request) {
+              activeLocationRequest = null;
+            }
+          });
+
+        return request.promise;
       },
 
       fetchProfile: async () => {

--- a/src/store/displayStore.ts
+++ b/src/store/displayStore.ts
@@ -59,6 +59,19 @@ const ITEM_ROW_HEIGHT: Record<UIScale, number> = {
   large: 84,
 };
 
+export function computeScaledFontSize(
+  basePx: number,
+  textScale: TextScale,
+  uiScale: UIScale,
+  systemScale: number = PixelRatio.getFontScale(),
+): number {
+  const combinedTextScale = Math.min(textScale * systemScale, 2.0);
+  const uiMult = UI_FONT_MULTIPLIER[uiScale];
+  const raw = basePx * combinedTextScale * uiMult;
+  const max = basePx > 20 ? 36 : 24;
+  return Math.round(Math.max(10, Math.min(raw, max)));
+}
+
 interface DisplayState {
   // Raw settings
   textScale: TextScale;
@@ -110,12 +123,7 @@ export const useDisplayStore = create<DisplayState>()(
       // Helper to compute font size with system Dynamic Type integration
       const computeScaledFont = (basePx: number): number => {
         const { textScale, uiScale } = get();
-        const systemScale = PixelRatio.getFontScale();
-        const combinedTextScale = Math.min(textScale * systemScale, 2.0);
-        const uiMult = UI_FONT_MULTIPLIER[uiScale];
-        const raw = basePx * combinedTextScale * uiMult;
-        const max = basePx > 20 ? 36 : 24;
-        return Math.round(Math.max(10, Math.min(raw, max)));
+        return computeScaledFontSize(basePx, textScale, uiScale);
       };
 
       const computeScaledSpacing = (basePx: number): number => {

--- a/src/store/helpers/cartHelpers.ts
+++ b/src/store/helpers/cartHelpers.ts
@@ -148,8 +148,27 @@ export function normalizeLocationCart(rawCart: unknown, locationId = 'unknown'):
     .filter((item): item is CartItem => Boolean(item));
 }
 
+const EMPTY_LOCATION_CART: CartItem[] = [];
+Object.freeze(EMPTY_LOCATION_CART);
+const normalizedLocationCartCache = new WeakMap<CartItem[], Map<string, CartItem[]>>();
+
 export function getLocationCart(cartByLocation: CartByLocation, locationId: string): CartItem[] {
-  return normalizeLocationCart(cartByLocation[locationId] || [], locationId);
+  const rawCart = cartByLocation[locationId];
+  if (!rawCart) return EMPTY_LOCATION_CART;
+
+  const cachedByLocation = normalizedLocationCartCache.get(rawCart);
+  const cached = cachedByLocation?.get(locationId);
+  if (cached) return cached;
+
+  const normalized = normalizeLocationCart(rawCart, locationId);
+  normalized.forEach((item) => Object.freeze(item));
+  Object.freeze(normalized);
+  if (cachedByLocation) {
+    cachedByLocation.set(locationId, normalized);
+  } else {
+    normalizedLocationCartCache.set(rawCart, new Map([[locationId, normalized]]));
+  }
+  return normalized;
 }
 
 export function normalizeCartByLocation(rawCartByLocation: unknown): CartByLocation {

--- a/src/store/inventoryStore.ts
+++ b/src/store/inventoryStore.ts
@@ -1,9 +1,10 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { InventoryItem, ItemCategory, SupplierCategory } from '@/types';
 import { supabase } from '@/lib/supabase';
 import { listInventory } from '@/lib/api/client';
+import { createEqualityGatedJSONStorage } from '@/lib/equalityGatedJSONStorage';
 import { normalizeInventoryItemUnits } from '@/lib/inventoryUnits';
 
 export interface NewInventoryItem {
@@ -41,6 +42,7 @@ interface InventoryState {
 
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 const INVENTORY_FETCH_LIMIT = 5000;
+const MAX_CACHED_ITEMS = 2000;
 const SESSION_EXPIRED_MESSAGE = 'Session expired. Please sign in again.';
 const DIRECT_INVENTORY_OPTIONAL_COLUMNS = ['supplier_id', 'location_id', 'created_by'] as const;
 
@@ -115,6 +117,44 @@ function mapDirectInventoryRow(row: DirectInventoryRow): InventoryItem {
   };
 }
 
+interface InventoryRequest {
+  generation: number;
+  followUpRequested: boolean;
+  promise: Promise<void> | null;
+}
+
+let inventoryRequestGeneration = 0;
+let activeInventoryRequest: InventoryRequest | null = null;
+
+interface PersistedInventoryState {
+  items: InventoryItem[];
+}
+
+let lastPartializedItemsSource: InventoryItem[] | null = null;
+let lastPartializedItems: InventoryItem[] = [];
+
+function partializeInventoryState(state: InventoryState): PersistedInventoryState {
+  if (lastPartializedItemsSource !== state.items) {
+    lastPartializedItemsSource = state.items;
+    lastPartializedItems =
+      state.items.length > MAX_CACHED_ITEMS
+        ? state.items.slice(0, MAX_CACHED_ITEMS)
+        : state.items;
+  }
+  return { items: lastPartializedItems };
+}
+
+const inventoryStorage = createEqualityGatedJSONStorage<
+  PersistedInventoryState,
+  InventoryItem[]
+>(() => AsyncStorage, (state) => state.items);
+
+/** Prevent an earlier account's request from joining or publishing after reset. */
+export function invalidatePendingInventoryRequests(): void {
+  inventoryRequestGeneration += 1;
+  activeInventoryRequest = null;
+}
+
 async function listInventoryDirect(options?: {
   limit?: number;
 }): Promise<InventoryItem[]> {
@@ -181,6 +221,13 @@ export const useInventoryStore = create<InventoryState>()(
 
       fetchItems: async (options) => {
         const force = options?.force === true;
+        const requestGeneration = inventoryRequestGeneration;
+        const activeRequest = activeInventoryRequest;
+        if (activeRequest?.generation === requestGeneration && activeRequest.promise) {
+          if (force) activeRequest.followUpRequested = true;
+          return activeRequest.promise;
+        }
+
         const { lastFetched, items, hasFetchedThisSession } = get();
 
         if (!force && hasFetchedThisSession && lastFetched && items.length > 0) {
@@ -190,73 +237,102 @@ export const useInventoryStore = create<InventoryState>()(
           }
         }
 
-        set({ isLoading: true, error: null });
-        try {
-          const result = await listInventory({
-            limit: INVENTORY_FETCH_LIMIT,
-          });
-          let resolvedItems = result.data ?? null;
+        const request: InventoryRequest = {
+          generation: requestGeneration,
+          followUpRequested: false,
+          promise: null,
+        };
+        activeInventoryRequest = request;
 
-          const shouldTryDirectFallback =
-            Boolean(result.error) ||
-            (Array.isArray(result.data) && result.data.length === 0);
+        request.promise = Promise.resolve().then(async () => {
+          set({ isLoading: true, error: null });
+          try {
+            do {
+              request.followUpRequested = false;
+              try {
+                const result = await listInventory({
+                  limit: INVENTORY_FETCH_LIMIT,
+                });
+                if (requestGeneration !== inventoryRequestGeneration) return;
+                let resolvedItems = result.data ?? null;
 
-          if (shouldTryDirectFallback) {
-            try {
-              const directItems = await listInventoryDirect({
-                limit: INVENTORY_FETCH_LIMIT,
-              });
+                const shouldTryDirectFallback =
+                  Boolean(result.error) ||
+                  (Array.isArray(result.data) && result.data.length === 0);
 
-              if (!result.error || directItems.length > 0) {
-                resolvedItems = directItems;
-              }
+                if (shouldTryDirectFallback) {
+                  try {
+                    const directItems = await listInventoryDirect({
+                      limit: INVENTORY_FETCH_LIMIT,
+                    });
+                    if (requestGeneration !== inventoryRequestGeneration) return;
 
-              if (result.error && directItems.length > 0) {
-                console.warn(
-                  'Inventory API failed; using direct inventory query fallback.',
-                  result.error
+                    if (!result.error || directItems.length > 0) {
+                      resolvedItems = directItems;
+                    }
+
+                    if (result.error && directItems.length > 0) {
+                      console.warn(
+                        'Inventory API failed; using direct inventory query fallback.',
+                        result.error
+                      );
+                    }
+                  } catch (fallbackError) {
+                    if (result.error) {
+                      console.warn(
+                        'Failed to fetch inventory items via API and direct fallback.',
+                        fallbackError
+                      );
+                    }
+                  }
+                }
+
+                if (requestGeneration !== inventoryRequestGeneration) return;
+                if (result.error && (!resolvedItems || resolvedItems.length === 0)) {
+                  console.warn('Failed to fetch inventory items.', result.error);
+                  set({ error: result.error });
+                  continue;
+                }
+
+                const activeItems = sortInventoryItems(
+                  (resolvedItems ?? []).filter((item) => item.active)
                 );
+
+                set({
+                  items: activeItems,
+                  error: null,
+                  lastFetched: Date.now(),
+                  hasFetchedThisSession: true,
+                });
+              } catch (error) {
+                if (requestGeneration !== inventoryRequestGeneration) return;
+                const message =
+                  error instanceof Error ? error.message : 'Failed to load inventory.';
+
+                if (isSessionExpiredErrorMessage(message)) {
+                  set({ error: message });
+                  continue;
+                }
+
+                console.error('Unexpected inventory fetch failure.', error);
+                set({ error: message });
               }
-            } catch (fallbackError) {
-              if (result.error) {
-                console.warn(
-                  'Failed to fetch inventory items via API and direct fallback.',
-                  fallbackError
-                );
-              }
+            } while (
+              request.followUpRequested &&
+              requestGeneration === inventoryRequestGeneration
+            );
+          } finally {
+            if (
+              requestGeneration === inventoryRequestGeneration &&
+              activeInventoryRequest === request
+            ) {
+              activeInventoryRequest = null;
+              set({ isLoading: false });
             }
           }
+        });
 
-          if (result.error && (!resolvedItems || resolvedItems.length === 0)) {
-            console.warn('Failed to fetch inventory items.', result.error);
-            set({ error: result.error });
-            return;
-          }
-
-          const activeItems = sortInventoryItems(
-            (resolvedItems ?? []).filter((item) => item.active)
-          );
-
-          set({
-            items: activeItems,
-            error: null,
-            lastFetched: Date.now(),
-            hasFetchedThisSession: true,
-          });
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : 'Failed to load inventory.';
-
-          if (isSessionExpiredErrorMessage(message)) {
-            set({ error: message });
-            return;
-          }
-
-          console.error('Unexpected inventory fetch failure.', error);
-          set({ error: message });
-        } finally {
-          set({ isLoading: false });
-        }
+        return request.promise;
       },
 
       addItem: async (item) => {
@@ -427,15 +503,8 @@ export const useInventoryStore = create<InventoryState>()(
     }),
     {
       name: 'inventory-storage',
-      storage: createJSONStorage(() => AsyncStorage),
-      partialize: (state) => {
-        const MAX_CACHED_ITEMS = 2000;
-        return {
-          items: state.items.length > MAX_CACHED_ITEMS 
-            ? state.items.slice(0, MAX_CACHED_ITEMS) 
-            : state.items,
-        };
-      },
+      storage: inventoryStorage,
+      partialize: partializeInventoryState,
     }
   )
 );

--- a/src/store/moduleStore.ts
+++ b/src/store/moduleStore.ts
@@ -5,7 +5,7 @@
 
 import { create } from 'zustand';
 import {
-  getMyModules,
+  getModulesForUser,
   subscribeToMyModules,
   type ModuleState,
 } from '@/services/userModules';
@@ -40,7 +40,7 @@ export const useModuleStore = create<ModuleStoreState>((set, get) => ({
     });
 
     try {
-      const states = await getMyModules();
+      const states = await getModulesForUser(userId);
       if (get().userId !== userId || loadId !== latestLoadId) return; // user changed mid-flight
       set({ fetched: states, status: 'ready' });
     } catch (error) {
@@ -72,9 +72,12 @@ export function acquireModuleAccess(userId: string): () => void {
     unsubscribeRealtime?.();
     subscribedUserId = userId;
     void useModuleStore.getState().load(userId);
-    unsubscribeRealtime = subscribeToMyModules(() => {
-      void useModuleStore.getState().load(userId);
-    });
+    unsubscribeRealtime = subscribeToMyModules(
+      () => {
+        void useModuleStore.getState().load(userId);
+      },
+      userId,
+    );
   }
 
   let released = false;

--- a/src/store/orderStore.ts
+++ b/src/store/orderStore.ts
@@ -514,9 +514,8 @@ export const useOrderStore = create<OrderState>()(
       getTotalCartCount: (context) => {
         const state = get();
         const cartByLocation = getCartByContext(state, context);
-        return Object.entries(cartByLocation).reduce((total, [locationId, rawItems]) => {
-          const items = normalizeLocationCart(rawItems, locationId);
-          return total + items.length;
+        return Object.keys(cartByLocation).reduce((total, locationId) => {
+          return total + getLocationCart(cartByLocation, locationId).length;
         }, 0);
       },
 
@@ -524,7 +523,7 @@ export const useOrderStore = create<OrderState>()(
         const state = get();
         const cartByLocation = getCartByContext(state, context);
         return Object.keys(cartByLocation).filter((locId) => {
-          const items = normalizeLocationCart(cartByLocation[locId], locId);
+          const items = getLocationCart(cartByLocation, locId);
           return items.length > 0;
         });
       },


### PR DESCRIPTION
Closes #70

Merge after #75

## Did the defect reproduce?

No. Two honest attempts, both green before any change was made:

1. `src/__tests__/quickOrderRehydratedSend.test.ts` drives the pure pipeline the composer send path runs over `parsedItems`, seeded with rows exactly as they come back out of persisted `quick_order_sessions.parsed_items` (null unit, absent unit key, and a unit id no longer in the catalog): cart hash, `countUnresolvedItems`, `getParsedItemIssue` / `getParsedItemKey` / `formatParsedItemQuantity`, `getQuantityFixQueue`, `normalizeQuickOrderParseResponse`, `applyQuickOrderOperations`, `mergeQuickOrderParsedItemsDetailed`, `buildQuickOrderAssistantMessage`, then the post-send reads. Nothing threw.
2. `src/__tests__/quickOrderRehydratedCartRender.test.ts` renders `QuickOrderListCard` and `QuickOrderItemRow` with the same rehydrated cart, then re-renders with the item the send would have merged in. The screen's `ErrorBoundary` only catches render and commit errors, so this is the phase the reported failure had to come from. Nothing threw.

So this is hardening, not a confirmed root-cause fix. Both suites are kept as regression guards.

## What changed

New `src/features/ordering/quickOrderSendGuards.ts`:

- `normalizePersistedQuickOrderItems` replaces the screen's private `normalizeParsedItems`. It keeps the same "keep anything we can render a row for" filter and then runs every surviving row through `normalizeQuickOrderItemForDisplay`, the same pass every freshly parsed row already gets. This removes the rehydrated-vs-freshly-parsed divergence the issue pointed at: a persisted row with no unit now always carries `status: 'missing_unit'` and `action: 'Choose unit'`, so it renders the amber resolve prompt no matter what shape was persisted. A row whose only orderable unit is known gets that unit filled instead of prompting.
- `applyQuickOrderCartUpdate` wraps the body of the send path's `setParsedItems` updater. React runs updaters during render, so a throw in there is exactly what reaches the error boundary and replaces the surface. On failure the cart is committed unchanged and the error is handed back to the caller.

In `QuickOrderScreen.tsx`:

- The parse-apply body moved into `computeParseApply` and is committed through the guard. On failure the send now appends a visible inline error pill (`cart_apply_failed`) and returns, instead of unmounting into "Advanced ordering unavailable".
- The synchronous pre-send `rewriteBareQuantityWithContext` call is wrapped so a failure falls back to the text the user typed.

In `quickOrderErrors.ts`: user-facing copy for the new `cart_apply_failed` code. No stack text, no technical wording.

## Assumptions

- The error boundary in `app/(tabs)/quick-order.tsx` is a plain React boundary, so the reported failure came from a render or commit phase, not from an async handler continuation. The send path's only render-phase work is the `setParsedItems` updater, so that is what got guarded.
- The cart in the report is the Quick Order parsed-item cart (`quick_order_sessions.parsed_items`), not the `orderStore` cart. `src/store/cartStore*` was not touched; no cart persistence change was needed.
- Normalizing message-embedded `parsed_items` on load (same helper, used by `mapPersistedMessages`) is desirable and not a behaviour regression: those rows already went through `getParsedItemIssue`, which normalizes internally.
- The simulator was not used for this task, per the assignment. Reproduction was attempted with tests only.

## Commands and results

Run from the worktree, which sits under `.claude/worktrees`, so the jest run overrides the config's `.claude` ignore as instructed.

| Command | Result |
| --- | --- |
| `npm run typecheck` | pass, no output |
| `npm run lint` | pass, 0 errors 0 warnings |
| `npx jest --runInBand --watchman=false --testPathIgnorePatterns '/node_modules/'` | pass, 76 suites / 1108 tests, 1 suite and 1 test skipped |
| `npm run verify:submit-order-rpc` | did not run: exits 2 with `Missing EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY (legacy ANON_KEY is also supported).` No stack trace, no env configured in this worktree |

New tests: 23 across the two files.

## What to test on the simulator

Release build, UDID `EF05F833-2AC4-4383-8688-36C51B956BCF` via `scripts/sim.sh`, local full stack.

1. Reproduce the reported setup: on Advanced ordering, send a message that leaves one item matched but without a unit, so the Order list card shows `N · 1 to fix` and a `Fix cart` button.
2. Force quit and relaunch. The cart should rehydrate with the same amber `Choose unit` row. Confirm the row still shows the amber action, not a green or blank quantity.
3. Tap the composer and send another item. It should be added normally, with no error boundary.
4. Tap `Choose unit` on the rehydrated row, pick a unit, then `Confirm order` and `Confirm & Submit`. The order should write a real `orders` row.
5. Sanity check that an item whose catalog row has exactly one orderable unit rehydrates with that unit filled and no `Choose unit` prompt.
6. Confirm no new inline error pill appears during a normal send. The `cart_apply_failed` pill ("I couldn't add that to your order list...") should never be seen in a healthy run; if it is, that is the guard catching what used to be the boundary crash and the console will carry `[QuickOrder] cart_apply_failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
